### PR TITLE
n64: improve and extend cache coherency checks

### DIFF
--- a/ares/n64/ai/ai.cpp
+++ b/ares/n64/ai/ai.cpp
@@ -38,7 +38,7 @@ auto AI::sample(f64& left, f64& right) -> void {
 
   if(io.dmaLength[0] && io.dmaEnable) {
     io.dmaAddress[0].bit(13,23) += io.dmaAddressCarry;
-    auto data  = rdram.ram.read<Word>(io.dmaAddress[0]);
+    auto data  = rdram.ram.read<Word>(io.dmaAddress[0], "AI");
     auto l     = s16(data >> 16);
     auto r     = s16(data >>  0);
     left       = l / 32768.0;
@@ -50,8 +50,9 @@ auto AI::sample(f64& left, f64& right) -> void {
   }
   if(!io.dmaLength[0]) {
     if(--io.dmaCount) {
-      io.dmaAddress[0] = io.dmaAddress[1];
-      io.dmaLength [0] = io.dmaLength [1];
+      io.dmaAddress[0]  = io.dmaAddress[1];
+      io.dmaLength [0]  = io.dmaLength [1];
+      io.dmaOriginPc[0] = io.dmaOriginPc[1];
       mi.raise(MI::IRQ::AI);
     }
   }

--- a/ares/n64/ai/ai.hpp
+++ b/ares/n64/ai/ai.hpp
@@ -38,6 +38,7 @@ struct AI : Thread, Memory::RCP<AI> {
     n1  dmaAddressCarry;
     n18 dmaLength[2];
     n2  dmaCount;
+    u64 dmaOriginPc[2];
     n14 dacRate;
     n4  bitRate;
   } io;

--- a/ares/n64/ai/io.cpp
+++ b/ares/n64/ai/io.cpp
@@ -38,6 +38,7 @@ auto AI::writeWord(u32 address, u32 data_, Thread& thread) -> void {
     if(io.dmaCount < 2) {
       if(io.dmaCount == 0) mi.raise(MI::IRQ::AI);
       io.dmaLength[io.dmaCount] = length;
+      io.dmaOriginPc[io.dmaCount] = cpu.ipu.pc;
       io.dmaCount++;
     }
   }

--- a/ares/n64/cartridge/flash.cpp
+++ b/ares/n64/cartridge/flash.cpp
@@ -85,7 +85,8 @@ auto Cartridge::Flash::writeWord(u32 address, u64 data) -> void {
     }
     if(mode == Mode::Write) {
       for(u32 index = 0; index < 128; index += 2) {
-        u16 half = rdram.ram.read<Half>(source + index);
+        // FIXME: this is obviously wrong, the flash can't access RDRAM
+        u16 half = rdram.ram.read<Half>(source + index, "Flash");
         Memory::Writable::write<Half>(offset + index, half);
       }
     }

--- a/ares/n64/cpu/cpu.cpp
+++ b/ares/n64/cpu/cpu.cpp
@@ -92,6 +92,7 @@ auto CPU::instruction() -> void {
     return exception.nmi();
   }
   if (scc.sysadFrozen) {
+    step(1 * 2);
     return;
   }
 

--- a/ares/n64/cpu/cpu.hpp
+++ b/ares/n64/cpu/cpu.hpp
@@ -187,8 +187,8 @@ struct CPU : Thread {
       u16  dirty;
       u32  tag;
       u16  index;
-      u64  fillpc;
-      u64  dirtypc;
+      u64  fillPc;
+      u64  dirtyPc;
       union {
         u8  bytes[16];
         u16 halfs[8];

--- a/ares/n64/cpu/cpu.hpp
+++ b/ares/n64/cpu/cpu.hpp
@@ -184,9 +184,11 @@ struct CPU : Thread {
       template<u32 Size> auto write(u32 address, u64 data) -> void;
 
       bool valid;
-      bool dirty;
+      u16  dirty;
       u32  tag;
       u16  index;
+      u64  fillpc;
+      u64  dirtypc;
       union {
         u8  bytes[16];
         u16 halfs[8];

--- a/ares/n64/cpu/dcache.cpp
+++ b/ares/n64/cpu/dcache.cpp
@@ -7,7 +7,7 @@ auto CPU::DataCache::Line::fill(u32 address) -> void {
   valid  = 1;
   dirty  = 0;
   tag    = address & ~0x0000'0fff;
-  fillpc = cpu.ipu.pc;
+  fillPc = cpu.ipu.pc;
   cpu.busReadBurst<DCache>(tag | index, words);
 }
 
@@ -43,7 +43,7 @@ auto CPU::DataCache::Line::write(u32 address, u64 data) -> void {
     words[address >> 2 & 2 | 1] = data >>  0;
   }
   dirty |= ((1 << Size) - 1) << (address & 0xF);
-  dirtypc = cpu.ipu.pc;
+  dirtyPc = cpu.ipu.pc;
 }
 
 template<u32 Size>

--- a/ares/n64/cpu/dcache.cpp
+++ b/ares/n64/cpu/dcache.cpp
@@ -4,9 +4,10 @@ auto CPU::DataCache::Line::hit(u32 address) const -> bool {
 
 auto CPU::DataCache::Line::fill(u32 address) -> void {
   cpu.step(40 * 2);
-  valid = 1;
-  dirty = 0;
-  tag   = address & ~0x0000'0fff;
+  valid  = 1;
+  dirty  = 0;
+  tag    = address & ~0x0000'0fff;
+  fillpc = cpu.ipu.pc;
   cpu.busReadBurst<DCache>(tag | index, words);
 }
 
@@ -41,7 +42,8 @@ auto CPU::DataCache::Line::write(u32 address, u64 data) -> void {
     words[address >> 2 & 2 | 0] = data >> 32;
     words[address >> 2 & 2 | 1] = data >>  0;
   }
-  dirty = 1;
+  dirty |= ((1 << Size) - 1) << (address & 0xF);
+  dirtypc = cpu.ipu.pc;
 }
 
 template<u32 Size>
@@ -60,7 +62,7 @@ auto CPU::DataCache::readDebug(u32 vaddr, u32 address) -> u8 {
   auto& line = this->line(vaddr);
   if(!line.hit(address)) {
     Thread dummyThread{};
-    return bus.read<Byte>(address, dummyThread);
+    return bus.read<Byte>(address, dummyThread, "Ares Debugger");
   }
   return line.read<Byte>(address);
 }

--- a/ares/n64/cpu/memory.cpp
+++ b/ares/n64/cpu/memory.cpp
@@ -146,7 +146,7 @@ auto CPU::devirtualizeDebug(u64 vaddr) -> u64 {
 
 template<u32 Size>
 inline auto CPU::busWrite(u32 address, u64 data) -> void {
-  bus.write<Size>(address, data, *this);
+  bus.write<Size>(address, data, *this, "CPU");
 }
 
 template<u32 Size>
@@ -156,7 +156,7 @@ inline auto CPU::busWriteBurst(u32 address, u32 *data) -> void {
 
 template<u32 Size>
 inline auto CPU::busRead(u32 address) -> u64 {
-  return bus.read<Size>(address, *this);
+  return bus.read<Size>(address, *this, "CPU");
 }
 
 template<u32 Size>
@@ -239,7 +239,7 @@ auto CPU::readDebug(u64 vaddr) -> u8 {
     case Context::Segment::Mapped:
       if(auto match = tlb.load(vaddr, true)) {
         if(match.cache) return dcache.readDebug(vaddr, match.address & context.physMask);
-        return bus.read<Byte>(match.address & context.physMask, dummyThread);
+        return bus.read<Byte>(match.address & context.physMask, dummyThread, "Ares Debugger");
       }
       return 0;
     case Context::Segment::Cached:
@@ -247,9 +247,9 @@ auto CPU::readDebug(u64 vaddr) -> u8 {
     case Context::Segment::Cached32:
       return dcache.readDebug(vaddr, vaddr & 0xffff'ffff);
     case Context::Segment::Direct:
-      return bus.read<Byte>(vaddr & 0x1fff'ffff, dummyThread);
+      return bus.read<Byte>(vaddr & 0x1fff'ffff, dummyThread, "Ares Debugger");
     case Context::Segment::Direct32:
-      return bus.read<Byte>(vaddr & 0xffff'ffff, dummyThread);
+      return bus.read<Byte>(vaddr & 0xffff'ffff, dummyThread, "Ares Debugger");
   }
 
   unreachable;

--- a/ares/n64/cpu/recompiler.cpp
+++ b/ares/n64/cpu/recompiler.cpp
@@ -36,7 +36,7 @@ auto CPU::Recompiler::emit(u32 vaddr, u32 address, bool singleInstruction) -> Bl
   Thread thread;
   bool hasBranched = 0;
   while(true) {
-    u32 instruction = bus.read<Word>(address, thread);
+    u32 instruction = bus.read<Word>(address, thread, "Ares Recompiler");
     if(callInstructionPrologue) {
       mov32(reg(1), imm(instruction));
       call(&CPU::instructionPrologue);

--- a/ares/n64/memory/bus.hpp
+++ b/ares/n64/memory/bus.hpp
@@ -1,10 +1,9 @@
 template<u32 Size>
-inline auto Bus::read(u32 address, Thread& thread) -> u64 {
+inline auto Bus::read(u32 address, Thread& thread, const char *peripheral) -> u64 {
   static constexpr u64 unmapped = 0;
   static_assert(Size == Byte || Size == Half || Size == Word || Size == Dual);
 
-  if(address <= 0x007f'ffff) return rdram.ram.read<Size>(address);
-  if(address <= 0x03ef'ffff) return unmapped;
+  if(address <= 0x03ef'ffff) return rdram.ram.read<Size>(address, peripheral);
   if(address <= 0x03ff'ffff) return rdram.read<Size>(address, thread);
   if(address <= 0x0407'ffff) return rsp.read<Size>(address, thread);
   if(address <= 0x040f'ffff) return rsp.status.read<Size>(address, thread);
@@ -27,16 +26,18 @@ template<u32 Size>
 inline auto Bus::readBurst(u32 address, u32 *data, Thread& thread) -> void {
   static_assert(Size == DCache || Size == ICache);
 
+  if(address <= 0x03ef'ffff) return rdram.ram.readBurst<Size>(address, data, "CPU");
   if(address <= 0x03ff'ffff) {
-    data[0] = read<Word>(address | 0x0, thread);
-    data[1] = read<Word>(address | 0x4, thread);
-    data[2] = read<Word>(address | 0x8, thread);
-    data[3] = read<Word>(address | 0xc, thread);
+    // FIXME: not hardware validated, no idea of the behavior
+    data[0] = rdram.readWord(address | 0x0, thread);
+    data[1] = 0;
+    data[2] = 0;
+    data[3] = 0;
     if constexpr(Size == ICache) {
-      data[4] = read<Word>(address | 0x10, thread);
-      data[5] = read<Word>(address | 0x14, thread);
-      data[6] = read<Word>(address | 0x18, thread);
-      data[7] = read<Word>(address | 0x1c, thread);      
+      data[4] = 0;
+      data[5] = 0;
+      data[6] = 0;
+      data[7] = 0;
     }
     return;
   }
@@ -46,15 +47,14 @@ inline auto Bus::readBurst(u32 address, u32 *data, Thread& thread) -> void {
 }
 
 template<u32 Size>
-inline auto Bus::write(u32 address, u64 data, Thread& thread) -> void {
+inline auto Bus::write(u32 address, u64 data, Thread& thread, const char *peripheral) -> void {
   static_assert(Size == Byte || Size == Half || Size == Word || Size == Dual);
   if constexpr(Accuracy::CPU::Recompiler) {
     cpu.recompiler.invalidate(address + 0); if constexpr(Size == Dual)
     cpu.recompiler.invalidate(address + 4);
   }
 
-  if(address <= 0x007f'ffff) return rdram.ram.write<Size>(address, data);
-  if(address <= 0x03ef'ffff) return;
+  if(address <= 0x03ef'ffff) return rdram.ram.write<Size>(address, data, peripheral);
   if(address <= 0x03ff'ffff) return rdram.write<Size>(address, data, thread);
   if(address <= 0x0407'ffff) return rsp.write<Size>(address, data, thread);
   if(address <= 0x040f'ffff) return rsp.status.write<Size>(address, data, thread);
@@ -76,21 +76,17 @@ inline auto Bus::write(u32 address, u64 data, Thread& thread) -> void {
 template<u32 Size>
 inline auto Bus::writeBurst(u32 address, u32 *data, Thread& thread) -> void {
   static_assert(Size == DCache || Size == ICache);
+  if constexpr(Accuracy::CPU::Recompiler) {
+    cpu.recompiler.invalidateRange(address, Size == DCache ? 16 : 32);
+  }
 
+  if(address <= 0x03ef'ffff) return rdram.ram.writeBurst<Size>(address, data, "CPU");
   if(address <= 0x03ff'ffff) {
-    write<Word>(address | 0x0, data[0], thread);
-    write<Word>(address | 0x4, data[1], thread);
-    write<Word>(address | 0x8, data[2], thread);
-    write<Word>(address | 0xc, data[3], thread);
-    if constexpr(Size == ICache) {
-      write<Word>(address | 0x10, data[4], thread);
-      write<Word>(address | 0x14, data[5], thread);
-      write<Word>(address | 0x18, data[6], thread);
-      write<Word>(address | 0x1c, data[7], thread);
-    }
+    // FIXME: not hardware validated, but a good guess
+    rdram.writeWord(address | 0x0, data[0], thread);
     return;
   }
 
-  debug(unusual, "[Bus::readBurst] CPU frozen because of cached write to non-RDRAM area: 0x", hex(address, 8L));
+  debug(unusual, "[Bus::writeBurst] CPU frozen because of cached write to non-RDRAM area: 0x", hex(address, 8L));
   cpu.scc.sysadFrozen = true;
 }

--- a/ares/n64/memory/bus.hpp
+++ b/ares/n64/memory/bus.hpp
@@ -1,12 +1,13 @@
 template<u32 Size>
 inline auto Bus::read(u32 address, Thread& thread, const char *peripheral) -> u64 {
-  static constexpr u64 unmapped = 0;
   static_assert(Size == Byte || Size == Half || Size == Word || Size == Dual);
 
   if(address <= 0x03ef'ffff) return rdram.ram.read<Size>(address, peripheral);
   if(address <= 0x03ff'ffff) return rdram.read<Size>(address, thread);
+  if(Size == Dual)           return freezeDualRead(address), 0;
   if(address <= 0x0407'ffff) return rsp.read<Size>(address, thread);
-  if(address <= 0x040f'ffff) return rsp.status.read<Size>(address, thread);
+  if(address <= 0x040b'ffff) return rsp.status.read<Size>(address, thread);
+  if(address <= 0x040f'ffff) return freezeUnmapped(address), 0;
   if(address <= 0x041f'ffff) return rdp.read<Size>(address, thread);
   if(address <= 0x042f'ffff) return rdp.io.read<Size>(address, thread);
   if(address <= 0x043f'ffff) return mi.read<Size>(address, thread);
@@ -15,13 +16,11 @@ inline auto Bus::read(u32 address, Thread& thread, const char *peripheral) -> u6
   if(address <= 0x046f'ffff) return pi.read<Size>(address, thread);
   if(address <= 0x047f'ffff) return ri.read<Size>(address, thread);
   if(address <= 0x048f'ffff) return si.read<Size>(address, thread);
-  if(address <= 0x04ff'ffff) return unmapped;
+  if(address <= 0x04ff'ffff) return freezeUnmapped(address), 0;
   if(address <= 0x1fbf'ffff) return pi.read<Size>(address, thread);
   if(address <= 0x1fcf'ffff) return si.read<Size>(address, thread);
   if(address <= 0x7fff'ffff) return pi.read<Size>(address, thread);
-  debug(unusual, "[Bus::write] CPU frozen because of read from physical address ", hex(address, 8L), " outside of RCP mapped range");
-  cpu.scc.sysadFrozen = true;
-  return unmapped;
+  return freezeUnmapped(address), 0;
 }
 
 template<u32 Size>
@@ -44,8 +43,7 @@ inline auto Bus::readBurst(u32 address, u32 *data, Thread& thread) -> void {
     return;
   }
 
-  debug(unusual, "[Bus::readBurst] CPU frozen because of cached read to non-RDRAM area: 0x", hex(address, 8L));
-  cpu.scc.sysadFrozen = true;
+  return freezeUncached(address);
 }
 
 template<u32 Size>
@@ -59,7 +57,8 @@ inline auto Bus::write(u32 address, u64 data, Thread& thread, const char *periph
   if(address <= 0x03ef'ffff) return rdram.ram.write<Size>(address, data, peripheral);
   if(address <= 0x03ff'ffff) return rdram.write<Size>(address, data, thread);
   if(address <= 0x0407'ffff) return rsp.write<Size>(address, data, thread);
-  if(address <= 0x040f'ffff) return rsp.status.write<Size>(address, data, thread);
+  if(address <= 0x040b'ffff) return rsp.status.write<Size>(address, data, thread);
+  if(address <= 0x040f'ffff) return freezeUnmapped(address);
   if(address <= 0x041f'ffff) return rdp.write<Size>(address, data, thread);
   if(address <= 0x042f'ffff) return rdp.io.write<Size>(address, data, thread);
   if(address <= 0x043f'ffff) return mi.write<Size>(address, data, thread);
@@ -68,12 +67,11 @@ inline auto Bus::write(u32 address, u64 data, Thread& thread, const char *periph
   if(address <= 0x046f'ffff) return pi.write<Size>(address, data, thread);
   if(address <= 0x047f'ffff) return ri.write<Size>(address, data, thread);
   if(address <= 0x048f'ffff) return si.write<Size>(address, data, thread);
-  if(address <= 0x04ff'ffff) return;
+  if(address <= 0x04ff'ffff) return freezeUnmapped(address);
   if(address <= 0x1fbf'ffff) return pi.write<Size>(address, data, thread);
   if(address <= 0x1fcf'ffff) return si.write<Size>(address, data, thread);
   if(address <= 0x7fff'ffff) return pi.write<Size>(address, data, thread);
-  debug(unusual, "[Bus::write] CPU frozen because of write to physical address ", hex(address, 8L), " outside of RCP mapped range");
-  cpu.scc.sysadFrozen = true;
+  return freezeUnmapped(address);
 }
 
 template<u32 Size>
@@ -90,6 +88,20 @@ inline auto Bus::writeBurst(u32 address, u32 *data, Thread& thread) -> void {
     return;
   }
 
-  debug(unusual, "[Bus::writeBurst] CPU frozen because of cached write to non-RDRAM area: 0x", hex(address, 8L));
+  return freezeUncached(address);
+}
+
+inline auto Bus::freezeUnmapped(u32 address) -> void {
+  debug(unusual, "[Bus::freezeUnmapped] CPU frozen because of access to RCP unmapped area: 0x", hex(address, 8L));
+  cpu.scc.sysadFrozen = true;
+}
+
+inline auto Bus::freezeUncached(u32 address) -> void {
+  debug(unusual, "[Bus::freezeUncached] CPU frozen because of cached access to non-RDRAM area: 0x", hex(address, 8L));
+  cpu.scc.sysadFrozen = true;
+}
+
+inline auto Bus::freezeDualRead(u32 address) -> void {
+  debug(unusual, "[Bus::freezeDualRead] CPU frozen because of 64-bit read from non-RDRAM area: 0x ", hex(address, 8L));
   cpu.scc.sysadFrozen = true;
 }

--- a/ares/n64/memory/bus.hpp
+++ b/ares/n64/memory/bus.hpp
@@ -19,6 +19,8 @@ inline auto Bus::read(u32 address, Thread& thread, const char *peripheral) -> u6
   if(address <= 0x1fbf'ffff) return pi.read<Size>(address, thread);
   if(address <= 0x1fcf'ffff) return si.read<Size>(address, thread);
   if(address <= 0x7fff'ffff) return pi.read<Size>(address, thread);
+  debug(unusual, "[Bus::write] CPU frozen because of read from physical address ", hex(address, 8L), " outside of RCP mapped range");
+  cpu.scc.sysadFrozen = true;
   return unmapped;
 }
 
@@ -70,7 +72,8 @@ inline auto Bus::write(u32 address, u64 data, Thread& thread, const char *periph
   if(address <= 0x1fbf'ffff) return pi.write<Size>(address, data, thread);
   if(address <= 0x1fcf'ffff) return si.write<Size>(address, data, thread);
   if(address <= 0x7fff'ffff) return pi.write<Size>(address, data, thread);
-  return;
+  debug(unusual, "[Bus::write] CPU frozen because of write to physical address ", hex(address, 8L), " outside of RCP mapped range");
+  cpu.scc.sysadFrozen = true;
 }
 
 template<u32 Size>

--- a/ares/n64/memory/memory.hpp
+++ b/ares/n64/memory/memory.hpp
@@ -31,8 +31,8 @@ namespace Memory {
 
 struct Bus {
   //bus.hpp
-  template<u32 Size> auto read(u32 address, Thread& thread) -> u64;
-  template<u32 Size> auto write(u32 address, u64 data, Thread& thread) -> void;
+  template<u32 Size> auto read(u32 address, Thread& thread, const char *peripheral) -> u64;
+  template<u32 Size> auto write(u32 address, u64 data, Thread& thread, const char *peripheral) -> void;
 
   template<u32 Size> auto readBurst(u32 address, u32* data, Thread& thread) -> void;
   template<u32 Size> auto writeBurst(u32 address, u32* data, Thread& thread) -> void;

--- a/ares/n64/memory/memory.hpp
+++ b/ares/n64/memory/memory.hpp
@@ -36,6 +36,10 @@ struct Bus {
 
   template<u32 Size> auto readBurst(u32 address, u32* data, Thread& thread) -> void;
   template<u32 Size> auto writeBurst(u32 address, u32* data, Thread& thread) -> void;
+
+  auto freezeUnmapped(u32 address) -> void;
+  auto freezeUncached(u32 address) -> void;
+  auto freezeDualRead(u32 address) -> void;
 };
 
 extern Bus bus;

--- a/ares/n64/n64.hpp
+++ b/ares/n64/n64.hpp
@@ -96,8 +96,8 @@ namespace ares::Nintendo64 {
   #include <n64/pif/pif.hpp>
   #include <n64/ri/ri.hpp>
   #include <n64/si/si.hpp>
-  #include <n64/rdram/rdram.hpp>
   #include <n64/cpu/cpu.hpp>
+  #include <n64/rdram/rdram.hpp>
   #include <n64/rsp/rsp.hpp>
   #include <n64/rdp/rdp.hpp>
   #include <n64/memory/bus.hpp>

--- a/ares/n64/pi/io.cpp
+++ b/ares/n64/pi/io.cpp
@@ -98,6 +98,7 @@ auto PI::ioWrite(u32 address, u32 data_) -> void {
     //PI_READ_LENGTH
     io.readLength = n24(data);
     io.dmaBusy = 1;
+    io.originPc = cpu.ipu.pc;
     queue.insert(Queue::PI_DMA_Read, dmaDuration(true));
     dmaRead();
   }
@@ -106,6 +107,7 @@ auto PI::ioWrite(u32 address, u32 data_) -> void {
     //PI_WRITE_LENGTH
     io.writeLength = n24(data);
     io.dmaBusy = 1;
+    io.originPc = cpu.ipu.pc;
     queue.insert(Queue::PI_DMA_Write, dmaDuration(false));
     dmaWrite();
   }

--- a/ares/n64/pi/pi.hpp
+++ b/ares/n64/pi/pi.hpp
@@ -51,6 +51,7 @@ struct PI : Memory::RCP<PI> {
     n32 readLength;
     n32 writeLength;
     n32 busLatch;
+    u64 originPc;
   } io;
 
   struct BSD {

--- a/ares/n64/pif/io.cpp
+++ b/ares/n64/pif/io.cpp
@@ -30,13 +30,13 @@ auto PIF::dmaRead(u32 address, u32 ramAddress) -> void {
   intA(Read, Size64);
   for(u32 offset = 0; offset < 64; offset += 4) {
     u32 data = readInt(address + offset);
-    rdram.ram.write<Word>(ramAddress + offset, data);
+    rdram.ram.write<Word>(ramAddress + offset, data, "SI DMA");
   }
 }
 
 auto PIF::dmaWrite(u32 address, u32 ramAddress) -> void {
   for(u32 offset = 0; offset < 64; offset += 4) {
-    u32 data = rdram.ram.read<Word>(ramAddress + offset);
+    u32 data = rdram.ram.read<Word>(ramAddress + offset, "SI DMA");
     writeInt(address + offset, data);
   }
   intA(Write, Size64);

--- a/ares/n64/rdp/render.cpp
+++ b/ares/n64/rdp/render.cpp
@@ -53,7 +53,7 @@ auto RDP::render() -> void {
   }
   #endif
 
-  auto& memory = !command.source ? rdram.ram : rsp.dmem;
+  auto& memory = !command.source ? (Memory::Writable&)rdram.ram : (Memory::Writable&)rsp.dmem;
 
   auto fetch = [&]() -> u64 {
     u64 op = memory.readUnaligned<Dual>(command.current);

--- a/ares/n64/rdram/debugger.cpp
+++ b/ares/n64/rdram/debugger.cpp
@@ -7,10 +7,10 @@ auto RDRAM::Debugger::load(Node::Object parent) -> void {
   }
   
   memory.ram->setRead([&](u32 address) -> u8 {
-    return rdram.ram.read<Byte>(address);
+    return rdram.ram.read<Byte>(address, "Ares Debugger");
   });
   memory.ram->setWrite([&](u32 address, u8 data) -> void {
-    return rdram.ram.write<Byte>(address, data);
+    return rdram.ram.write<Byte>(address, data, "Ares Debugger");
   });
 
   memory.dcache = parent->append<Node::Debugger::Memory>("DCache");
@@ -25,7 +25,7 @@ auto RDRAM::Debugger::load(Node::Object parent) -> void {
     if(line.hit(address)) {
       line.write<Byte>(address, data);
     } else {
-      rdram.ram.write<Byte>(address, data);
+      rdram.ram.write<Byte>(address, data, "Ares Debugger");
     }
   });
 
@@ -57,5 +57,53 @@ auto RDRAM::Debugger::io(bool mode, u32 chipID, u32 address, u32 data) -> void {
       message = {name.split("|").last(), " <= ", hex(data, 8L)};
     }
     tracer.io->notify(message);
+  }
+}
+
+auto RDRAM::Debugger::cacheErrorContext(string peripheral) -> string {
+  if(peripheral == "CPU") {
+    return { "\tCurrent CPU PC: ", hex(cpu.ipu.pc, 16L), "\n" };
+  }
+  if(peripheral == "RSP DMA") {
+    if(rsp.dma.current.originCpu) {
+      return { "\tRSP DMA started at CPU PC: ", hex(rsp.dma.current.originPc, 16L), "\n" };
+    } else {
+      return { "\tRSP DMA started at RSP PC: ", hex(rsp.dma.current.originPc,  3L), "\n" };
+    }
+  }
+  if(peripheral == "PI DMA") {
+    return { "\tPI DMA started at CPU PC: ", hex(pi.io.originPc, 16L), "\n" };
+  }
+  if(peripheral == "AI DMA") {
+    return { "\tAI DMA started at CPU PC: ", hex(ai.io.dmaOriginPc[0], 16L), "\n" };
+  }
+  return "";
+}
+
+auto RDRAM::Debugger::readWord(u32 address, int size, const char *peripheral) -> void {
+  if (system.homebrewMode && (address & ~15) != lastReadCacheline) {
+    lastReadCacheline = address & ~15;
+    auto& line = cpu.dcache.line(address);
+    u16 dirtyMask = ((1 << size) - 1) << (address & 0xF);
+    if (line.hit(address) && (line.dirty & dirtyMask)) {
+      string msg = { peripheral, " reading from RDRAM address ", hex(address), " which is modified in the cache (missing cache writeback?)\n"};
+      msg.append(string{ "\tCacheline was loaded at CPU PC: ", hex(line.fillpc, 16L), "\n" });
+      msg.append(string{ "\tCacheline was last written at CPU PC: ", hex(line.dirtypc, 16L), "\n" });
+      msg.append(cacheErrorContext(peripheral));
+      debug(unusual, msg);
+    }
+  }
+}
+
+auto RDRAM::Debugger::writeWord(u32 address, int size, u64 value, const char *peripheral) -> void {
+  if (system.homebrewMode && (address & ~15) != lastWrittenCacheline) {
+    lastWrittenCacheline = address & ~15;
+    auto& line = cpu.dcache.line(address);
+    if (line.hit(address)) {
+      string msg = { peripheral, " writing to RDRAM address ", hex(address), " which is cached (missing cache invalidation?)\n"};
+      msg.append(string{ "\tCacheline was loaded at CPU PC: ", hex(line.fillpc, 16L), "\n" });
+      msg.append(cacheErrorContext(peripheral));
+      debug(unusual, msg);
+    }
   }
 }

--- a/ares/n64/rdram/debugger.cpp
+++ b/ares/n64/rdram/debugger.cpp
@@ -62,20 +62,20 @@ auto RDRAM::Debugger::io(bool mode, u32 chipID, u32 address, u32 data) -> void {
 
 auto RDRAM::Debugger::cacheErrorContext(string peripheral) -> string {
   if(peripheral == "CPU") {
-    return { "\tCurrent CPU PC: ", hex(cpu.ipu.pc, 16L), "\n" };
+    return { "\tCurrent CPU PC: 0x", hex(cpu.ipu.pc, 16L), "\n" };
   }
   if(peripheral == "RSP DMA") {
     if(rsp.dma.current.originCpu) {
-      return { "\tRSP DMA started at CPU PC: ", hex(rsp.dma.current.originPc, 16L), "\n" };
+      return { "\tRSP DMA started at CPU PC: 0x", hex(rsp.dma.current.originPc, 16L), "\n" };
     } else {
-      return { "\tRSP DMA started at RSP PC: ", hex(rsp.dma.current.originPc,  3L), "\n" };
+      return { "\tRSP DMA started at RSP PC: 0x", hex(rsp.dma.current.originPc,  3L), "\n" };
     }
   }
   if(peripheral == "PI DMA") {
-    return { "\tPI DMA started at CPU PC: ", hex(pi.io.originPc, 16L), "\n" };
+    return { "\tPI DMA started at CPU PC: 0x", hex(pi.io.originPc, 16L), "\n" };
   }
   if(peripheral == "AI DMA") {
-    return { "\tAI DMA started at CPU PC: ", hex(ai.io.dmaOriginPc[0], 16L), "\n" };
+    return { "\tAI DMA started at CPU PC: 0x", hex(ai.io.dmaOriginPc[0], 16L), "\n" };
   }
   return "";
 }
@@ -86,9 +86,9 @@ auto RDRAM::Debugger::readWord(u32 address, int size, const char *peripheral) ->
     auto& line = cpu.dcache.line(address);
     u16 dirtyMask = ((1 << size) - 1) << (address & 0xF);
     if (line.hit(address) && (line.dirty & dirtyMask)) {
-      string msg = { peripheral, " reading from RDRAM address ", hex(address), " which is modified in the cache (missing cache writeback?)\n"};
-      msg.append(string{ "\tCacheline was loaded at CPU PC: ", hex(line.fillpc, 16L), "\n" });
-      msg.append(string{ "\tCacheline was last written at CPU PC: ", hex(line.dirtypc, 16L), "\n" });
+      string msg = { peripheral, " reading from RDRAM address 0x", hex(address), " which is modified in the cache (missing cache writeback?)\n"};
+      msg.append(string{ "\tCacheline was loaded at CPU PC: 0x", hex(line.fillPc, 16L), "\n" });
+      msg.append(string{ "\tCacheline was last written at CPU PC: 0x", hex(line.dirtyPc, 16L), "\n" });
       msg.append(cacheErrorContext(peripheral));
       debug(unusual, msg);
     }
@@ -100,8 +100,8 @@ auto RDRAM::Debugger::writeWord(u32 address, int size, u64 value, const char *pe
     lastWrittenCacheline = address & ~15;
     auto& line = cpu.dcache.line(address);
     if (line.hit(address)) {
-      string msg = { peripheral, " writing to RDRAM address ", hex(address), " which is cached (missing cache invalidation?)\n"};
-      msg.append(string{ "\tCacheline was loaded at CPU PC: ", hex(line.fillpc, 16L), "\n" });
+      string msg = { peripheral, " writing to RDRAM address 0x", hex(address), " which is cached (missing cache invalidation?)\n"};
+      msg.append(string{ "\tCacheline was loaded at CPU PC: 0x", hex(line.fillPc, 16L), "\n" });
       msg.append(cacheErrorContext(peripheral));
       debug(unusual, msg);
     }

--- a/ares/n64/rdram/rdram.hpp
+++ b/ares/n64/rdram/rdram.hpp
@@ -11,14 +11,18 @@ struct RDRAM : Memory::RCP<RDRAM> {
     template<u32 Size>
     auto read(u32 address, const char *peripheral) -> u64 {
       if (address >= size) return 0;
-      if (system.homebrewMode) self.debugger.readWord(address, Size, peripheral);
+      if (peripheral && system.homebrewMode) {
+        self.debugger.readWord(address, Size, peripheral);
+      }
       return Memory::Writable::read<Size>(address);
     }
 
     template<u32 Size>
     auto write(u32 address, u64 value, const char *peripheral) -> void {
       if (address >= size) return;
-      if (system.homebrewMode) self.debugger.writeWord(address, Size, value, peripheral);
+      if (peripheral && system.homebrewMode) {
+        self.debugger.writeWord(address, Size, value, peripheral);
+      }
       Memory::Writable::write<Size>(address, value);
     }
 

--- a/ares/n64/rdram/rdram.hpp
+++ b/ares/n64/rdram/rdram.hpp
@@ -4,23 +4,71 @@ struct RDRAM : Memory::RCP<RDRAM> {
   Node::Object node;
 
   struct Writable : public Memory::Writable {
+    RDRAM& self;
+
+    Writable(RDRAM& self) : self(self) {}
+
     template<u32 Size>
-    auto read(u32 address) -> u64 {
+    auto read(u32 address, const char *peripheral) -> u64 {
       if (address >= size) return 0;
+      if (system.homebrewMode) self.debugger.readWord(address, Size, peripheral);
       return Memory::Writable::read<Size>(address);
     }
 
     template<u32 Size>
-    auto write(u32 address, u64 value) -> void {
+    auto write(u32 address, u64 value, const char *peripheral) -> void {
       if (address >= size) return;
+      if (system.homebrewMode) self.debugger.writeWord(address, Size, value, peripheral);
       Memory::Writable::write<Size>(address, value);
     }
-  } ram;
+
+    template<u32 Size>
+    auto writeBurst(u32 address, u32 *value, const char *peripheral) -> void {
+      if (address >= size) return;
+      Memory::Writable::write<Word>(address | 0x00, value[0]);
+      Memory::Writable::write<Word>(address | 0x04, value[1]);
+      Memory::Writable::write<Word>(address | 0x08, value[2]);
+      Memory::Writable::write<Word>(address | 0x0c, value[3]);
+      if (Size == ICache) {
+        Memory::Writable::write<Word>(address | 0x10, value[4]);
+        Memory::Writable::write<Word>(address | 0x14, value[5]);
+        Memory::Writable::write<Word>(address | 0x18, value[6]);
+        Memory::Writable::write<Word>(address | 0x1c, value[7]);
+      }
+    }
+
+    template<u32 Size>
+    auto readBurst(u32 address, u32 *value, const char *peripheral) -> void {
+      if (address >= size) {
+        value[0] = value[1] = value[2] = value[3] = 0;
+        if (Size == ICache)
+          value[4] = value[5] = value[6] = value[7] = 0;
+        return;
+      }
+      value[0] = Memory::Writable::read<Word>(address | 0x00);
+      value[1] = Memory::Writable::read<Word>(address | 0x04);
+      value[2] = Memory::Writable::read<Word>(address | 0x08);
+      value[3] = Memory::Writable::read<Word>(address | 0x0c);
+      if (Size == ICache) {
+        value[4] = Memory::Writable::read<Word>(address | 0x10);
+        value[5] = Memory::Writable::read<Word>(address | 0x14);
+        value[6] = Memory::Writable::read<Word>(address | 0x18);
+        value[7] = Memory::Writable::read<Word>(address | 0x1c);
+      }
+    }
+
+  } ram{*this};
 
   struct Debugger {
+    u32 lastReadCacheline    = 0xffff'ffff;
+    u32 lastWrittenCacheline = 0xffff'ffff;
+
     //debugger.cpp
     auto load(Node::Object) -> void;
     auto io(bool mode, u32 chipID, u32 address, u32 data) -> void;
+    auto readWord(u32 address, int size, const char *peripheral) -> void;
+    auto writeWord(u32 address, int size, u64 value, const char *peripheral) -> void;
+    auto cacheErrorContext(string peripheral) -> string;
 
     struct Memory {
       Node::Debugger::Memory ram;

--- a/ares/n64/ri/ri.cpp
+++ b/ares/n64/ri/ri.cpp
@@ -27,8 +27,8 @@ auto RI::power(bool reset) -> void {
     io.refresh = 0x0006'3634;
 
     //store RDRAM size result into memory
-    rdram.ram.write<Word>(0x318, rdram.ram.size);  //CIC-NUS-6102
-    rdram.ram.write<Word>(0x3f0, rdram.ram.size);  //CIC-NUS-6105
+    rdram.ram.write<Word>(0x318, rdram.ram.size, "IPL3");  //CIC-NUS-6102
+    rdram.ram.write<Word>(0x3f0, rdram.ram.size, "IPL3");  //CIC-NUS-6105
   }
 }
 

--- a/ares/n64/rsp/debugger.cpp
+++ b/ares/n64/rsp/debugger.cpp
@@ -146,10 +146,38 @@ auto RSP::Debugger::dmemReadWord(u12 address, int size, const char *peripheral) 
   }
 }
 
+auto RSP::Debugger::dmemReadUnalignedWord(u12 address, int size, const char *peripheral) -> void {
+  if (system.homebrewMode) {
+    u32 addressAlignedStart = address            & ~7;
+    u32 addressAlignedEnd   = address + size - 1 & ~7;
+    if(addressAlignedStart == addressAlignedEnd) {
+      dmemReadWord(address, size, "RSP");
+    } else {
+      int sizeStart = addressAlignedEnd - address;
+      dmemReadWord(address,             sizeStart,        "RSP");
+      dmemReadWord(address + sizeStart, size - sizeStart, "RSP");
+    }
+  }
+}
+
 auto RSP::Debugger::dmemWriteWord(u12 address, int size, u64 value) -> void {
   if (system.homebrewMode) {
     auto& taintWord = taintMask.dmem[address >> 3];
     taintWord.dirty &= ~(((1 << size) - 1) << (address & 0x7));
+  }
+}
+
+auto RSP::Debugger::dmemWriteUnalignedWord(u12 address, int size, u64 value) -> void {
+  if (system.homebrewMode) {
+    u32 addressAlignedStart = address            & ~7;
+    u32 addressAlignedEnd   = address + size - 1 & ~7;
+    if(addressAlignedStart == addressAlignedEnd) {
+      dmemWriteWord(address, size, value);
+    } else {
+      int sizeStart = addressAlignedEnd - address;
+      dmemWriteWord(address,             sizeStart,        value);
+      dmemWriteWord(address + sizeStart, size - sizeStart, value);
+    }
   }
 }
 

--- a/ares/n64/rsp/debugger.cpp
+++ b/ares/n64/rsp/debugger.cpp
@@ -123,13 +123,13 @@ auto RSP::Debugger::dmaReadWord(u32 rdramAddress, u32 pbusRegion, u32 pbusAddres
   }
 }
 
-auto RSP::Debugger::dmemReadWord(u12 address, int size) -> void {
+auto RSP::Debugger::dmemReadWord(u12 address, int size, const char *peripheral) -> void {
   if (system.homebrewMode) {
     u8 readMask = ((1 << size) - 1) << (address & 0x7);
     auto& taintWord = taintMask.dmem[address >> 3];
     if (taintWord.dirty & readMask) {
       u32 rdramAddress = taintWord.ctxDmaRdramAddress + (address & 0x7);
-      string msg = { "RSP reading from DMEM address 0x", hex(address), " which contains a value which is not cache coherent\n"};
+      string msg = { peripheral, " reading from DMEM address 0x", hex(address), " which contains a value which is not cache coherent\n"};
       msg.append(string{ "\tCurrent RSP PC: 0x", hex(rsp.ipu.pc, 3L), "\n" });
       msg.append(string{ "\tThe value read was previously written by RSP DMA from RDRAM address 0x", hex(rdramAddress, 8L), "\n" });
       if(taintWord.ctxDmaOriginCpu) {

--- a/ares/n64/rsp/debugger.cpp
+++ b/ares/n64/rsp/debugger.cpp
@@ -30,6 +30,15 @@ auto RSP::Debugger::load(Node::Object parent) -> void {
   }
 
   tracer.io = parent->append<Node::Debugger::Tracer::Notification>("I/O", "RSP");
+
+  if (system.homebrewMode) {
+    for (auto& taintWord : taintMask.dmem) {
+      taintWord = {};
+    }
+    for (auto& taintWord : taintMask.imem) {
+      taintWord = {};
+    }
+  }
 }
 
 auto RSP::Debugger::unload() -> void {
@@ -92,6 +101,55 @@ auto RSP::Debugger::ioStatus(bool mode, u32 address, u32 data) -> void {
       message = {name.split("|").last(), " <= ", hex(data, 8L)};
     }
     tracer.io->notify(message);
+  }
+}
+
+auto RSP::Debugger::dmaReadWord(u32 rdramAddress, u32 pbusRegion, u32 pbusAddress) -> void {
+  if (system.homebrewMode) {
+    auto& line = cpu.dcache.line(rdramAddress);
+    u16 dmaMask = 0xff << (rdramAddress & 0xF);
+    auto& tm = !pbusRegion ? taintMask.dmem : taintMask.imem;
+    auto& taintWord = tm[pbusAddress >> 3];
+    if (line.hit(rdramAddress) && (line.dirty & dmaMask)) {
+      taintWord.dirty              = (line.dirty & dmaMask) >> (rdramAddress & 0x8);
+      taintWord.ctxDmaRdramAddress = rdramAddress & ~0x7;
+      taintWord.ctxDmaOriginPc     = rsp.dma.current.originPc;
+      taintWord.ctxDmaOriginCpu    = rsp.dma.current.originCpu;
+      taintWord.ctxCacheFillPc     = line.fillPc;
+      taintWord.ctxCacheDirtyPc    = line.dirtyPc;
+    } else {
+      taintWord.dirty = 0;
+    }
+  }
+}
+
+auto RSP::Debugger::dmemReadWord(u12 address, int size) -> void {
+  if (system.homebrewMode) {
+    u8 readMask = ((1 << size) - 1) << (address & 0x7);
+    auto& taintWord = taintMask.dmem[address >> 3];
+    if (taintWord.dirty & readMask) {
+      u32 rdramAddress = taintWord.ctxDmaRdramAddress + (address & 0x7);
+      string msg = { "RSP reading from DMEM address 0x", hex(address), " which contains a value which is not cache coherent\n"};
+      msg.append(string{ "\tCurrent RSP PC: 0x", hex(rsp.ipu.pc, 3L), "\n" });
+      msg.append(string{ "\tThe value read was previously written by RSP DMA from RDRAM address 0x", hex(rdramAddress, 8L), "\n" });
+      if(taintWord.ctxDmaOriginCpu) {
+        msg.append(string{ "\tRSP DMA started at CPU PC: 0x", hex(taintWord.ctxDmaOriginPc, 16L), "\n" });
+      } else {
+        msg.append(string{ "\tRSP DMA started at RSP PC: 0x", hex(taintWord.ctxDmaOriginPc,  3L), "\n" });
+      }
+      msg.append(string{ "\tThe relative CPU cacheline was dirty (missing cache writeback?)\n" });
+      msg.append(string{ "\tCacheline was last written at CPU PC: 0x", hex(taintWord.ctxCacheDirtyPc, 16L), "\n" });
+      msg.append(string{ "\tCacheline was loaded at CPU PC: 0x", hex(taintWord.ctxCacheFillPc, 16L), "\n" });
+      debug(unusual, msg);
+      taintWord.dirty = 0;
+    }
+  }
+}
+
+auto RSP::Debugger::dmemWriteWord(u12 address, int size, u64 value) -> void {
+  if (system.homebrewMode) {
+    auto& taintWord = taintMask.dmem[address >> 3];
+    taintWord.dirty &= ~(((1 << size) - 1) << (address & 0x7));
   }
 }
 

--- a/ares/n64/rsp/dma.cpp
+++ b/ares/n64/rsp/dma.cpp
@@ -18,16 +18,17 @@ auto RSP::dmaTransferStep() -> void {
       }
     }
     for(u32 i = 0; i <= dma.current.length; i += 8) {
-        u64 data = rdram.ram.read<Dual>(dma.current.dramAddress);
+        u64 data = rdram.ram.read<Dual>(dma.current.dramAddress, "RSP DMA");
         region.write<Dual>(dma.current.pbusAddress, data);
         dma.current.dramAddress += 8;
         dma.current.pbusAddress += 8;
     }
   }
   if(dma.busy.write) {
+    u32 lastCacheline = 0xffff'ffff;
     for(u32 i = 0; i <= dma.current.length; i += 8) {
         u64 data = region.read<Dual>(dma.current.pbusAddress);
-        rdram.ram.write<Dual>(dma.current.dramAddress, data);
+        rdram.ram.write<Dual>(dma.current.dramAddress, data, "RSP DMA");
         dma.current.dramAddress += 8;
         dma.current.pbusAddress += 8;
     }

--- a/ares/n64/rsp/dma.cpp
+++ b/ares/n64/rsp/dma.cpp
@@ -18,14 +18,16 @@ auto RSP::dmaTransferStep() -> void {
       }
     }
     for(u32 i = 0; i <= dma.current.length; i += 8) {
-        u64 data = rdram.ram.read<Dual>(dma.current.dramAddress, "RSP DMA");
+        u64 data = rdram.ram.read<Dual>(dma.current.dramAddress, nullptr);
         region.write<Dual>(dma.current.pbusAddress, data);
+        if (system.homebrewMode) {
+          rsp.debugger.dmaReadWord(dma.current.dramAddress, dma.current.pbusRegion, dma.current.pbusAddress);
+        }
         dma.current.dramAddress += 8;
         dma.current.pbusAddress += 8;
     }
   }
   if(dma.busy.write) {
-    u32 lastCacheline = 0xffff'ffff;
     for(u32 i = 0; i <= dma.current.length; i += 8) {
         u64 data = region.read<Dual>(dma.current.pbusAddress);
         rdram.ram.write<Dual>(dma.current.dramAddress, data, "RSP DMA");

--- a/ares/n64/rsp/interpreter-scc.cpp
+++ b/ares/n64/rsp/interpreter-scc.cpp
@@ -1,9 +1,9 @@
 auto RSP::MFC0(r32& rt, u8 rd) -> void {
-  if((rd & 8) == 0) rt.u32 = Nintendo64::rsp.ioRead  ((rd & 7) << 2);
+  if((rd & 8) == 0) rt.u32 = Nintendo64::rsp.ioRead  ((rd & 7) << 2, *this);
   if((rd & 8) != 0) rt.u32 = Nintendo64::rdp.readWord((rd & 7) << 2, *this);
 }
 
 auto RSP::MTC0(cr32& rt, u8 rd) -> void {
-  if((rd & 8) == 0) Nintendo64::rsp.ioWrite  ((rd & 7) << 2, rt.u32);
+  if((rd & 8) == 0) Nintendo64::rsp.ioWrite  ((rd & 7) << 2, rt.u32, *this);
   if((rd & 8) != 0) Nintendo64::rdp.writeWord((rd & 7) << 2, rt.u32, *this);
 }

--- a/ares/n64/rsp/io.cpp
+++ b/ares/n64/rsp/io.cpp
@@ -3,10 +3,10 @@ auto RSP::readWord(u32 address, Thread& thread) -> u32 {
     if(address & 0x1000) return imem.read<Word>(address);
     else                 return dmem.read<Word>(address);
   }
-  return ioRead(address);
+  return ioRead(address, thread);
 }
 
-auto RSP::ioRead(u32 address) -> u32 {
+auto RSP::ioRead(u32 address, Thread &thread) -> u32 {
   address = (address & 0x3ffff) >> 2;
   n32 data;
 
@@ -72,10 +72,10 @@ auto RSP::writeWord(u32 address, u32 data, Thread& thread) -> void {
     if(address & 0x1000) return recompiler.invalidate(address & 0xfff), imem.write<Word>(address, data);
     else                 return dmem.write<Word>(address, data);
   }
-  return ioWrite(address, data);
+  return ioWrite(address, data, thread);
 }
 
-auto RSP::ioWrite(u32 address, u32 data_) -> void {
+auto RSP::ioWrite(u32 address, u32 data_, Thread& thread) -> void {
 
   address = (address & 0x3ffff) >> 2;
   n32 data = data_;
@@ -96,6 +96,8 @@ auto RSP::ioWrite(u32 address, u32 data_) -> void {
     dma.pending.length.bit(3,11) = data.bit( 3,11);
     dma.pending.count            = data.bit(12,19);
     dma.pending.skip.bit(3,11)   = data.bit(23,31);
+    dma.pending.originCpu = &thread != this;
+    dma.pending.originPc = dma.pending.originCpu ? cpu.ipu.pc : (u64)rsp.ipu.r[31].u32;
     dma.full.read  = 1;
     dma.full.write = 0;
     dmaTransferStart();
@@ -106,6 +108,8 @@ auto RSP::ioWrite(u32 address, u32 data_) -> void {
     dma.pending.length.bit(3,11) = data.bit( 3,11);
     dma.pending.count            = data.bit(12,19);
     dma.pending.skip.bit(3,11)   = data.bit(23,31);
+    dma.pending.originCpu = &thread != this;
+    dma.pending.originPc = dma.pending.originCpu ? cpu.ipu.pc : (u64)rsp.ipu.r[31].u32;
     dma.full.write = 1;
     dma.full.read  = 0;
     dmaTransferStart();

--- a/ares/n64/rsp/io.cpp
+++ b/ares/n64/rsp/io.cpp
@@ -100,6 +100,7 @@ auto RSP::ioWrite(u32 address, u32 data_, Thread& thread) -> void {
     dma.pending.originPc = dma.pending.originCpu ? cpu.ipu.pc : (u64)rsp.ipu.r[31].u32;
     dma.full.read  = 1;
     dma.full.write = 0;
+    // printf("RSP DMA Read: %08x => %08x %08x\n", dma.pending.dramAddress, dma.pending.pbusAddress, dma.pending.length);
     dmaTransferStart();
   }
 

--- a/ares/n64/rsp/rsp.hpp
+++ b/ares/n64/rsp/rsp.hpp
@@ -166,8 +166,8 @@ struct RSP : Thread, Memory::RCP<RSP> {
   //io.cpp
   auto readWord(u32 address, Thread& thread) -> u32;
   auto writeWord(u32 address, u32 data, Thread& thread) -> void;
-  auto ioRead(u32 address) -> u32;
-  auto ioWrite(u32 address, u32 data) -> void;
+  auto ioRead(u32 address, Thread& thread) -> u32;
+  auto ioWrite(u32 address, u32 data, Thread& thread) -> void;
 
   //serialization.cpp
   auto serialize(serializer&) -> void;
@@ -180,7 +180,9 @@ struct RSP : Thread, Memory::RCP<RSP> {
       n12 length;
       n12 skip;
       n8  count;
-      
+      n64 originPc;
+      n1  originCpu;
+
       auto serialize(serializer&) -> void;
     } pending, current;
 

--- a/ares/n64/rsp/rsp.hpp
+++ b/ares/n64/rsp/rsp.hpp
@@ -10,7 +10,7 @@ struct RSP : Thread, Memory::RCP<RSP> {
     template<u32 Size>
     auto read(u32 address) -> u64 {
       if (system.homebrewMode) {
-        self.debugger.dmemReadWord(address, Size);
+        self.debugger.dmemReadWord(address, Size, "RSP");
       }
       return Memory::Writable::read<Size>(address);
     }
@@ -36,7 +36,7 @@ struct RSP : Thread, Memory::RCP<RSP> {
     auto ioStatus(bool mode, u32 address, u32 data) -> void;
 
     auto dmaReadWord(u32 rdramAddress, u32 pbusRegion, u32 pbusAddress) -> void;
-    auto dmemReadWord(u12 address, int size) -> void;
+    auto dmemReadWord(u12 address, int size, const char *peripheral) -> void;
     auto dmemWriteWord(u12 address, int size, u64 value) -> void;
 
     struct TaintMask {

--- a/ares/n64/rsp/rsp.hpp
+++ b/ares/n64/rsp/rsp.hpp
@@ -9,20 +9,28 @@ struct RSP : Thread, Memory::RCP<RSP> {
 
     template<u32 Size>
     auto read(u32 address) -> u64 {
-      if (system.homebrewMode) {
-        self.debugger.dmemReadWord(address, Size, "RSP");
-      }
+      if (system.homebrewMode) self.debugger.dmemReadWord(address, Size, "RSP");
       return Memory::Writable::read<Size>(address);
     }
 
     template<u32 Size>
+    auto readUnaligned(u32 address) -> u64 {
+      if (system.homebrewMode) self.debugger.dmemReadUnalignedWord(address, Size, "RSP");
+      return Memory::Writable::readUnaligned<Size>(address);
+    }
+
+    template<u32 Size>
     auto write(u32 address, u64 value) -> void {
-      if (system.homebrewMode) {
-        self.debugger.dmemWriteWord(address, Size, value);
-      }
+      if (system.homebrewMode) self.debugger.dmemWriteWord(address, Size, value);
       Memory::Writable::write<Size>(address, value);
     }
     
+    template<u32 Size>
+    auto writeUnaligned(u32 address, u64 value) -> void {
+      if (system.homebrewMode) self.debugger.dmemWriteUnalignedWord(address, Size, value);
+      Memory::Writable::writeUnaligned<Size>(address, value);
+    }
+
   } dmem{*this};
   Memory::Writable imem;
 
@@ -38,6 +46,8 @@ struct RSP : Thread, Memory::RCP<RSP> {
     auto dmaReadWord(u32 rdramAddress, u32 pbusRegion, u32 pbusAddress) -> void;
     auto dmemReadWord(u12 address, int size, const char *peripheral) -> void;
     auto dmemWriteWord(u12 address, int size, u64 value) -> void;
+    auto dmemReadUnalignedWord(u12 address, int size, const char *peripheral) -> void;
+    auto dmemWriteUnalignedWord(u12 address, int size, u64 value) -> void;
 
     struct TaintMask {
       struct TaintWord {

--- a/ares/n64/vi/vi.cpp
+++ b/ares/n64/vi/vi.cpp
@@ -150,7 +150,7 @@ auto VI::refresh() -> void {
         auto line = screen->pixels(1).data() + (dy - vscan_start) * hscan_len;
         u32 x0 = vi.io.xsubpixel + vi.io.xscale * (dx0 - vi.io.hstart);
         for(i32 dx = dx0; dx < dx1; dx++) {
-          u16 data = rdram.ram.read<Half>(address + (x0 >> 10) * 2);
+          u16 data = rdram.ram.read<Half>(address + (x0 >> 10) * 2, "VI");
           line[dx - hscan_start] = 1 << 24 | data >> 1;
           x0 += vi.io.xscale;
         }
@@ -168,7 +168,7 @@ auto VI::refresh() -> void {
         auto line = screen->pixels(1).data() + (dy - vscan_start) * hscan_len;
         u32 x0 = vi.io.xsubpixel + vi.io.xscale * (dx0 - vi.io.hstart);
         for(i32 dx = dx0; dx < dx1; dx++) {
-          u32 data = rdram.ram.read<Word>(address + (x0 >> 10) * 4);
+          u32 data = rdram.ram.read<Word>(address + (x0 >> 10) * 4, "VI");
           line[dx - hscan_start] = data >> 8;
           x0 += vi.io.xscale;
         }

--- a/ares/n64/vulkan/vulkan.cpp
+++ b/ares/n64/vulkan/vulkan.cpp
@@ -82,7 +82,6 @@ auto Vulkan::render() -> bool {
   };
 
   auto& command = rdp.command;
-  auto& memory = !command.source ? (Memory::Writable&)rdram.ram : (Memory::Writable&)rsp.dmem;
 
   u32 current = command.current & ~7;
   u32 end = command.end & ~7;
@@ -94,11 +93,22 @@ auto Vulkan::render() -> bool {
   u32& queueOffset = implementation->queueOffset;
   if(queueSize + length >= 0x8000) return true;
 
-  do {
-    buffer[queueSize * 2 + 0] = memory.read<Word>(current); current += 4;
-    buffer[queueSize * 2 + 1] = memory.read<Word>(current); current += 4;
-    queueSize++;
-  } while(--length);
+  if(!command.source) {
+    do {
+      buffer[queueSize * 2 + 0] = rdram.ram.read<Word>(current, "RDP DMA"); current += 4;
+      buffer[queueSize * 2 + 1] = rdram.ram.read<Word>(current, "RDP DMA"); current += 4;
+      queueSize++;
+    } while(--length);
+  } else {
+    do {
+      buffer[queueSize * 2 + 0] = rsp.dmem.read<Word>(current); current += 4;
+      buffer[queueSize * 2 + 1] = rsp.dmem.read<Word>(current); current += 4;
+      if(system.homebrewMode) {
+        rsp.debugger.dmemReadWord(current - 8, 8, "RDP XBUS");
+      }
+      queueSize++;
+    } while(--length);
+  }
 
   while(queueOffset < queueSize) {
     u32 op = buffer[queueOffset * 2];

--- a/ares/n64/vulkan/vulkan.cpp
+++ b/ares/n64/vulkan/vulkan.cpp
@@ -82,7 +82,7 @@ auto Vulkan::render() -> bool {
   };
 
   auto& command = rdp.command;
-  auto& memory = !command.source ? rdram.ram : rsp.dmem;
+  auto& memory = !command.source ? (Memory::Writable&)rdram.ram : (Memory::Writable&)rsp.dmem;
 
   u32 current = command.current & ~7;
   u32 end = command.end & ~7;


### PR DESCRIPTION
To make sure to intercept all possible errors, the check are now performed by the RDRAM module, whenever a RDRAM read/write behind a cacheline happens.

CPU writes to cache is now tracking dirtyness at the byte level rather than whole cacheline level, so that hardware accessing memory does not trigger a false positive for false-shared variables. An initial round of testing has shown that the check would trigger far too much otherwise. Error reporting is also much improved to provide more context to analyze the issue, including tracking the PC at which the hardware DMA was triggered.

For RSP DMA, we do even more: instead of reporting an issue when an area of a cached memory is DMA’d into RSP DMEM/IMEM, we actually just mark those memory locations as tainted, and emit the warning only if RSP later reads them. This is necessary because it is extremely common for RSP ucode to read data beyond the actual buffers it cares about, even though that data is then never accessed.

Some of the warnings issued by Ares have been analyzed on Super Mario 64 and Zelda OOT and in both cases they have been confirmed to be real bugs in cache management made by the game. 

For instance, in Mario 64, the programmers forgot to invalidate the cache before loading data for the initial Mario head animation, as reported by Ares now:
```
[unusual] PI DMA writing to RDRAM address 0x390650 which is cached (missing cache invalidation?)
	Cacheline was loaded at CPU PC: 0xffffffff80183b38
	PI DMA started at CPU PC: 0xffffffff80328558
```

The game just happens to work because after loading, the game does something else and manages to get the cache invalidated by touching other locations, but otherwise it would be a real bug.

As another example, in Zelda OOT, we get these warnings at boot:

```
[unusual] AI reading from RDRAM address 190820 which is modified in the cache (missing cache writeback?)
    Cacheline was loaded at CPU PC: ffffffff800b54fc
    Cacheline was last written at CPU PC: ffffffff800b5528
    
[unusual] RSP reading from DMEM address fe0 which contains a value which is not cache coherent
    Current RSP PC: d10
    The value read was previously written by RSP DMA from RDRAM address 00199e40
    RSP DMA started at RSP PC: abc
    The relative CPU cacheline was dirty (missing cache writeback?)
    Cacheline was loaded at CPU PC: ffffffff800b5244
    Cacheline was last written at CPU PC: ffffffff800b5264
```

These warnings appear to be real bugs in the audio library. Quoting Thar0:
```
* AudioHeap_ClearCurrentAiBuffer/AudioHeap_ResetStep wipe the AI buffers with CPU writes and 
  then don't write back the cache, and I guess an AI DMA is either in progress or starts before it can
  be properly flushed. On boot this shouldn't matter as gAudioHeap is BSS and is already zero, but
  if the driver is reset later it might cause some minor issues?
* The RSP cache coherency problems is from loading filters in AudioHeap_LoadLowPassFilter.
  The heap allocator returns a pointer to which the CPU writes the filter data.. but the allocator
  writes back the cache before the CPU writes the data 😂
```

Moreover, this PR also implements all the known SysAD-related CPU freezes that cause the console to crash. We now pass the [n64-systemcrash](https://github.com/rasky/n64-systemcrash) testsuite in full.
