### PR TITLE
MD - fixing interrupts and regressions from PR#257

### DIFF
--- a/ares/ares/ares.hpp
+++ b/ares/ares/ares.hpp
@@ -46,7 +46,7 @@ namespace ares {
 
   //incremented only when serialization format changes
   static const u32    SerializerSignature = 0x31545342;  //"BST1" (little-endian)
-  static const string SerializerVersion   = "123.1";
+  static const string SerializerVersion   = "124";
 
   namespace VFS {
     using Pak = shared_pointer<vfs::directory>;

--- a/ares/md/apu/apu.cpp
+++ b/ares/md/apu/apu.cpp
@@ -20,11 +20,6 @@ auto APU::unload() -> void {
 }
 
 auto APU::main() -> void {
-  //handle a bus switching request from the CPU
-  if(state.resLine) {
-    state.busreqLatch = state.busreqLine;
-  }
-
   //stall the APU until the CPU relinquishes control of the bus
   if(!state.resLine || state.busreqLatch) {
     return step(1);
@@ -48,6 +43,7 @@ auto APU::main() -> void {
 
 auto APU::step(u32 clocks) -> void {
   Thread::step(clocks);
+  state.busreqLatch = busownerCPU() ? 1 : 0;
   Thread::synchronize(cpu, vdp, vdp.psg, opn2);
 }
 

--- a/ares/md/cpu/io.cpp
+++ b/ares/md/cpu/io.cpp
@@ -42,7 +42,7 @@ auto CPU::readIO(n1 upper, n1 lower, n24 address, n16 data) -> n16 {
   }
 
   if(address >= 0xa11100 && address <= 0xa111ff) {
-    data.bit(8) = !apu.busownerCPU();
+    data.bit(8) = !apu.busgrantedCPU();
     return data;
   }
 

--- a/ares/md/vdp/io.cpp
+++ b/ares/md/vdp/io.cpp
@@ -175,6 +175,13 @@ auto VDP::readControlPort() -> n16 {
 
 auto VDP::writeControlPort(n16 data) -> void {
   //command write (lo)
+
+  // Note: A pending interrupt will be delayed when a register write
+  // is used to enable that interrupt. Further testing is required,
+  // but the current method should be sufficient to handle most cases.
+  // Required for Sesame Street Counting Cafe et al.
+  irq.delay = 2; // 4 pixel delay (4-6 M68k clocks) from this write
+
   if(command.latch) {
     command.latch = 0;
 
@@ -214,7 +221,6 @@ auto VDP::writeControlPort(n16 data) -> void {
     irq.hblank.enable        = data.bit(4);
     io.leftColumnBlank       = data.bit(5);
 
-    irq.poll();
     if(!io.videoMode4) debug(unimplemented, "[VDP] M4=0");
     return;
   }
@@ -228,7 +234,6 @@ auto VDP::writeControlPort(n16 data) -> void {
     io.displayEnable   = data.bit(6);
     vram.mode          = data.bit(7);
 
-    irq.poll();
     if(!io.videoMode5) debug(unimplemented, "[VDP] M5=0");
     return;
   }
@@ -281,7 +286,6 @@ auto VDP::writeControlPort(n16 data) -> void {
     layers.vscrollMode  = data.bit(2);
     irq.external.enable = data.bit(3);
 
-    irq.poll();
     return;
   }
 

--- a/ares/md/vdp/irq.cpp
+++ b/ares/md/vdp/irq.cpp
@@ -1,32 +1,33 @@
 auto VDP::IRQ::poll() -> void {
+  if(delay) { delay--; return; }
+
   if(external.enable && external.pending) {
-    vdp.debugger.interrupt(CPU::Interrupt::External);
     cpu.raise(CPU::Interrupt::External);
   } else {
-    external.pending = 0;
     cpu.lower(CPU::Interrupt::External);
   }
 
   if(hblank.enable && hblank.pending) {
-    vdp.debugger.interrupt(CPU::Interrupt::HorizontalBlank);
     cpu.raise(CPU::Interrupt::HorizontalBlank);
   } else {
-    // note: pending H-INT is not cleared when disabled
     cpu.lower(CPU::Interrupt::HorizontalBlank);
   }
 
   if(vblank.enable && vblank.pending) {
-    vdp.debugger.interrupt(CPU::Interrupt::VerticalBlank);
     cpu.raise(CPU::Interrupt::VerticalBlank);
   } else {
-    vblank.pending = 0;
     cpu.lower(CPU::Interrupt::VerticalBlank);
   }
 }
 
 auto VDP::IRQ::acknowledge(u8 level) -> void {
   if(level == 2) external.pending = 0;
-  if(level == 4) hblank.pending = 0;
+  if(level == 4) {
+    // H-INT ack can errantly cancel V-INT if they coincide.
+    // Required for Fatal Rewind et al.
+    if(!vblank.pending) hblank.pending = 0;
+    else                vblank.pending = 0;
+  }
   if(level == 6) vblank.pending = 0;
 }
 
@@ -34,4 +35,5 @@ auto VDP::IRQ::power(bool reset) -> void {
   external = {};
   hblank = {};
   vblank = {};
+  delay = 0;
 }

--- a/ares/md/vdp/main.cpp
+++ b/ares/md/vdp/main.cpp
@@ -19,6 +19,7 @@ auto VDP::tick() -> void {
     if(hcounter() == 0xb3) hblank(1);
     if(hcounter() == 0xb6) state.hcounter = 0xe4;
   }
+  irq.poll();
   vram.refreshing = 0;
 }
 
@@ -28,7 +29,7 @@ auto VDP::vtick() -> void {
   } else if(irq.hblank.counter-- == 0) {
     irq.hblank.counter = irq.hblank.frequency;
     irq.hblank.pending = 1;
-    irq.poll();
+    debugger.interrupt(CPU::Interrupt::HorizontalBlank);
   }
 
   state.vcounter++;
@@ -72,7 +73,7 @@ auto VDP::vedge() -> void {
     cartridge.vblank(1);
     apu.setINT(1);
     irq.vblank.pending = 1;
-    irq.poll();
+    debugger.interrupt(CPU::Interrupt::VerticalBlank);
   }
 }
 

--- a/ares/md/vdp/serialization.cpp
+++ b/ares/md/vdp/serialization.cpp
@@ -74,6 +74,7 @@ auto VDP::IRQ::serialize(serializer& s) -> void {
   s(vblank.enable);
   s(vblank.pending);
   s(vblank.transitioned);
+  s(delay);
 }
 
 auto VDP::Slot::serialize(serializer& s) -> void {

--- a/ares/md/vdp/vdp.hpp
+++ b/ares/md/vdp/vdp.hpp
@@ -137,6 +137,9 @@ struct VDP : Thread {
       n1 pending;
       n1 transitioned;
     } vblank;
+
+    n8 delay;
+
   } irq;
 
   struct Slot {


### PR DESCRIPTION
1. Fixes outstanding interrupt issues and adds proper support for well known edge cases (Sesame Street Counting Cafe, Fatal Rewind). All the obvious interrupt issues are fixed now ;^)
2. There were timing issues after the last PR, so this commit specifically addresses those. Now, we wait for the next apu step (of arbitrary length) before granting the bus. It not exactly precise, but it seems to work well enough for stability.

Fixed: #237, #253, and regressions in Comix Zone and probably a few others