### PR TITLE
n64: increase screen canvas to 576 lines

### DIFF
--- a/ares/n64/vi/vi.cpp
+++ b/ares/n64/vi/vi.cpp
@@ -11,9 +11,9 @@ auto VI::load(Node::Object parent) -> void {
   node = parent->append<Node::Object>("VI");
 
   #if defined(VULKAN)
-  screen = node->append<Node::Video::Screen>("Screen", vulkan.outputUpscale * 640, vulkan.outputUpscale * 480);
+  screen = node->append<Node::Video::Screen>("Screen", vulkan.outputUpscale * 640, vulkan.outputUpscale * 576);
   #else
-  screen = node->append<Node::Video::Screen>("Screen", 640, 480);
+  screen = node->append<Node::Video::Screen>("Screen", 640, 576);
   #endif
   screen->setRefresh({&VI::refresh, this});
   screen->colors((1 << 24) + (1 << 15), [&](n32 color) -> n64 {


### PR DESCRIPTION
Certain PAL games require this. Affected games include:
- Michael Owen's WLS 2000
- Perfect Dark
- Top Gear Overdrive

This fixes #254. As for why only SD mode was affected, parallel-rdp does not upscale progressive scan modes on the vertical axis until the upscaling factor is increased beyond 2x. I'm not sure if this is a bug or by design. In any case, ares simply multiplies the canvas size by the upscaling factor in both dimensions, which is why there was enough room in HD modes even when the unscaled number of lines was incorrect.