### PR TITLE
fc: improve fds timer irq generation

### DIFF
--- a/ares/fc/fds/timer.cpp
+++ b/ares/fc/fds/timer.cpp
@@ -1,9 +1,13 @@
 auto FDSTimer::clock() -> void {
-  if(enable && !--counter) {
+  if(!enable || !irq) return;
+
+  if(!counter) {
     pending = 1;
     fds.poll();
     if(repeat) counter = period;
     irq &= repeat;
+  } else {
+    counter--;
   }
 }
 
@@ -40,12 +44,16 @@ auto FDSTimer::write(n16 address, n8 data) -> void {
       counter = period;
     } else {
       pending = 0;
+      fds.poll();
     }
     return;
 
-  case 0x4025:
+  case 0x4023:
     enable = data.bit(0);
-    if(!enable) pending = 0;
+    if(!enable) {
+      pending = 0;
+      fds.poll();
+    }
     return;
 
   }


### PR DESCRIPTION
Improvements to fds irq generation logic, to match description at https://www.nesdev.org/wiki/Family_Computer_Disk_System#Timer_IRQ_control_($4022)

- Fixed "i/o enable" register address
- Correctly acknowledge interrupts in writes to $4022 / $4023
- Improve irq generation logic

The changes are based on the discusion on this thread: https://forums.nesdev.org/viewtopic.php?t=16507

With this pr ares passes all 21 tests on FdsIrqTestsV7 (many failed before), which can be downloaded at https://forums.nesdev.org/download/file.php?id=10240

In addition to passing the tests this pr also fixes Kaettekita Mario Bros. (Japan): this game has 3 random opening animations before requesting to switch to side B, two of these openings will display a glitchy screen with old irq logic. This can be tested by just resetting if the game shows the animation that works.