### PR TITLE
Mega-CD fixes + a couple MegaDrive quick fixes

### DIFF
--- a/ares/md/mcd/cdd.cpp
+++ b/ares/md/mcd/cdd.cpp
@@ -242,6 +242,8 @@ auto MCD::CDD::process() -> void {
     io.status = Status::Playing;
   } break;
 
+  default:
+    io.status = Status::CommandError;
   }
 
   status[0] = io.status;

--- a/ares/md/mcd/cdd.cpp
+++ b/ares/md/mcd/cdd.cpp
@@ -54,17 +54,15 @@ auto MCD::CDD::clock() -> void {
 }
 
 auto MCD::CDD::advance() -> void {
-  //is the next sector still within the current track?
   if(auto track = session.inTrack(io.sector + 1)) {
-    if(track() == io.track) {
-      io.sector++;
-      io.sample = 0;
-      return;
-    }
+    io.track = track();
+    io.sector++;
+    io.sample = 0;
+    return;
   }
 
-  //if not, then the track has been completed
-  io.status = Status::Paused;
+  io.status = Status::LeadOut;
+  io.track = 0xaa;
 }
 
 auto MCD::CDD::sample() -> void {

--- a/ares/md/mcd/io-internal.cpp
+++ b/ares/md/mcd/io-internal.cpp
@@ -252,7 +252,7 @@ auto MCD::writeIO(n1 upper, n1 lower, n24 address, n16 data) -> void {
 
   if(address == 0xff8030) {
     if(lower) {
-      timer.frequency = data.byte(0);
+      timer.counter = timer.frequency = data.byte(0);
     }
   }
 

--- a/ares/md/vdp/irq.cpp
+++ b/ares/md/vdp/irq.cpp
@@ -25,8 +25,10 @@ auto VDP::IRQ::acknowledge(u8 level) -> void {
   if(level == 4) {
     // H-INT ack can errantly cancel V-INT if they coincide.
     // Required for Fatal Rewind et al.
-    if(!vblank.pending) hblank.pending = 0;
-    else                vblank.pending = 0;
+    if(vblank.pending && vblank.enable)
+      vblank.pending = 0;
+    else
+      hblank.pending = 0;
   }
   if(level == 6) vblank.pending = 0;
 }

--- a/desktop-ui/emulator/mega-cd.cpp
+++ b/desktop-ui/emulator/mega-cd.cpp
@@ -18,6 +18,17 @@ MegaCD::MegaCD() {
   for(auto id : range(2)) {
     InputPort port{string{"Controller Port ", 1 + id}};
 
+  { InputDevice device{"Control Pad"};
+    device.digital("Up",    virtualPorts[id].pad.up);
+    device.digital("Down",  virtualPorts[id].pad.down);
+    device.digital("Left",  virtualPorts[id].pad.left);
+    device.digital("Right", virtualPorts[id].pad.right);
+    device.digital("A",     virtualPorts[id].pad.a);
+    device.digital("B",     virtualPorts[id].pad.b);
+    device.digital("C",     virtualPorts[id].pad.c);
+    device.digital("Start", virtualPorts[id].pad.start);
+    port.append(device); }
+
   { InputDevice device{"Fighting Pad"};
     device.digital("Up",    virtualPorts[id].pad.up);
     device.digital("Down",  virtualPorts[id].pad.down);
@@ -58,12 +69,12 @@ auto MegaCD::load() -> bool {
   }
 
   if(auto port = root->find<ares::Node::Port>("Controller Port 1")) {
-    port->allocate("Fighting Pad");
+    port->allocate("Control Pad");
     port->connect();
   }
 
   if(auto port = root->find<ares::Node::Port>("Controller Port 2")) {
-    port->allocate("Fighting Pad");
+    port->allocate("Control Pad");
     port->connect();
   }
 

--- a/mia/medium/mega-drive.cpp
+++ b/mia/medium/mega-drive.cpp
@@ -302,6 +302,12 @@ auto MegaDrive::analyzeStorage(vector<u8>& rom, string hash) -> void {
     ram.size = 32768;
   }
 
+  //Super Hydlide (Japan)
+  if(hash == "30749097096807abf67cd1f7b2392f5789f5149ee33661e6d13113396f06a121") {
+    ram.mode = "lower";
+    ram.size = 8192;
+  }
+
   //M28C16
   //======
 


### PR DESCRIPTION
1. Squashed a bug in M-CD timer control to eliminate Silpheed read errors.
2. Rewrote M-CD graphics render function, which fixes several issues including #219 & gfx glitches in Battlecorps, Batman Returns.
3. Changed behavior of CDD to allow continuous playback (BIOS handles pausing when applicable). Fixes delay issue in Willy Beamish intro (& general CDDA playback).
4. Report error on unhandled CDD command, which is stopgap to avoid app crashes when using unsupported BIOS version. This should resolve the crash in #221 (though this issue is fully resolved when using a compatible v2 BIOS).
5. Proper region autodetect on discs via identifying boot code, specifically for cases where the disc header is incorrect.
6. Added support for the 3-button pad on M-CD and set it to default as in #197. Some games have incompatibility (e.g., Battlecorps char select) or exhibit slowdown in ares due to improper polling patterns (Willy Beamish, Rebel Assault).
7. Fixed a minor issue in VDP interrupt ack which occurs when H-INT is enabled but V-INT is disabled. This fixes glitches in one scene of The Spiral demo (ref: #261, this is fully resolved now).
8. Specific fix for #112 which is missing SRAM info in its header.