### PR TITLE
Make it more obvious that the apply button for drivers needs to be used

### DIFF
--- a/desktop-ui/settings/drivers.cpp
+++ b/desktop-ui/settings/drivers.cpp
@@ -3,10 +3,16 @@ auto DriverSettings::construct() -> void {
   setVisible(false);
 
   videoLabel.setText("Video").setFont(Font().setBold());
+  videoDriverList.onChange([&] {
+    bool enabled = false;
+    if(videoDriverList.selected().text() != settings.video.driver) { enabled = true; }
+    videoDriverAssign.setEnabled(enabled);
+  });
   videoDriverLabel.setText("Driver:");
-  videoDriverAssign.setText("Apply").onActivate([&] {
+  videoDriverAssign.setText("Apply").setEnabled(false).onActivate([&] {
     settings.video.driver = videoDriverList.selected().text();
     videoDriverUpdate();
+    videoDriverAssign.setEnabled(false);
   });
   videoMonitorLabel.setText("Fullscreen monitor:");
   videoMonitorList.onChange([&] {
@@ -34,10 +40,16 @@ auto DriverSettings::construct() -> void {
   });
 
   audioLabel.setText("Audio").setFont(Font().setBold());
+  audioDriverList.onChange([&] {
+    bool enabled = false;
+    if(audioDriverList.selected().text() != settings.audio.driver) { enabled = true; }
+    audioDriverAssign.setEnabled(enabled);
+  });
   audioDriverLabel.setText("Driver:");
-  audioDriverAssign.setText("Apply").onActivate([&] {
+  audioDriverAssign.setText("Apply").setEnabled(false).onActivate([&] {
     settings.audio.driver = audioDriverList.selected().text();
     audioDriverUpdate();
+    audioDriverAssign.setEnabled(false);
   });
   audioDeviceLabel.setText("Output device:");
   audioDeviceList.onChange([&] {
@@ -71,10 +83,16 @@ auto DriverSettings::construct() -> void {
   });
 
   inputLabel.setText("Input").setFont(Font().setBold());
+  inputDriverList.onChange([&] {
+    bool enabled = false;
+    if(inputDriverList.selected().text() != settings.input.driver) { enabled = true; }
+    inputDriverAssign.setEnabled(enabled);
+  });
   inputDriverLabel.setText("Driver:");
-  inputDriverAssign.setText("Apply").onActivate([&] {
+  inputDriverAssign.setText("Apply").setEnabled(false).onActivate([&] {
     settings.input.driver = inputDriverList.selected().text();
     inputDriverUpdate();
+    inputDriverAssign.setEnabled(false);
   });
   inputDefocusLabel.setText("When focus is lost:");
   inputDefocusPause.setText("Pause emulation").onActivate([&] {
@@ -89,6 +107,8 @@ auto DriverSettings::construct() -> void {
   if(settings.input.defocus == "Pause") inputDefocusPause.setChecked();
   if(settings.input.defocus == "Block") inputDefocusBlock.setChecked();
   if(settings.input.defocus == "Allow") inputDefocusAllow.setChecked();
+
+  driverApplyHint.setText("Note: You must click on the 'Apply' button to update and save changes to driver selection.").setFont(Font().setSize(8.0)).setForegroundColor(SystemColor::Sublabel);
     
   videoDriverLayout.setPadding(12_sx, 0);
   videoPropertyLayout.setPadding(12_sx, 0);

--- a/desktop-ui/settings/settings.hpp
+++ b/desktop-ui/settings/settings.hpp
@@ -366,6 +366,8 @@ struct DriverSettings : VerticalLayout {
     RadioLabel inputDefocusBlock{&inputDefocusLayout, Size{0, 0}};
     RadioLabel inputDefocusAllow{&inputDefocusLayout, Size{0, 0}};
     Group inputDefocusGroup{&inputDefocusPause, &inputDefocusBlock, &inputDefocusAllow};
+  //
+  Label driverApplyHint{this, Size{0, 35}};
 };
 
 struct DebugSettings : VerticalLayout {


### PR DESCRIPTION
We frequently get issue reports in GitHub and Discord about driver settings not being saved. This is due to the fact that changes to drivers requires using the Apply (formerly Reload) button for changes to stick, which is different than other options in the settings window. 

With this change, the Apply button is grayed out until a different driver is selected, hopefully making it more obvious that the buttons need to be used. A small note was also added at the bottom explicitly stating that they Apply buttons must be used in order to switch/change updates to driver selection. 