### PR TITLE
M68000 & MegaDrive related fixes

### DIFF
--- a/ares/component/processor/m68000/disassembler.cpp
+++ b/ares/component/processor/m68000/disassembler.cpp
@@ -50,7 +50,7 @@ template<u32 Size> auto M68000::_address(EffectiveAddress& ea) -> string {
   if(ea.mode ==  2) return {_addressRegister(AddressRegister{ea.reg})};
   if(ea.mode ==  5) return {"$", hex(_readDisplacement(read(AddressRegister{ea.reg})), 6L)};
   if(ea.mode ==  6) return {"$", hex(_readIndex(read(AddressRegister{ea.reg})), 6L)};
-  if(ea.mode ==  7) return {"$", hex((i16)_readPC<Word>(), 6L)};
+  if(ea.mode ==  7) { auto imm = _readPC<Word>(); return {"$", imm >= 0x8000 ? hex((i16)imm, 6L, 'f') : hex((i16)imm, 6L, '0') }; }
   if(ea.mode ==  8) return {"$", hex(_readPC<Long>(), 6L)};
   if(ea.mode ==  9) return {"$", hex(_pc + (i16)_readPC(), 6L)};
   if(ea.mode == 10) return {"$", hex(_readIndex(_pc), 6L)};
@@ -65,7 +65,7 @@ template<u32 Size> auto M68000::_effectiveAddress(EffectiveAddress& ea) -> strin
   if(ea.mode ==  4) return {"-(", _addressRegister(AddressRegister{ea.reg}), ")"};
   if(ea.mode ==  5) return {"($", hex(_readDisplacement(read(AddressRegister{ea.reg})), 6L), ")"};
   if(ea.mode ==  6) return {"($", hex(_readIndex(read(AddressRegister{ea.reg})), 6L), ")"};
-  if(ea.mode ==  7) return {"($", hex((i16)_readPC<Word>(), 6L), ")"};
+  if(ea.mode ==  7) { auto imm = _readPC<Word>(); return {"($", imm >= 0x8000 ? hex((i16)imm, 6L, 'f') : hex((i16)imm, 6L, '0'), ")"}; }
   if(ea.mode ==  8) return {"($", hex(_readPC<Long>(), 6L), ")"};
   if(ea.mode ==  9) return {"($", hex(_readDisplacement(_pc), 6L), ")"};
   if(ea.mode == 10) return {"($", hex(_readIndex(_pc), 6L), ")"};

--- a/ares/component/processor/m68000/instructions.cpp
+++ b/ares/component/processor/m68000/instructions.cpp
@@ -1262,7 +1262,7 @@ auto M68000::instructionSWAP(DataRegister with) -> void {
 auto M68000::instructionTAS(EffectiveAddress with) -> void {
   n32 data;
 
-  if(with.mode == DataRegisterDirect) {
+  if(lockable() || with.mode == DataRegisterDirect) {
     data = read<Byte, Hold>(with);
     prefetch();
     write<Byte>(with, data | 0x80);

--- a/ares/component/processor/m68000/m68000.cpp
+++ b/ares/component/processor/m68000/m68000.cpp
@@ -56,7 +56,7 @@ auto M68000::exception(u32 exception, u32 vector, u32 priority) -> void {
   auto sr = readSR();
 
   if(!r.s) swap(r.a[7], r.sp);
-  r.i = priority;
+  if(priority) r.i = priority;
   r.s = 1;
   r.t = 0;
 

--- a/ares/component/processor/m68000/m68000.hpp
+++ b/ares/component/processor/m68000/m68000.hpp
@@ -9,6 +9,7 @@ struct M68000 {
   virtual auto wait(u32 clocks) -> void = 0;
   virtual auto read(n1 upper, n1 lower, n24 address, n16 data = 0) -> n16 = 0;
   virtual auto write(n1 upper, n1 lower, n24 address, n16 data) -> void = 0;
+  virtual auto lockable() -> bool { return true; }
 
   auto ird() const -> n16 { return r.ird; }
 

--- a/ares/component/processor/m68000/m68000.hpp
+++ b/ares/component/processor/m68000/m68000.hpp
@@ -70,8 +70,8 @@ struct M68000 {
   M68000();
   auto power() -> void;
   auto supervisor() -> bool;
-  auto exception(u32 exception, u32 vector, u32 priority = 7) -> void;
-  auto interrupt(u32 vector, u32 priority = 7) -> void;
+  auto exception(u32 exception, u32 vector, u32 priority = 0) -> void;
+  auto interrupt(u32 vector, u32 priority = 0) -> void;
 
   //registers.cpp
   struct DataRegister {

--- a/ares/md/apu/apu.cpp
+++ b/ares/md/apu/apu.cpp
@@ -22,13 +22,11 @@ auto APU::unload() -> void {
 auto APU::main() -> void {
   //handle a bus switching request from the CPU
   if(state.resLine) {
-    //switching requires a minimum of 9 cycles to allow the 68K to read back unavailable bus state
-    if(state.busreqLine && !state.busreqLatch) step(9);
     state.busreqLatch = state.busreqLine;
   }
 
   //stall the APU until the CPU relinquishes control of the bus
-  if(!state.resLine || !busownerAPU()) {
+  if(!state.resLine || state.busreqLatch) {
     return step(1);
   }
 

--- a/ares/md/apu/apu.hpp
+++ b/ares/md/apu/apu.hpp
@@ -21,8 +21,12 @@ struct APU : Z80, Z80::Bus, Thread {
   } debugger;
 
   auto synchronizing() const -> bool override { return scheduler.synchronizing(); }
-  auto busownerAPU() const -> bool { return (state.resLine & state.busreqLatch) == 0; }  //Z80 has bus access
-  auto busownerCPU() const -> bool { return (state.resLine & state.busreqLatch) == 1; }  //68K has bus access
+  auto busgrantedCPU() const -> bool { return state.resLine & state.busreqLatch;  }
+  auto busownerCPU()   const -> bool { return state.resLine & state.busreqLine;   }
+  // Note: bus ownership is flagged according to line state, since it could be too slow
+  // to wait for latching with only instruction-level granularity on the Z80 emulation.
+  // At worst, a positive signal would indicate bus grant is imminent, which should be safe.
+  // (fixes Arkagis Revolution - Trial Version [Rev 00])
 
   //z80.cpp
   auto load(Node::Object) -> void;

--- a/ares/md/bus/inline.hpp
+++ b/ares/md/bus/inline.hpp
@@ -27,7 +27,7 @@ inline auto Bus::read(n1 upper, n1 lower, n24 address, n16 data) -> n16 {
   }
 
   if(address >= 0xa00000 && address <= 0xa0ffff) {
-    if(!apu.busownerCPU()) return data;
+    if(!apu.busgrantedCPU()) return data;
     if(cpu.active()) cpu.wait(3);  //todo: inaccurate approximation of Z80 RAM access delay
     address.bit(15) = 0;  //a080000-a0ffff mirrors a00000-a07fff
     //word reads load the even input byte into both output bytes
@@ -85,7 +85,7 @@ inline auto Bus::write(n1 upper, n1 lower, n24 address, n16 data) -> void {
   }
 
   if(address >= 0xa00000 && address <= 0xa0ffff) {
-    if(!apu.busownerCPU()) return;
+    if(!apu.busgrantedCPU()) return;
     if(cpu.active()) cpu.wait(3);  //todo: inaccurate approximation of Z80 RAM access delay
     address.bit(15) = 0;  //a08000-a0ffff mirrors a00000-a07fff
     //word writes store the upper input byte into the lower output byte

--- a/ares/md/cartridge/board/linear.cpp
+++ b/ares/md/cartridge/board/linear.cpp
@@ -29,7 +29,7 @@ struct Linear : Interface {
   }
 
   auto read(n1 upper, n1 lower, n22 address, n16 data) -> n16 override {
-    if(address >= 0x200000) {
+    if(address >= 0x200000 && address < 0x300000) {
       if(wram && ramEnable) {
         return wram[address >> 1];
       }

--- a/ares/md/cpu/bus.cpp
+++ b/ares/md/cpu/bus.cpp
@@ -1,6 +1,7 @@
-auto CPU::read(n1 upper, n1 lower, n24 address, n16 data) -> n16 {
+auto CPU::read(n1 upper, n1 lower, n24 address, n16) -> n16 {
   while(bus.acquired()) wait(1);
-  return bus.read(upper, lower, address, data);
+  //using m68k prefetch for open-bus data
+  return bus.read(upper, lower, address, r.irc);
 }
 
 auto CPU::write(n1 upper, n1 lower, n24 address, n16 data) -> void {

--- a/ares/md/cpu/cpu.hpp
+++ b/ares/md/cpu/cpu.hpp
@@ -47,7 +47,7 @@ struct CPU : M68000, Thread {
   auto power(bool reset) -> void;
 
   //bus.cpp
-  auto read(n1 upper, n1 lower, n24 address, n16 data = 0) -> n16 override;
+  auto read(n1 upper, n1 lower, n24 address, n16 _ = 0) -> n16 override;
   auto write(n1 upper, n1 lower, n24 address, n16 data) -> void override;
 
   //io.cpp

--- a/ares/md/cpu/cpu.hpp
+++ b/ares/md/cpu/cpu.hpp
@@ -5,6 +5,10 @@ struct CPU : M68000, Thread {
   Memory::Readable<n16> tmss;
   Memory::Writable<n16> ram;
 
+  // Bus locking is unavailable for the main cpu of MegaDrive models 1 & 2,
+  // preventing the TAS instruction from working correctly in most cases.
+  auto lockable() -> bool override { return false; }
+
   struct Debugger {
     //debugger.cpp
     auto load(Node::Object) -> void;

--- a/ares/md/cpu/io.cpp
+++ b/ares/md/cpu/io.cpp
@@ -42,7 +42,7 @@ auto CPU::readIO(n1 upper, n1 lower, n24 address, n16 data) -> n16 {
   }
 
   if(address >= 0xa11100 && address <= 0xa111ff) {
-    data.bit(8) = apu.busownerAPU();
+    data.bit(8) = !apu.busownerCPU();
     return data;
   }
 

--- a/ares/md/cpu/io.cpp
+++ b/ares/md/cpu/io.cpp
@@ -2,9 +2,9 @@
 
 auto CPU::readIO(n1 upper, n1 lower, n24 address, n16 data) -> n16 {
   if(address >= 0xa10000 && address <= 0xa100ff) {
-    if(!lower) return data;  //even byte writes ignored
-    address.bit(5,7) = 0;    //a10020-a100ff mirrors a10000-a1001f
+    if(!lower) return data.byte(0) << 8;
 
+    address.bit(5,7) = 0;    //a10020-a100ff mirrors a10000-a1001f
     switch(address) {
     case 0xa10000:
       data.bit(0) =  io.version;       //0 = Model 1; 1 = Model 2+
@@ -38,7 +38,7 @@ auto CPU::readIO(n1 upper, n1 lower, n24 address, n16 data) -> n16 {
       break;
     }
 
-    return data;
+    return data.byte(1)=data.byte(0), data;
   }
 
   if(address >= 0xa11100 && address <= 0xa111ff) {


### PR DESCRIPTION
1. M68k modifies the interrupt mask based on active priority, but it doesn't do this for exceptions or traps. This likely fixes issues in a number of MD/M-CD games, including The Amazing Spider-man vs. The Kingpin [CD] which now boots.
2. The M68k TAS instruction was purposely borked for the MD cpu, but that doesn't apply to the Mega-CD subcpu (or other systems). Fixes severe graphical glitches in The Adventures of Batman & Robin (CD) and Batman Returns (CD).
3. Fixed M68k trace disassembly of PC-relative addresses to show proper sign-extension.
4. Fixed a masking issue that occurs when a MD cart has SRAM starting at $200000 but ROM extends past $300000. Fixes #242.
5. Tweaked the MD Z80 bus ownership flag so that bus switching appears to be instantaneous because _some games_ want to do very dumb things otherwise (ahem, fixes #248). This should be fairly safe since the bus is extremely likely to be available by the time the next instruction executes (unfortunately, at this time we can't break in the middle of a Z80 instruction based on bus cycle). Also, removed a kludge that artificially delays the bus switch (added to fix Fatal Rewind, but it was errant due to a different issue).
6. Implemented MD M68k open bus lines correctly, at least for shared Z80 & I/O areas. Several games incorrectly check the bus ownership flag, comparing against open bus lines instead. Fixes #249, #250 and others.

Also, #240 is fixed somewhere in there as well, I lost track.