### PR TITLE
gba: improve ROM to ROM DMA timings

### DIFF
--- a/ares/gba/cpu/dma.cpp
+++ b/ares/gba/cpu/dma.cpp
@@ -13,12 +13,8 @@ auto CPU::DMA::transfer() -> void {
   mode |= latch.length() == length() ? Nonsequential : Sequential;
 
   if(mode & Nonsequential) {
-    if((source() & 0x0800'0000) && (target() & 0x0800'0000)) {
-      //ROM -> ROM transfer
-    } else {
-      cpu.idle();
-      cpu.idle();
-    }
+    cpu.idle();
+    cpu.idle();
   }
 
   if(latch.source() < 0x0200'0000) {
@@ -29,6 +25,14 @@ auto CPU::DMA::transfer() -> void {
     if(mode & Half) addr &= ~1;
     cpu.dmabus.data = cpu.get(mode, addr);
     if(mode & Half) cpu.dmabus.data |= cpu.dmabus.data << 16;
+  }
+
+  if(mode & Nonsequential) {
+    if((source() & 0x0800'0000) && (target() & 0x0800'0000)) {
+      //ROM -> ROM transfer
+      mode |= Sequential;
+      mode ^= Nonsequential;
+    }
   }
 
   if(latch.target() < 0x0200'0000) {


### PR DESCRIPTION
When performing a DMA with source and destination addresses both in cartridge memory, the first write should use sequential access timings. Implementing this in ares gives more accurate timings for ROM to ROM DMAs than the previous approach, which instead removed the 2-cycle DMA starting delay in these cases.