### PR TITLE
CD fixes - CUEsheet processing and CD session handling

### DIFF
--- a/nall/decode/cue.hpp
+++ b/nall/decode/cue.hpp
@@ -11,7 +11,7 @@ struct CUE {
   struct Index {
     auto sectorCount() const -> u32;
 
-    s32 number;  //01-99
+    u8 number = 0xff; //00-99
     s32 lba = -1;
     s32 end = -1;
   };
@@ -20,7 +20,7 @@ struct CUE {
     auto sectorCount() const -> u32;
     auto sectorSize() const -> u32;
 
-    s32 number;  //01-99
+    u8 number = 0xff; //01-99
     string type;
     vector<Index> indices;
     maybe<s32> pregap;
@@ -145,7 +145,7 @@ inline auto CUE::loadTrack(vector<string>& lines, u32& offset) -> Track {
     offset++;
   }
 
-  if(track.number > 99) return {};
+  if(track.number == 0 || track.number > 99) return {};
   return track;
 }
 

--- a/nall/vfs/cdrom.hpp
+++ b/nall/vfs/cdrom.hpp
@@ -95,26 +95,22 @@ private:
     session.leadOut.lba = lbaFileBase;
     session.leadOut.end = lbaFileBase + LeadOutSectors - 1;
 
+    // determine track and index ranges
+    session.firstTrack = 0xff;
     for(u32 track : range(100)) {
       if(!session.tracks[track]) continue;
-      session.firstTrack = track;
-      for(u32 index : range(100)) {
-        if(!session.tracks[track].indices[index]) continue;
-        session.tracks[track].firstIndex = index;
-        break;
+      if(session.firstTrack > 99) session.firstTrack = track;
+      // find first index
+      for(u32 indexID : range(100)) {
+        auto& index = session.tracks[track].indices[indexID];
+        if(index) { session.tracks[track].firstIndex = indexID; break; }
       }
-      break;
-    }
-
-    for(u32 track : reverse(range(100))) {
-      if(!session.tracks[track]) continue;
+      // find last index
+      for(u32 indexID : reverse(range(100))) {
+        auto& index = session.tracks[track].indices[indexID];
+        if(index) { session.tracks[track].lastIndex = indexID; break; }
+      }
       session.lastTrack = track;
-      for(u32 index : reverse(range(100))) {
-        if(!session.tracks[track].indices[index]) continue;
-        session.tracks[track].lastIndex = index;
-        break;
-      }
-      break;
     }
 
     _image.resize(2448 * (LeadInSectors + lbaFileBase + LeadOutSectors));

--- a/nall/vfs/cdrom.hpp
+++ b/nall/vfs/cdrom.hpp
@@ -51,22 +51,49 @@ private:
     CD::Session session;
     session.leadIn.lba = -LeadInSectors;
     session.leadIn.end = -1;
-    s32 lbaDisc = Track1Pregap;
-    s32 endDisc = lbaDisc;
+    s32 lbaFileBase = 0;
+
+    // add 2 sec pregap to 1st track
+    if(!cuesheet.files[0].tracks[0].pregap)
+      cuesheet.files[0].tracks[0].pregap = Track1Pregap;
+    else
+      cuesheet.files[0].tracks[0].pregap = Track1Pregap + cuesheet.files[0].tracks[0].pregap();
+
+    if(cuesheet.files[0].tracks[0].indices[0].number == 1) {
+      session.tracks[1].indices[0].lba = 0;
+      session.tracks[1].indices[0].end =
+          cuesheet.files[0].tracks[0].pregap() + cuesheet.files[0].tracks[0].indices[0].lba - 1;
+    }
+
+    s32 lbaIndex = 0;
     for(auto& file : cuesheet.files) {
       for(auto& track : file.tracks) {
         session.tracks[track.number].control = track.type == "audio" ? 0b0000 : 0b0100;
-        session.tracks[track.number].address = 0b0001;
+        if(track.pregap) lbaFileBase += track.pregap();
         for(auto& index : track.indices) {
-          session.tracks[track.number].indices[index.number].lba = lbaDisc + index.lba;
-          session.tracks[track.number].indices[index.number].end = lbaDisc + index.end;
+          if(index.lba >= 0) {
+            session.tracks[track.number].indices[index.number].lba = lbaFileBase + index.lba;
+            session.tracks[track.number].indices[index.number].end = lbaFileBase + index.end;
+            if(index.number == 0 && track.pregap) {
+              session.tracks[track.number].indices[index.number].lba -= track.pregap();
+              session.tracks[track.number].indices[index.number].end -= track.pregap();
+            }
+          } else {
+            // insert gap
+            session.tracks[track.number].indices[index.number].lba = lbaIndex;
+            if(index.number == 0)
+              session.tracks[track.number].indices[index.number].end = lbaIndex + track.pregap() - 1;
+            else
+              session.tracks[track.number].indices[index.number].end = lbaIndex + track.postgap() - 1;
+          }
+          lbaIndex = session.tracks[track.number].indices[index.number].end + 1;
         }
+        if(track.postgap) lbaFileBase += track.postgap();
       }
-      lbaDisc += file.tracks.last().indices.last().end + 1;
-      endDisc = lbaDisc;
+      lbaFileBase = lbaIndex;
     }
-    session.leadOut.lba = endDisc;
-    session.leadOut.end = endDisc + LeadOutSectors - 1;
+    session.leadOut.lba = lbaFileBase;
+    session.leadOut.end = lbaFileBase + LeadOutSectors - 1;
 
     for(u32 track : range(100)) {
       if(!session.tracks[track]) continue;
@@ -90,27 +117,25 @@ private:
       break;
     }
 
-    session.tracks[1].indices[0].lba = 0;  //track 1, index 0 is not present in CUE files
-    session.tracks[1].indices[0].end = Track1Pregap - 1;
+    _image.resize(2448 * (LeadInSectors + lbaFileBase + LeadOutSectors));
 
-    _image.resize(2448 * (LeadInSectors + endDisc + LeadOutSectors));
-
-    lbaDisc = Track1Pregap;
+    lbaFileBase = 0;
     for(auto& file : cuesheet.files) {
       auto location = string{Location::path(cueLocation), file.name};
       auto filedata = nall::file::open(location, nall::file::mode::read);
       if(file.type == "wave") filedata.seek(44);  //skip RIFF header
-      u64 offset = 0;
       for(auto& track : file.tracks) {
+        if(track.pregap) lbaFileBase += track.pregap();
         for(auto& index : track.indices) {
+          if(index.lba < 0) continue; // ignore gaps (not in file)
           for(s32 sector : range(index.sectorCount())) {
-            auto target = _image.data() + 2448ull * (LeadInSectors + lbaDisc + index.lba + sector);
+            auto target = _image.data() + 2448ull * (LeadInSectors + lbaFileBase + index.lba + sector);
             auto length = track.sectorSize();
             if(length == 2048) {
               //ISO: generate header + parity data
               memory::assign(target + 0, 0x00, 0xff, 0xff, 0xff, 0xff, 0xff);  //sync
               memory::assign(target + 6, 0xff, 0xff, 0xff, 0xff, 0xff, 0x00);  //sync
-              auto [minute, second, frame] = CD::MSF(lbaDisc + index.lba + sector);
+              auto [minute, second, frame] = CD::MSF(lbaFileBase + index.lba + sector);
               target[12] = CD::BCD::encode(minute);
               target[13] = CD::BCD::encode(second);
               target[14] = CD::BCD::encode(frame);
@@ -124,9 +149,9 @@ private:
             }
           }
         }
-        offset += track.sectorSize() * track.sectorCount();
+        if(track.postgap) lbaFileBase += track.postgap();
       }
-      lbaDisc += file.tracks.last().indices.last().end + 1;
+      lbaFileBase += file.tracks.last().indices.last().end + 1;
     }
 
     auto subchannel = session.encode(LeadInSectors + session.leadOut.end + 1);


### PR DESCRIPTION
The main objective of this PR is to properly support the PREGAP and POSTGAP commands in CD CUEsheets. Previously, these commands were being ignored, leading to misplaced CD audio tracks, which could cause broken audio or hangups in certain Mega-CD titles that cue to audio based on hardcoded time/LBA.

The other changes here fix minor issues re: the CD session (TOC & subchannel data generation), mostly as safeguard but also to conform more closely to CD standards (particularly ECMA-130).

I tested this with various Mega-CD images. If anyone is able to test any of the other CD-based platforms, please do. I don't expect new issues to crop up, but better safe than sorry.