### PR TITLE
tms9918: widen vcounter to 9 bits

### DIFF
--- a/ares/component/video/tms9918/tms9918.hpp
+++ b/ares/component/video/tms9918/tms9918.hpp
@@ -125,7 +125,7 @@ protected:
   } irqFrame;
 
   struct IO {
-    n8  vcounter;
+    n9  vcounter;
     n8  hcounter;
 
     n1  controlLatch;


### PR DESCRIPTION
By using an 8 bit counter, the last 6 lines of every frame were being
skipped and the VDP was firing vblank interrupts ~2.3% faster than
intended in the ColecoVision, SG-1000, and MSX.

This also fixes the corrupted turtle graphics in Frogger for
ColecoVision, though this is mostly by chance. The game is buggy and
susceptible to graphics corruption if a vblank is raised between these
instructions:

1d09  out  ($bf),a      ; write low VRAM address byte
1d0b  ld   a,h
1d0c  out  ($bf),a      ; write high VRAM address byte

It could easily be regressed by any future change that impacts timing.