### PR TITLE
recompiler: avoid encoding absolute data addresses

### DIFF
--- a/ares/component/processor/sh2/instruction.cpp
+++ b/ares/component/processor/sh2/instruction.cpp
@@ -36,7 +36,7 @@ auto SH2::instruction() -> void {
     // minimum cycle counts ensure that the recompiler is a net positive
     do {
       auto block = recompiler.block(PC - 4);
-      block->execute();
+      block->execute(*this);
     } while (CCR <= recompiler.min_cycles);
 
     step(CCR);

--- a/ares/component/processor/sh2/recompiler.cpp
+++ b/ares/component/processor/sh2/recompiler.cpp
@@ -46,8 +46,8 @@ auto SH2::Recompiler::emit(u32 address) -> Block* {
   if constexpr(ABI::Windows) {
     sub(rsp, imm8(0x40));
   }
-  mov(rbx, imm64(&self.R[0]));
-  mov(rbp, imm64(&self));
+  mov(rbx, ra0);
+  mov(rbp, ra1);
 
   auto entry = declareLabel();
   jmp8(entry);

--- a/ares/component/processor/sh2/sh2.hpp
+++ b/ares/component/processor/sh2/sh2.hpp
@@ -250,8 +250,8 @@ struct SH2 {
     Recompiler(SH2& self) : self(self) {}
 
     struct Block {
-      auto execute() -> void {
-        ((void (*)())code)();
+      auto execute(SH2& self) -> void {
+        ((void (*)(u32*, SH2*))code)(&self.R[0], &self);
       }
 
       u8* code;

--- a/ares/n64/cpu/cpu.cpp
+++ b/ares/n64/cpu/cpu.cpp
@@ -79,7 +79,7 @@ auto CPU::instruction() -> void {
   if constexpr(Accuracy::CPU::Recompiler) {
     auto address = devirtualize(ipu.pc)(0);
     auto block = recompiler.block(address);
-    block->execute();
+    block->execute(*this);
   }
 
   if constexpr(Accuracy::CPU::Interpreter) {

--- a/ares/n64/cpu/cpu.hpp
+++ b/ares/n64/cpu/cpu.hpp
@@ -690,8 +690,8 @@ struct CPU : Thread {
     Recompiler(CPU& self) : self(self) {}
 
     struct Block {
-      auto execute() -> void {
-        ((void (*)())code)();
+      auto execute(CPU& self) -> void {
+        ((void (*)(r64*, CPU*, r64*))code)(&self.ipu.r[16], &self, &self.fpu.r[16]);
       }
 
       u8* code;

--- a/ares/n64/rsp/recompiler.cpp
+++ b/ares/n64/rsp/recompiler.cpp
@@ -43,9 +43,9 @@ auto RSP::Recompiler::emit(u32 address) -> Block* {
   if constexpr(ABI::Windows) {
     sub(rsp, imm8(0x40));
   }
-  mov(rbx, imm64(&self.ipu.r[0]));
-  mov(rbp, imm64(&self));
-  mov(r13, imm64(&self.vpu.r[0]));
+  mov(rbx, ra0);
+  mov(rbp, ra1);
+  mov(r13, ra2);
 
   auto entry = declareLabel();
   jmp8(entry);
@@ -66,9 +66,6 @@ auto RSP::Recompiler::emit(u32 address) -> Block* {
   while(true) {
     u32 instruction = self.imem.read<Word>(address);
     bool branched = emitEXECUTE(instruction);
-    mov(rax, mem64(&self.clock));
-    add(rax, imm8(3));
-    mov(mem64(&self.clock), rax);
     call(&RSP::instructionEpilogue);
     address += 4;
     if(hasBranched || (address & 0xffc) == 0) break;  //IMEM boundary

--- a/ares/n64/rsp/rsp.cpp
+++ b/ares/n64/rsp/rsp.cpp
@@ -40,7 +40,7 @@ auto RSP::step(u32 clocks) -> void {
 auto RSP::instruction() -> void {
   if constexpr(Accuracy::RSP::Recompiler) {
     auto block = recompiler.block(ipu.pc);
-    block->execute();
+    block->execute(*this);
   }
 
   if constexpr(Accuracy::RSP::Interpreter) {
@@ -54,6 +54,10 @@ auto RSP::instruction() -> void {
 }
 
 auto RSP::instructionEpilogue() -> bool {
+  if constexpr(Accuracy::RSP::Recompiler) {
+    step(3);
+  }
+
   ipu.r[0].u32 = 0;
 
   switch(branch.state) {

--- a/ares/n64/rsp/rsp.hpp
+++ b/ares/n64/rsp/rsp.hpp
@@ -320,8 +320,8 @@ struct RSP : Thread, Memory::IO<RSP> {
     Recompiler(RSP& self) : self(self) {}
 
     struct Block {
-      auto execute() -> void {
-        ((void (*)())code)();
+      auto execute(RSP& self) -> void {
+        ((void (*)(r32*, RSP*, r128*))code)(&self.ipu.r[0], &self, &self.vpu.r[0]);
       }
 
       u8* code;

--- a/ares/ps1/cpu/cpu.cpp
+++ b/ares/ps1/cpu/cpu.cpp
@@ -85,7 +85,7 @@ auto CPU::instruction() -> void {
 
   if constexpr(Accuracy::CPU::Recompiler) {
     auto block = recompiler.block(ipu.pc);
-    block->execute();
+    block->execute(*this);
   }
 }
 

--- a/ares/ps1/cpu/cpu.hpp
+++ b/ares/ps1/cpu/cpu.hpp
@@ -510,8 +510,8 @@ struct CPU : Thread {
     Recompiler(CPU& self) : self(self) {}
 
     struct Block {
-      auto execute() -> void {
-        ((void (*)())code)();
+      auto execute(CPU& self) -> void {
+        ((void (*)(u32*, CPU*))code)(&self.ipu.r[0], &self);
       }
 
       u8* code;

--- a/ares/ps1/cpu/recompiler.cpp
+++ b/ares/ps1/cpu/recompiler.cpp
@@ -26,8 +26,8 @@ auto CPU::Recompiler::emit(u32 address) -> Block* {
   if constexpr(ABI::Windows) {
     sub(rsp, imm8(0x40));
   }
-  mov(rbx, imm64(&self.ipu.r[0]));
-  mov(rbp, imm64(&self));
+  mov(rbx, ra0);
+  mov(rbp, ra1);
 
   auto entry = declareLabel();
   jmp8(entry);


### PR DESCRIPTION
Reference data members via offsets from nonvolatile registers instead of
directly encoded absolute memory addresses. This is the last change
required for generated code to be fully position independent.

The reduction in code size is generally 5-7%, with the exception of the
N64 RSP, which sees a reduction of nearly 40%. This is mostly a result
of moving the clock increment to instructionEpilogue().