### PR TITLE
fc: support for taito x1-005 / x1-017 boards

### DIFF
--- a/ares/fc/cartridge/board/board.cpp
+++ b/ares/fc/cartridge/board/board.cpp
@@ -32,6 +32,7 @@ namespace Board {
 #include "sunsoft-5b.cpp"
 #include "taito-tc0190.cpp"
 #include "taito-tc0690.cpp"
+#include "taito-x1-005.cpp"
 
 auto Interface::create(string board) -> Interface* {
   Interface* p = nullptr;
@@ -67,6 +68,7 @@ auto Interface::create(string board) -> Interface* {
   if(!p) p = Sunsoft5B::create(board);
   if(!p) p = TaitoTC0190::create(board);
   if(!p) p = TaitoTC0690::create(board);
+  if(!p) p = TaitoX1005::create(board);
   if(!p) p = new Interface;
   return p;
 }

--- a/ares/fc/cartridge/board/board.cpp
+++ b/ares/fc/cartridge/board/board.cpp
@@ -31,6 +31,7 @@ namespace Board {
 #include "sunsoft-4.cpp"
 #include "sunsoft-5b.cpp"
 #include "taito-tc0190.cpp"
+#include "taito-tc0690.cpp"
 
 auto Interface::create(string board) -> Interface* {
   Interface* p = nullptr;
@@ -65,6 +66,7 @@ auto Interface::create(string board) -> Interface* {
   if(!p) p = Sunsoft4::create(board);
   if(!p) p = Sunsoft5B::create(board);
   if(!p) p = TaitoTC0190::create(board);
+  if(!p) p = TaitoTC0690::create(board);
   if(!p) p = new Interface;
   return p;
 }

--- a/ares/fc/cartridge/board/board.cpp
+++ b/ares/fc/cartridge/board/board.cpp
@@ -33,6 +33,7 @@ namespace Board {
 #include "taito-tc0190.cpp"
 #include "taito-tc0690.cpp"
 #include "taito-x1-005.cpp"
+#include "taito-x1-017.cpp"
 
 auto Interface::create(string board) -> Interface* {
   Interface* p = nullptr;
@@ -69,6 +70,7 @@ auto Interface::create(string board) -> Interface* {
   if(!p) p = TaitoTC0190::create(board);
   if(!p) p = TaitoTC0690::create(board);
   if(!p) p = TaitoX1005::create(board);
+  if(!p) p = TaitoX1017::create(board);
   if(!p) p = new Interface;
   return p;
 }

--- a/ares/fc/cartridge/board/board.cpp
+++ b/ares/fc/cartridge/board/board.cpp
@@ -31,7 +31,6 @@ namespace Board {
 #include "sunsoft-4.cpp"
 #include "sunsoft-5b.cpp"
 #include "taito-tc0190.cpp"
-#include "taito-tc0690.cpp"
 
 auto Interface::create(string board) -> Interface* {
   Interface* p = nullptr;
@@ -66,7 +65,6 @@ auto Interface::create(string board) -> Interface* {
   if(!p) p = Sunsoft4::create(board);
   if(!p) p = Sunsoft5B::create(board);
   if(!p) p = TaitoTC0190::create(board);
-  if(!p) p = TaitoTC0690::create(board);
   if(!p) p = new Interface;
   return p;
 }

--- a/ares/fc/cartridge/board/taito-tc0190.cpp
+++ b/ares/fc/cartridge/board/taito-tc0190.cpp
@@ -69,9 +69,6 @@ struct TaitoTC0190 : Interface {
     if(address & 0x2000) return ppu.writeCIRAM(addressCIRAM(address), data);
   }
 
-  auto power() -> void override {
-  }
-
   auto serialize(serializer& s) -> void override {
     s(mirror);
     s(programBank);

--- a/ares/fc/cartridge/board/taito-tc0190.cpp
+++ b/ares/fc/cartridge/board/taito-tc0190.cpp
@@ -69,6 +69,9 @@ struct TaitoTC0190 : Interface {
     if(address & 0x2000) return ppu.writeCIRAM(addressCIRAM(address), data);
   }
 
+  auto power() -> void override {
+  }
+
   auto serialize(serializer& s) -> void override {
     s(mirror);
     s(programBank);

--- a/ares/fc/cartridge/board/taito-x1-005.cpp
+++ b/ares/fc/cartridge/board/taito-x1-005.cpp
@@ -1,0 +1,111 @@
+struct TaitoX1005 : Interface {
+  static auto create(string id) -> Interface* {
+    if(id == "TAITO-X1-005" ) return new TaitoX1005(Revision::X1005);
+    if(id == "TAITO-X1-005A") return new TaitoX1005(Revision::X1005A);
+    return nullptr;
+  }
+
+  Memory::Readable<n8> programROM;
+  Memory::Writable<n8> programRAM;
+  Memory::Readable<n8> characterROM;
+
+  enum class Revision : u32 {
+    X1005,
+    X1005A,
+  } revision;
+
+  TaitoX1005(Revision revision) : revision(revision) {}
+
+  auto load() -> void override {
+    Interface::load(programROM, "program.rom");
+    Interface::load(programRAM, "save.ram");
+    Interface::load(characterROM, "character.rom");
+  }
+
+  auto save() -> void override {
+    Interface::save(programRAM, "save.ram");
+  }
+
+  auto readPRG(n32 address, n8 data) -> n8 override {
+    if(address < 0x7f00) return data;
+
+    if(address < 0x8000) {
+      if(!ramEnable) return data;
+      return programRAM.read((n7)address);
+    }
+
+    n6 bank;
+    switch(address >> 13 & 3) {
+    case 0: bank = programBank[0]; break;
+    case 1: bank = programBank[1]; break;
+    case 2: bank = programBank[2]; break;
+    case 3: bank = 0x3f; break;
+    }
+    return programROM.read(bank << 13 | (n13)address);
+  }
+
+  auto writePRG(n32 address, n8 data) -> void override {
+    if(address >= 0x7f00 && address < 0x8000) {
+      if(!ramEnable) return;
+      return programRAM.write((n7)address, data);
+    }
+
+    switch(address) {
+    case 0x7ef0 ... 0x7ef1:
+      characterBank[address & 1] = data >> 1;
+      nametableBank[address & 1] = data.bit(7);
+      break;
+    case 0x7ef2: characterBank[2] = data; break;
+    case 0x7ef3: characterBank[3] = data; break;
+    case 0x7ef4: characterBank[4] = data; break;
+    case 0x7ef5: characterBank[5] = data; break;
+    case 0x7ef6 ... 0x7ef7: mirror = data.bit(0); break;
+    case 0x7ef8 ... 0x7ef9: ramEnable = data == 0xa3; break;
+    case 0x7efa ... 0x7efb: programBank[0] = data.bit(0,5); break;
+    case 0x7efc ... 0x7efd: programBank[1] = data.bit(0,5); break;
+    case 0x7efe ... 0x7eff: programBank[2] = data.bit(0,5); break;
+    }
+  }
+
+  auto addressCHR(n32 address) const -> n32 {
+    if(address <= 0x07ff) return characterBank[0] << 11 | (n11)address;
+    if(address <= 0x0fff) return characterBank[1] << 11 | (n11)address;
+    if(address <= 0x13ff) return characterBank[2] << 10 | (n10)address;
+    if(address <= 0x17ff) return characterBank[3] << 10 | (n10)address;
+    if(address <= 0x1bff) return characterBank[4] << 10 | (n10)address;
+    if(address <= 0x1fff) return characterBank[5] << 10 | (n10)address;
+    unreachable;
+  }
+
+  auto addressCIRAM(n32 address) const -> n32 {
+    if(revision == Revision::X1005A) {
+      return nametableBank[address >> 12 & 1] << 10 | (n10)address;
+    }
+    return address >> !mirror & 0x0400 | (n10)address;
+  }
+
+  auto readCHR(n32 address, n8 data) -> n8 override {
+    if(address & 0x2000) return ppu.readCIRAM(addressCIRAM(address));
+    if(characterROM) return characterROM.read(addressCHR(address));
+    return data;
+  }
+
+  auto writeCHR(n32 address, n8 data) -> void override {
+    if(address & 0x2000) return ppu.writeCIRAM(addressCIRAM(address), data);
+  }
+
+  auto serialize(serializer& s) -> void override {
+    s(programRAM);
+    s(mirror);
+    s(ramEnable);
+    s(programBank);
+    s(characterBank);
+    s(nametableBank);
+  }
+
+  n1 mirror;
+  n1 ramEnable;
+  n6 programBank[3];
+  n8 characterBank[6];
+  n1 nametableBank[2];
+};

--- a/ares/fc/cartridge/board/taito-x1-017.cpp
+++ b/ares/fc/cartridge/board/taito-x1-017.cpp
@@ -1,0 +1,103 @@
+struct TaitoX1017 : Interface {
+  static auto create(string id) -> Interface* {
+    if(id == "TAITO-X1-017") return new TaitoX1017;
+    return nullptr;
+  }
+
+  Memory::Readable<n8> programROM;
+  Memory::Writable<n8> programRAM;
+  Memory::Readable<n8> characterROM;
+
+  auto load() -> void override {
+    Interface::load(programROM, "program.rom");
+    Interface::load(programRAM, "save.ram");
+    Interface::load(characterROM, "character.rom");
+  }
+
+  auto save() -> void override {
+    Interface::save(programRAM, "save.ram");
+  }
+
+  auto readPRG(n32 address, n8 data) -> n8 override {
+    if(address >= 0x6000 && address < 0x7400) {
+      if(!ramEnable[address >> 11 & 3]) return data;
+      return programRAM.read((n13)address);
+    }
+    if(address < 0x800) return data;
+
+    n6 bank;
+    switch(address >> 13 & 3) {
+    case 0: bank = programBank[0]; break;
+    case 1: bank = programBank[1]; break;
+    case 2: bank = programBank[2]; break;
+    case 3: bank = 0x3f; break;
+    }
+    return programROM.read(bank << 13 | (n13)address);
+  }
+
+  auto writePRG(n32 address, n8 data) -> void override {
+    if(address >= 0x6000 && address < 0x7400) {
+      if(!ramEnable[address >> 11 & 3]) return;
+      return programRAM.write((n13)address, data);
+    }
+
+    switch(address) {
+    case 0x7ef0: characterBank[0] = data >> 1; break;
+    case 0x7ef1: characterBank[1] = data >> 1; break;
+    case 0x7ef2: characterBank[2] = data; break;
+    case 0x7ef3: characterBank[3] = data; break;
+    case 0x7ef4: characterBank[4] = data; break;
+    case 0x7ef5: characterBank[5] = data; break;
+    case 0x7ef6:
+      mirror = data.bit(0);
+      characterMode = data.bit(1);
+      break;
+    case 0x7ef7: ramEnable[0] = data == 0xca; break;
+    case 0x7ef8: ramEnable[1] = data == 0x69; break;
+    case 0x7ef9: ramEnable[2] = data == 0x84; break;
+    case 0x7efa: programBank[0] = data >> 2; break;
+    case 0x7efb: programBank[1] = data >> 2; break;
+    case 0x7efc: programBank[2] = data >> 2; break;
+    }
+  }
+
+  auto addressCHR(n32 address) const -> n32 {
+    if(characterMode) address ^= 0x1000;
+    if(address <= 0x07ff) return characterBank[0] << 11 | (n11)address;
+    if(address <= 0x0fff) return characterBank[1] << 11 | (n11)address;
+    if(address <= 0x13ff) return characterBank[2] << 10 | (n10)address;
+    if(address <= 0x17ff) return characterBank[3] << 10 | (n10)address;
+    if(address <= 0x1bff) return characterBank[4] << 10 | (n10)address;
+    if(address <= 0x1fff) return characterBank[5] << 10 | (n10)address;
+    unreachable;
+  }
+
+  auto addressCIRAM(n32 address) const -> n32 {
+    return address >> !mirror & 0x0400 | (n10)address;
+  }
+
+  auto readCHR(n32 address, n8 data) -> n8 override {
+    if(address & 0x2000) return ppu.readCIRAM(addressCIRAM(address));
+    if(characterROM) return characterROM.read(addressCHR(address));
+    return data;
+  }
+
+  auto writeCHR(n32 address, n8 data) -> void override {
+    if(address & 0x2000) return ppu.writeCIRAM(addressCIRAM(address), data);
+  }
+
+  auto serialize(serializer& s) -> void override {
+    s(programRAM);
+    s(mirror);
+    s(ramEnable);
+    s(programBank);
+    s(characterBank);
+    s(characterMode);
+  }
+
+  n1 mirror;
+  n1 ramEnable[3];
+  n6 programBank[3];
+  n8 characterBank[6];
+  n1 characterMode;
+};

--- a/ares/fc/cartridge/board/taito-x1-017.cpp
+++ b/ares/fc/cartridge/board/taito-x1-017.cpp
@@ -23,7 +23,7 @@ struct TaitoX1017 : Interface {
       if(!ramEnable[address >> 11 & 3]) return data;
       return programRAM.read((n13)address);
     }
-    if(address < 0x800) return data;
+    if(address < 0x8000) return data;
 
     n6 bank;
     switch(address >> 13 & 3) {

--- a/mia/medium/famicom.cpp
+++ b/mia/medium/famicom.cpp
@@ -317,6 +317,12 @@ auto Famicom::analyzeINES(vector<u8>& data) -> string {
     prgram = 128;
     break;
 
+  case  82:
+    s += "  board:  TAITO-X1-017\n";
+    s += "    chip type=X1-017\n";
+    prgram = 5120;
+    break;
+
   case  85:
     s += "  board:  KONAMI-VRC-7\n";
     s += "    chip type=VRC7\n";

--- a/mia/medium/famicom.cpp
+++ b/mia/medium/famicom.cpp
@@ -264,6 +264,7 @@ auto Famicom::analyzeINES(vector<u8>& data) -> string {
 
   case  33:
     s += "  board:  TAITO-TC0190\n";
+    s += "    chip type=TC0190\n";
     break;
 
   case  34:
@@ -273,6 +274,7 @@ auto Famicom::analyzeINES(vector<u8>& data) -> string {
 
   case  48:
     s += "  board:  TAITO-TC0690\n";
+    s += "    chip type=TC0690\n";
     break;
 
   case  66:

--- a/mia/medium/famicom.cpp
+++ b/mia/medium/famicom.cpp
@@ -311,6 +311,12 @@ auto Famicom::analyzeINES(vector<u8>& data) -> string {
     s += "    chip type=VRC1\n";
     break;
 
+  case  80:
+    s += "  board:  TAITO-X1-005\n";
+    s += "    chip type=X1-005\n";
+    prgram = 128;
+    break;
+
   case  85:
     s += "  board:  KONAMI-VRC-7\n";
     s += "    chip type=VRC7\n";
@@ -349,6 +355,12 @@ auto Famicom::analyzeINES(vector<u8>& data) -> string {
   case 206:
     s += "  board: HVC-DRROM\n";
     chrram = 2048;
+    break;
+
+  case 207:
+    s += "  board:  TAITO-X1-005A\n";
+    s += "    chip type=X1-005\n";
+    prgram = 128;
     break;
 
   }


### PR DESCRIPTION
Support added for Taito X1-005 and X1-017 chips found on some Taito NES boards.

Taito X1-005 (iNES mapper 80):
- Kyonshiizu 2 (Japan)
- Kyoto Ryuu no Tera Satsujin Jiken (Japan)
- Kyuukyoku Harikiri Stadium (Japan)
- Kyuukyoku Harikiri Stadium - '88 Senshu Shin Data Version (Japan)
- Minelvaton Saga - Ragon no Fukkatsu (Japan)
- Mirai Shinwa Jarvas (Japan)
- Taito Grand Prix - Eikou e no License (Japan)

Taito X1-005 with alternative mirroring (iNES mapper 207):
- Fudou Myouou Den (Japan)

Taito X1-017 (iNES mapper 82):
- Kyuukyoku Harikiri Koushien (Japan)
- Kyuukyoku Harikiri Stadium - Heisei Gannen Ban (Japan)
- Kyuukyoku Harikiri Stadium III (Japan)
- SD Keiji - Blader (Japan)

The X1-017 chip has been reverse-engineered last year, and was discovered to have irq capabilities. It's not implemented here, as it's not used by any of the commercial games, and I have not a test case for it.

Two of the baseball games require a reset to correctly boot. They show a message on japanese on first boot that I guess is warning that.