### PR TITLE
fc: support for taito tc0190 / tc0690 boards

### DIFF
--- a/ares/fc/cartridge/board/board.cpp
+++ b/ares/fc/cartridge/board/board.cpp
@@ -31,6 +31,7 @@ namespace Board {
 #include "sunsoft-4.cpp"
 #include "sunsoft-5b.cpp"
 #include "taito-tc0190.cpp"
+#include "taito-tc0690.cpp"
 
 auto Interface::create(string board) -> Interface* {
   Interface* p = nullptr;
@@ -65,6 +66,7 @@ auto Interface::create(string board) -> Interface* {
   if(!p) p = Sunsoft4::create(board);
   if(!p) p = Sunsoft5B::create(board);
   if(!p) p = TaitoTC0190::create(board);
+  if(!p) p = TaitoTC0690::create(board);
   if(!p) p = new Interface;
   return p;
 }

--- a/ares/fc/cartridge/board/board.cpp
+++ b/ares/fc/cartridge/board/board.cpp
@@ -30,6 +30,7 @@ namespace Board {
 #include "sunsoft-3.cpp"
 #include "sunsoft-4.cpp"
 #include "sunsoft-5b.cpp"
+#include "taito-tc0190.cpp"
 
 auto Interface::create(string board) -> Interface* {
   Interface* p = nullptr;
@@ -63,6 +64,7 @@ auto Interface::create(string board) -> Interface* {
   if(!p) p = Sunsoft3::create(board);
   if(!p) p = Sunsoft4::create(board);
   if(!p) p = Sunsoft5B::create(board);
+  if(!p) p = TaitoTC0190::create(board);
   if(!p) p = new Interface;
   return p;
 }

--- a/ares/fc/cartridge/board/taito-tc0190.cpp
+++ b/ares/fc/cartridge/board/taito-tc0190.cpp
@@ -1,0 +1,84 @@
+struct TaitoTC0190 : Interface {
+  static auto create(string id) -> Interface* {
+    if(id == "TAITO-TC0190") return new TaitoTC0190;
+    return nullptr;
+  }
+
+  Memory::Readable<n8> programROM;
+  Memory::Readable<n8> characterROM;
+
+  auto load() -> void override {
+    Interface::load(programROM, "program.rom");
+    Interface::load(characterROM, "character.rom");
+  }
+
+  auto readPRG(n32 address, n8 data) -> n8 override {
+    if(address < 0x8000) return data;
+
+    n6 bank;
+    switch(address >> 13 & 3) {
+    case 0: bank = programBank[0]; break;
+    case 1: bank = programBank[1]; break;
+    case 2: bank = 0x3e; break;
+    case 3: bank = 0x3f; break;
+    }
+    return programROM.read(bank << 13 | (n13)address);
+  }
+
+  auto writePRG(n32 address, n8 data) -> void override {
+    if(address < 0x8000) return;
+
+    switch(address & 0xa003) {
+    case 0x8000:
+      programBank[0] = data.bit(0,5);
+      mirror = data.bit(6);
+      break;
+    case 0x8001:
+      programBank[1] = data.bit(0,5);
+      break;
+    case 0x8002: characterBank[0] = data; break;
+    case 0x8003: characterBank[1] = data; break;
+    case 0xa000: characterBank[2] = data; break;
+    case 0xa001: characterBank[3] = data; break;
+    case 0xa002: characterBank[4] = data; break;
+    case 0xa003: characterBank[5] = data; break;
+    }
+  }
+
+  auto addressCHR(n32 address) const -> n32 {
+    if(address <= 0x07ff) return characterBank[0] << 11 | (n11)address;
+    if(address <= 0x0fff) return characterBank[1] << 11 | (n11)address;
+    if(address <= 0x13ff) return characterBank[2] << 10 | (n10)address;
+    if(address <= 0x17ff) return characterBank[3] << 10 | (n10)address;
+    if(address <= 0x1bff) return characterBank[4] << 10 | (n10)address;
+    if(address <= 0x1fff) return characterBank[5] << 10 | (n10)address;
+    unreachable;
+  }
+
+  auto addressCIRAM(n32 address) const -> n32 {
+    return address >> mirror & 0x0400 | (n10)address;
+  }
+
+  auto readCHR(n32 address, n8 data) -> n8 override {
+    if(address & 0x2000) return ppu.readCIRAM(addressCIRAM(address));
+    if(characterROM) return characterROM.read(addressCHR(address));
+    return data;
+  }
+
+  auto writeCHR(n32 address, n8 data) -> void override {
+    if(address & 0x2000) return ppu.writeCIRAM(addressCIRAM(address), data);
+  }
+
+  auto power() -> void override {
+  }
+
+  auto serialize(serializer& s) -> void override {
+    s(mirror);
+    s(programBank);
+    s(characterBank);
+  }
+
+  n1 mirror;
+  n6 programBank[2];
+  n8 characterBank[6];
+};

--- a/mia/medium/famicom.cpp
+++ b/mia/medium/famicom.cpp
@@ -262,6 +262,10 @@ auto Famicom::analyzeINES(vector<u8>& data) -> string {
     prgram = 8192;
     break;
 
+  case  33:
+    s += "  board:  TAITO-TC0190\n";
+    break;
+
   case  34:
     s += "  board:  HVC-BNROM\n";
     s +={"    mirror mode=", !mirror ? "horizontal" : "vertical", "\n"};
@@ -297,7 +301,7 @@ auto Famicom::analyzeINES(vector<u8>& data) -> string {
     s +={"    mirror mode=", !mirror ? "horizontal" : "vertical", "\n"};
     prgram = 8192;
     break;
-    
+
   case  75:
     s += "  board:  KONAMI-VRC-1\n";
     s += "    chip type=VRC1\n";

--- a/mia/medium/famicom.cpp
+++ b/mia/medium/famicom.cpp
@@ -271,6 +271,10 @@ auto Famicom::analyzeINES(vector<u8>& data) -> string {
     s +={"    mirror mode=", !mirror ? "horizontal" : "vertical", "\n"};
     break;
 
+  case  48:
+    s += "  board:  TAITO-TC0690\n";
+    break;
+
   case  66:
     s += "  board:  HVC-GNROM\n";
     s +={"    mirror mode=", !mirror ? "horizontal" : "vertical", "\n"};


### PR DESCRIPTION
Support added for TC0190 and TC0690 chips found on some Taito boards. These chips are very similar to Nintendo MMC3.

Taito TC0190 (iNes mapper 33):
- Akira (Japan) - Hangs when trying to get ingame
- Bakushou!! Jinsei Gekijou (Japan)
- Bakushou!! Jinsei Gekijou 2 (Japan)
- Don Doko Don (Japan)
- Golfkko Open (Japan)
- Insector X (Japan)
- Operation Wolf (Japan)
- Power Blazer (Japan)
- Takeshi no Sengoku Fuuunji (Japan)

Taito TC0690 (iNes mapper 48):
- Bakushou!! Jinsei Gekijou 3 (Japan)
- Bubble Bobble 2 (Japan)
- Captain Saver (Japan)
- Don Doko Don 2 (Japan)
- Flintstones, The - The Rescue of Dino & Hoppy (Japan)
- Jetsons, The - Cogswell's Caper (Japan)

"Akira" hangs when trying to get ingame. This does not seem to be mapper related but a timing issue, but I need to debug it further.

Comparing to MMC3, TC0690 raises the irq line with some cycles of delay, the exact value is unknown. I'm delaying the irq 6 cpu cycles as it fix shaking on "The Jetsons" (Mesen is doing the same).

Because of its similitudes I was using the existing MMC3 implementation for irq timing, and that uncover a bug: when irqCounter and irqLatch are both zero the irq line won't raise and it should; this was causing hangs on "Captain Saver". It's fixed on this implementation, but the same fix is probably needed on txrom.

"The Flintstones" is known to have erratic irq behavior, and Mesen is applying special fixes for it. It's apparently working in this implementation, but more testing is needed.