### PR TITLE
desktop-ui: fix file/folder browser dialog alignment

### DIFF
--- a/desktop-ui/settings/firmware.cpp
+++ b/desktop-ui/settings/firmware.cpp
@@ -73,6 +73,7 @@ auto FirmwareSettings::eventAssign() -> void {
       BrowserDialog dialog;
       dialog.setTitle({"Select ", name, " ", type, " (", region, ")"});
       dialog.setPath(Path::desktop());
+      dialog.setAlignment(settingsWindow);
       dialog.setFilters({"All|*"});
       if(auto location = program.openFile(dialog)) {
         firmware.location = location;

--- a/desktop-ui/settings/paths.cpp
+++ b/desktop-ui/settings/paths.cpp
@@ -15,6 +15,7 @@ auto PathSettings::construct() -> void {
     BrowserDialog dialog;
     dialog.setTitle("Select Home Path");
     dialog.setPath(Path::desktop());
+    dialog.setAlignment(settingsWindow);
     if(auto location = program.selectFolder(dialog)) {
       settings.paths.home = location;
       refresh();
@@ -32,6 +33,7 @@ auto PathSettings::construct() -> void {
     BrowserDialog dialog;
     dialog.setTitle("Select Saves Path");
     dialog.setPath(Path::desktop());
+    dialog.setAlignment(settingsWindow);
     if(auto location = program.selectFolder(dialog)) {
       settings.paths.saves = location;
       refresh();
@@ -49,6 +51,7 @@ auto PathSettings::construct() -> void {
     BrowserDialog dialog;
     dialog.setTitle("Select Screenshots Path");
     dialog.setPath(Path::desktop());
+    dialog.setAlignment(settingsWindow);
     if(auto location = program.selectFolder(dialog)) {
       settings.paths.screenshots = location;
       refresh();
@@ -66,6 +69,7 @@ auto PathSettings::construct() -> void {
     BrowserDialog dialog;
     dialog.setTitle("Select Debugging Path");
     dialog.setPath(Path::desktop());
+    dialog.setAlignment(settingsWindow);
     if(auto location = program.selectFolder(dialog)) {
       settings.paths.debugging = location;
       refresh();


### PR DESCRIPTION
Align file/folder dialogs to the settings window when appropriate. The
absence of this alignment was triggering asserts in debug builds.