### PR TITLE
n64: more accurate RDP status bit management

### DIFF
--- a/ares/n64/rdp/io.cpp
+++ b/ares/n64/rdp/io.cpp
@@ -22,14 +22,14 @@ auto RDP::readWord(u32 address) -> u32 {
     data.bit( 0) = command.source;
     data.bit( 1) = command.freeze;
     data.bit( 2) = command.flush;
-    data.bit( 3) = 0;  //start gclk?
+    data.bit( 3) = command.startGclk;
     data.bit( 4) = command.tmemBusy > 0;
     data.bit( 5) = command.pipeBusy > 0;
     data.bit( 6) = command.bufferBusy > 0;
     data.bit( 7) = command.ready;
     data.bit( 8) = 0;  //DMA busy
-    data.bit( 9) = 0;  //end valid
-    data.bit(10) = 0;  //start valid
+    data.bit( 9) = command.endValid;
+    data.bit(10) = command.startValid;
   }
 
   if(address == 4) {
@@ -63,17 +63,21 @@ auto RDP::writeWord(u32 address, u32 data_) -> void {
   if(address == 0) {
     //DPC_START
     command.start = data.bit(0,23) & ~7;
-    command.current = command.start;
+    command.startValid = 1;
   }
 
   if(address == 1) {
     //DPC_END
     command.end = data.bit(0,23) & ~7;
-    if(command.end > command.current) {
-      command.freeze = 0;
-      render();
-      command.ready = 1;
+
+    if(command.startValid) {
+      command.current = command.start;
+      command.startValid = 0;
     }
+    command.pipeBusy = 1;
+    command.startGclk = 1;
+    if(command.end > command.current) render();
+    command.ready = 1;
   }
 
   if(address == 2) {
@@ -85,7 +89,7 @@ auto RDP::writeWord(u32 address, u32 data_) -> void {
     if(data.bit(0)) command.source = 0;
     if(data.bit(1)) command.source = 1;
     if(data.bit(2)) command.freeze = 0;
-  //if(data.bit(3)) command.freeze = 1;
+    if(data.bit(3)) command.freeze = 1;
     if(data.bit(4)) command.flush = 0;
     if(data.bit(5)) command.flush = 1;
     if(data.bit(6)) command.tmemBusy = 0;

--- a/ares/n64/rdp/rdp.hpp
+++ b/ares/n64/rdp/rdp.hpp
@@ -82,6 +82,9 @@ struct RDP : Thread, Memory::IO<RDP> {
     n1  source;  //0 = RDRAM, 1 = DMEM
     n1  freeze;
     n1  flush;
+    n1  startValid;
+    n1  endValid;
+    n1  startGclk;
     n1  ready = 1;
   } command;
 

--- a/ares/n64/rdp/render.cpp
+++ b/ares/n64/rdp/render.cpp
@@ -619,6 +619,8 @@ auto RDP::syncTile() -> void {
 //0x29
 auto RDP::syncFull() -> void {
   mi.raise(MI::IRQ::DP);
+  command.pipeBusy = 0;
+  command.startGclk = 0;
 }
 
 //0x2a


### PR DESCRIPTION
This begins improving the RDP status bits to more accurately reflect
what it can be seen on real hardware. It also undoes a hack for RDP
freeze that was allowing Banjo-Tooie to boot. Being a game-specific
hack, I think it is better to simply disable and wait until we find
out how to properly fix the game.

Fix a few new tests in n64-systemtest.