### PR TITLE
gb: improve handling of LCD/BG enable bits on DMG

### DIFF
--- a/ares/gb/ppu/dmg.cpp
+++ b/ares/gb/ppu/dmg.cpp
@@ -75,7 +75,8 @@ auto PPU::runDMG() -> void {
 
   if(Model::GameBoy()) {
     auto output = screen->pixels().data() + status.ly * 160 + px++;
-    *output = color;
+    //LCD is still blank during the first frame
+    if(!latch.displayEnable) *output = color;
   }
   if(Model::SuperGameBoy()) {
     superGameBoy->ppuWrite(color);
@@ -101,6 +102,7 @@ auto PPU::runWindowDMG() -> void {
   if(status.ly < status.wy) return;
   if(px + 7 < status.wx) return;
   if(px + 7 == status.wx) latch.wy++;
+  if(!status.bgEnable) return;
 
   n8 scrollY = latch.wy - 1;
   n8 scrollX = px + 7 - latch.wx;

--- a/ares/gb/ppu/ppu.cpp
+++ b/ares/gb/ppu/ppu.cpp
@@ -97,8 +97,7 @@ auto PPU::main() -> void {
     latch.wy = 0;
   }
 
-  if(latch.displayEnable) {
-    latch.displayEnable = 0;
+  if(latch.displayEnable && status.ly == 0) {
     mode(0);
     step(72);
 
@@ -136,6 +135,8 @@ auto PPU::main() -> void {
     cpu.raise(CPU::Interrupt::VerticalBlank);
     if(screen) screen->frame();
     scheduler.exit(Event::Frame);
+
+    latch.displayEnable = 0;
   }
 
   if(status.ly == 154) {


### PR DESCRIPTION
On DMG, when the LCD is toggled from off to on, the screen remains blank
until one frame after the PPU becomes operational.

Furthermore, when the BG is disabled, the window is also no longer
drawn, though the other window logic (like the incrementing window line
counter) seems to remain operational.

This cleans up the visuals of Hyper Lode Runner on level start, but many
more games will be affected by blanking the first frame after the LCD is
toggled on.