### PR TITLE
recompiler: on macOS allow data segment to be executable

### DIFF
--- a/nall/GNUmakefile
+++ b/nall/GNUmakefile
@@ -148,6 +148,8 @@ endif
 ifeq ($(platform),macos)
   flags   += -stdlib=libc++ -mmacosx-version-min=10.9 -Wno-auto-var-id -fobjc-arc
   options += -lc++ -lobjc -mmacosx-version-min=10.9
+  # allow mprotect() on dynamic recompiler code blocks
+  options += -Wl,-segprot,__DATA,rwx,rw
   ifneq ($(local),true)
     flags   += -arch x86_64
     options += -arch x86_64


### PR DESCRIPTION
Override the data segment's maximum protection from rw to rwx, allowing
mprotect() to be called on recompiler code blocks to make them
executable.