### PR TITLE
sfc: master volume -> main volume

### DIFF
--- a/ares/sfc/dsp/dsp.cpp
+++ b/ares/sfc/dsp/dsp.cpp
@@ -201,7 +201,7 @@ auto DSP::power(bool reset) -> void {
     random.array({registers, sizeof(registers)});
   }
 
-  master = {};
+  mainvol = {};
   echo = {};
   noise = {};
   brr = {};

--- a/ares/sfc/dsp/dsp.hpp
+++ b/ares/sfc/dsp/dsp.hpp
@@ -16,7 +16,7 @@ struct DSP : Thread {
   n8 apuram[64_KiB];
   n8 registers[128];
 
-  auto mute() const -> bool { return master.mute; }
+  auto mute() const -> bool { return mainvol.mute; }
 
   //dsp.cpp
   auto load(Node::Object) -> void;
@@ -45,12 +45,12 @@ private:
     n1  sample = 1;
   } clock;
 
-  struct Master {
+  struct MainVol {
     n1  reset = 1;
     n1  mute = 1;
     i8  volume[2];
     i17 output[2];
-  } master;
+  } mainvol;
 
   struct Echo {
     i8  feedback;

--- a/ares/sfc/dsp/echo.cpp
+++ b/ares/sfc/dsp/echo.cpp
@@ -4,9 +4,9 @@ auto DSP::calculateFIR(n1 channel, s32 index) -> s32 {
 }
 
 auto DSP::echoOutput(n1 channel) const -> i16 {
-  i16 masterOutput = master.output[channel] * master.volume[channel] >> 7;
+  i16 mainvolOutput = mainvol.output[channel] * mainvol.volume[channel] >> 7;
     i16 echoOutput =    echo.input[channel] *   echo.volume[channel] >> 7;
-  return sclamp<16>(masterOutput + echoOutput);
+  return sclamp<16>(mainvolOutput + echoOutput);
 }
 
 auto DSP::echoRead(n1 channel) -> void {
@@ -77,7 +77,7 @@ auto DSP::echo25() -> void {
 auto DSP::echo26() -> void {
   //left output volumes
   //(save sample for next clock so we can output both together)
-  master.output[0] = echoOutput(0);
+  mainvol.output[0] = echoOutput(0);
 
   //echo feedback
   s32 l = echo.output[0] + i16(echo.input[0] * echo.feedback >> 7);
@@ -88,14 +88,14 @@ auto DSP::echo26() -> void {
 }
 
 auto DSP::echo27() -> void {
-  s32 outl = master.output[0];
+  s32 outl = mainvol.output[0];
   s32 outr = echoOutput(1);
-  master.output[0] = 0;
-  master.output[1] = 0;
+  mainvol.output[0] = 0;
+  mainvol.output[1] = 0;
 
   //todo: global muting isn't this simple
   //(turns DAC on and off or something, causing small ~37-sample pulse when first muted)
-  if(master.mute) {
+  if(mainvol.mute) {
     outl = 0;
     outr = 0;
   }

--- a/ares/sfc/dsp/memory.cpp
+++ b/ares/sfc/dsp/memory.cpp
@@ -7,10 +7,10 @@ auto DSP::write(n7 address, n8 data) -> void {
 
   switch(address) {
   case 0x0c:  //MVOLL
-    master.volume[0] = data;
+    mainvol.volume[0] = data;
     break;
   case 0x1c:  //MVOLR
-    master.volume[1] = data;
+    mainvol.volume[1] = data;
     break;
   case 0x2c:  //EVOLL
     echo.volume[0] = data;
@@ -28,8 +28,8 @@ auto DSP::write(n7 address, n8 data) -> void {
   case 0x6c:  //FLG
     noise.frequency = data.bit(0,4);
     echo.readonly   = data.bit(5);
-    master.mute     = data.bit(6);
-    master.reset    = data.bit(7);
+    mainvol.mute     = data.bit(6);
+    mainvol.reset    = data.bit(7);
     break;
   case 0x7c:  //ENDX
     for(u32 n : range(8)) voice[n]._end = 0;

--- a/ares/sfc/dsp/serialization.cpp
+++ b/ares/sfc/dsp/serialization.cpp
@@ -7,10 +7,10 @@ auto DSP::serialize(serializer& s) -> void {
   s(clock.counter);
   s(clock.sample);
 
-  s(master.reset);
-  s(master.mute);
-  s(master.volume);
-  s(master.output);
+  s(mainvol.reset);
+  s(mainvol.mute);
+  s(mainvol.volume);
+  s(mainvol.output);
 
   s(echo.feedback);
   s(echo.volume);

--- a/ares/sfc/dsp/voice.cpp
+++ b/ares/sfc/dsp/voice.cpp
@@ -3,8 +3,8 @@ inline auto DSP::voiceOutput(Voice& v, n1 channel) -> void {
   s32 amp = latch.output * v.volume[channel] >> 7;
 
   //add to output total
-  master.output[channel] += amp;
-  master.output[channel] = sclamp<16>(master.output[channel]);
+  mainvol.output[channel] += amp;
+  mainvol.output[channel] = sclamp<16>(mainvol.output[channel]);
 
   //optionally add to echo total
   if(v._echo) {
@@ -87,7 +87,7 @@ auto DSP::voice3c(Voice& v) -> void {
   v.envx = v.envelope >> 4;
 
   //immediate silence due to end of sample or soft reset
-  if(master.reset || brr._header.bit(0,1) == 1) {
+  if(mainvol.reset || brr._header.bit(0,1) == 1) {
     v.envelopeMode = Envelope::Release;
     v.envelope = 0;
   }


### PR DESCRIPTION
When talking about audio on the SNES, the phrase "Main Volume" should be preferred over "Master Volume" because:

- it is what the official Super Nintendo development manual calls the registers MVOLL and MVOLR (see 7.2.2.6 on page 3-7-9, link below)
- changing the values of MVOLL and MVOLR actually has no effect on hardware echos whatsoever, so talking about a "master volume" can paint the wrong picture in someone's mind about how the S-DSP paths are actually wired up, making them think that MVOLL and MVOLR control absolutely everything

I have tested this with "Seiken Densetsu 3 (Japan).sfc" and hear no difference in the opening crawl.

https://archive.org/details/SNESDevManual/book1/page/n175
Note that there is an itsy typo on this page - it should say "The output of **these registers** is the sum..."