### PR TITLE
gb: resume from halt whenever (IE & IF) != 0

### DIFF
--- a/ares/gb/cpu/memory.cpp
+++ b/ares/gb/cpu/memory.cpp
@@ -7,6 +7,7 @@ auto CPU::stop() -> void {
 
 auto CPU::halt() -> void {
   idle();
+  if(status.interruptLatch) r.halt = 0;
   if(Model::SuperGameBoy()) {
     scheduler.exit(Event::Step);
   }


### PR DESCRIPTION
Normally, breaking out of the halt state is handled by CPU::raise(), but
there is an edge case:
    ; preconditions: IME = 0, IE = 1, IF.0 = 1, LCDC.7 = 0
    ei
    halt

In other words, a vblank interrupt was requested with IME disabled, then
the display was disabled (so no more vblank interrupts will follow),
then interrupts were enabled while entering the halt state. Once halted,
there is no logic in ares to service the requested vblank interrupt.

A better long term approach would be to refactor the SM83 implementation
of halt to be more like the Z80 core - eliminating the loop within the
halt instruction itself - but in the meantime this change offers an
incremental improvement.

This fix prevents Amazing Penguin from freezing immediately on load.