### PR TITLE
MD/32X fixes

### DIFF
--- a/ares/component/processor/sh2/sh2.cpp
+++ b/ares/component/processor/sh2/sh2.cpp
@@ -50,7 +50,7 @@ auto SH2::power(bool reset) -> void {
   cache = {*this};
   intc = {*this};
   dmac = {*this};
-  sci = {*this};
+  sci = {*this, reset ? sci.link : maybe<SH2&>()};
   wdt = {};
   ubc = {};
   frt = {*this};

--- a/ares/component/processor/sh2/sh7604/io.cpp
+++ b/ares/component/processor/sh2/sh7604/io.cpp
@@ -553,7 +553,7 @@ auto SH2::internalWriteByte(u32 address, n8 data) -> void {
     sci.scr.te   = data.bit(5);
     sci.scr.rie  = data.bit(6);
     sci.scr.tie  = data.bit(7);
-    if(!te && sci.scr.te) sci.run();
+    if(te && !sci.scr.te) sci.ssr.tdre = 1;
     return;
   }
 
@@ -563,7 +563,8 @@ auto SH2::internalWriteByte(u32 address, n8 data) -> void {
     return;
 
   //SSR: serial status register
-  case 0xffff'fe04:
+  case 0xffff'fe04: {
+    bool tdre = sci.ssr.tdre;
     sci.ssr.mpbt  = data.bit(0);
   //sci.ssr.mpb   = data.bit(1) = readonly;
   //sci.ssr.tend  = data.bit(2) = readonly;
@@ -572,8 +573,9 @@ auto SH2::internalWriteByte(u32 address, n8 data) -> void {
     sci.ssr.orer &= data.bit(5);
     sci.ssr.rdrf &= data.bit(6);
     sci.ssr.tdre &= data.bit(7);
-    if(sci.scr.te) sci.run();
+    if(tdre && !sci.ssr.tdre) sci.run();
     return;
+  }
 
   //RDR: receive data register
   case 0xffff'fe05:

--- a/ares/component/processor/sh2/sh7604/sh7604.hpp
+++ b/ares/component/processor/sh2/sh7604/sh7604.hpp
@@ -201,7 +201,7 @@
       n1 fer;       //framing error
       n1 orer;      //overrun error
       n1 rdrf;      //receive data register full
-      n1 tdre;      //transmit data register empty
+      n1 tdre = 1;  //transmit data register empty
     } ssr;
     n8 brr = 0xff;  //bit rate register
     n8 tdr = 0xff;  //transmit data register

--- a/ares/md/m32x/io-external.cpp
+++ b/ares/md/m32x/io-external.cpp
@@ -11,7 +11,9 @@ auto M32X::readExternalIO(n1 upper, n1 lower, n24 address, n16 data) -> n16 {
   if(address == 0xa15100) {
     data.bit( 0) = io.adapterEnable;
     data.bit( 1) = io.adapterReset;
+    data.bit(2, 6) = 0;
     data.bit( 7) = io.resetEnable;
+    data.bit(8, 14) = 0;
     data.bit(15) = vdp.framebufferAccess;
   }
 

--- a/desktop-ui/emulator/mega-cd-32x.cpp
+++ b/desktop-ui/emulator/mega-cd-32x.cpp
@@ -66,8 +66,14 @@ auto MegaCD32X::load() -> bool {
   }
 
   if(auto port = root->find<ares::Node::Port>("Controller Port 2")) {
-    port->allocate("Fighting Pad");
-    port->connect();
+    if(game->pak->attribute("serial") == "GM T-16201F-00") {
+      // CORPSE KILLER 32X (U) -- GM T-16201F-00
+      // Gamepad in controller port 2 breaks input polling, so leave it disconnected.
+      // No supported lightgun devices are currently emulated (Sega Menacer, ALG GameGun).
+    } else {
+      port->allocate("Fighting Pad");
+      port->connect();
+    }
   }
 
   return true;

--- a/mia/medium/mega-drive.cpp
+++ b/mia/medium/mega-drive.cpp
@@ -522,6 +522,15 @@ auto MegaDrive::analyzeStorage(vector<u8>& rom, string hash) -> void {
     eeprom.wscl = 1;
   }
 
+  //Wonder Boy V - Monster World III (Japan)
+  if(hash == "d758864efa18da7a8a87dce32a5b61a8067fb60846696a9588956bc316e480f9") {
+    eeprom.mode = "X24C01";
+    eeprom.size = 128;
+    eeprom.rsda = 0;
+    eeprom.wsda = 0;
+    eeprom.wscl = 1;
+  }
+
   //X24C02
   //======
 


### PR DESCRIPTION
1. Fixes the bits read from the 32X adapter control register (external), confirmed by the 32X Mars Check Program.
2. Serial communication between paired SH-2's is fixed, confirmed by Mars Check. This also fixes the crash when starting the X-Men 32X prototype.
3. Added eeprom fix for the J version of Wonder Boy V to satisfy #680. The UE version was already covered.
4. Added controller workaround for Corpse Killer 32X CD, same that was added for the plain CD version previously (ref: 
commit 0049c89).

Ares now passes 32X Mars Check Program with no explicit errors. Note, there are still some PWM issues that will need to be tackled.