### PR TITLE
ws, m93lcx6: improve EEPROM emulation accuracy

### DIFF
--- a/ares/component/eeprom/m93lcx6/m93lcx6.cpp
+++ b/ares/component/eeprom/m93lcx6/m93lcx6.cpp
@@ -165,6 +165,8 @@ auto M93LCx6::ShiftRegister::read() -> n1 {
 }
 
 auto M93LCx6::ShiftRegister::write(n1 bit) -> void {
+  // wait for start bit
+  if(!bit && !count) return;
   value <<= 1;
   value.bit(0) = bit;
   count++;

--- a/ares/ws/cartridge/io.cpp
+++ b/ares/ws/cartridge/io.cpp
@@ -43,12 +43,12 @@ auto Cartridge::readIO(n16 address) -> n8 {
     data = eeprom.read(EEPROM::DataHi);
     break;
 
-  case 0x00c6:  //EEP_ADDRLO
-    data = eeprom.read(EEPROM::AddressLo);
+  case 0x00c6:  //EEP_CMDLO
+    data = eeprom.read(EEPROM::CommandLo);
     break;
 
-  case 0x00c7:  //EEP_ADDRHI
-    data = eeprom.read(EEPROM::AddressHi);
+  case 0x00c7:  //EEP_CMDHI
+    data = eeprom.read(EEPROM::CommandHi);
     break;
 
   case 0x00c8:  //EEP_STATUS
@@ -138,16 +138,16 @@ auto Cartridge::writeIO(n16 address, n8 data) -> void {
     eeprom.write(EEPROM::DataHi, data);
     break;
 
-  case 0x00c6:  //EEP_ADDRLO
-    eeprom.write(EEPROM::AddressLo, data);
+  case 0x00c6:  //EEP_CMDLO
+    eeprom.write(EEPROM::CommandLo, data);
     break;
 
-  case 0x00c7:  //EEP_ADDRHI
-    eeprom.write(EEPROM::AddressHi, data);
+  case 0x00c7:  //EEP_CMDHI
+    eeprom.write(EEPROM::CommandHi, data);
     break;
 
-  case 0x00c8:  //EEP_CMD
-    eeprom.write(EEPROM::Command, data);
+  case 0x00c8:  //EEP_CTRL
+    eeprom.write(EEPROM::Control, data);
     break;
 
   case 0x00ca:  //RTC_CMD

--- a/ares/ws/eeprom/eeprom.cpp
+++ b/ares/ws/eeprom/eeprom.cpp
@@ -100,7 +100,9 @@ auto InternalEEPROM::read(u32 port) -> n8 {
 auto InternalEEPROM::canWrite(n16 command) -> bool {
   // TODO: This is a guess that gets the basic cases (read, write, write lock/unlock) correct.
   // More testing is required for full accuracy.
-  return !io.protect || !(command & 0xC00) || ((command & 0x3FF) < 0x30);
+  if(!io.protect) return true;
+  if(SoC::ASWAN()) return !(command & 0xC0) || ((command & 0x3F) < 0x30);
+  return !(command & 0xC00) || ((command & 0x3FF) < 0x30);
 }
 
 auto InternalEEPROM::padCommand(n16 command) -> n16 {

--- a/ares/ws/eeprom/eeprom.cpp
+++ b/ares/ws/eeprom/eeprom.cpp
@@ -7,27 +7,23 @@ namespace ares::WonderSwan {
 auto EEPROM::power() -> void {
   M93LCx6::power();
   io = {};
+  io.ready = 1;
 }
 
 auto EEPROM::read(u32 port) -> n8 {
   n8 data;
   if(!size) return data = 0xff;
 
-  if(port == DataLo) return io.data.byte(0);
-  if(port == DataHi) return io.data.byte(1);
+  if(port == DataLo) return io.read.byte(0);
+  if(port == DataHi) return io.read.byte(1);
 
-  if(port == AddressLo) return io.address.byte(0);
-  if(port == AddressHi) return io.address.byte(1);
+  if(port == CommandLo) return io.command.byte(0);
+  if(port == CommandHi) return io.command.byte(1);
 
   if(port == Status) {
-    data.bit(0) = io.readReady;
-    data.bit(1) = io.writeReady;
-    data.bit(2) = io.eraseReady;
-    data.bit(3) = io.resetReady;
-    data.bit(4) = io.readPending;
-    data.bit(5) = io.writePending;
-    data.bit(6) = io.erasePending;
-    data.bit(7) = io.resetPending;
+    data.bit(0) = io.readComplete;
+    data.bit(1) = io.ready;
+    data.bit(4,7) = io.control;
     return data;
   }
 
@@ -38,65 +34,88 @@ auto EEPROM::write(u32 port, n8 data) -> void {
   if(!size) return;
 
   if(port == DataLo) {
-    io.data.byte(0) = data;
+    io.write.byte(0) = data;
     return;
   }
 
   if(port == DataHi) {
-    io.data.byte(1) = data;
+    io.write.byte(1) = data;
     return;
   }
 
-  if(port == AddressLo) {
-    io.address.byte(0) = data;
+  if(port == CommandLo) {
+    io.command.byte(0) = data;
     return;
   }
 
-  if(port == AddressHi) {
-    io.address.byte(1) = data;
+  if(port == CommandHi) {
+    io.command.byte(1) = data;
     return;
   }
 
-  if(port == Command) {
-    io.readPending  = data.bit(4);
-    io.writePending = data.bit(5);
-    io.erasePending = data.bit(6);
-    io.resetPending = data.bit(7);
+  if(port == Control) {
+    io.control = data.bit(4,7);
+    n16 command = padCommand(io.command);
 
-    //nothing happens unless only one bit is set.
-    if(bit::count(data.bit(4,7)) != 1) return;
-
-    if(io.resetPending) {
-      M93LCx6::power();
-      io.resetPending = 0;
-      return;
-    }
-
-    //start bit + command bits + address bits
-    for(u32 index : reverse(range(1 + 2 + input.addressLength))) input.write(io.address.bit(index));
-
-    if(io.readPending) {
+    if(io.control == 1) { // read
+      for(u32 index : reverse(range(16))) input.write(command.bit(index));
       edge();
       output.read();  //padding bit
-      for(u32 index : reverse(range(input.dataLength))) io.data.bit(index) = output.read();
-      io.readPending = 0;
+      for(u32 index : reverse(range(16))) io.read.bit(index) = output.read();
+      io.readComplete = 1;
+    } else if(io.control == 2 && canWrite(command)) { // write
+      for(u32 index : reverse(range(16))) input.write(command.bit(index));
+      for(u32 index : reverse(range(16))) input.write(io.write.bit(index));
+      edge();
+    } else if(io.control == 4 && canWrite(command)) { // erase/other
+      for(u32 index : reverse(range(16))) input.write(command.bit(index));
+      edge();
+    } else if (io.control == 8) { // protect (only used on internal EEPROM)
+      io.protect = 1;
     }
 
-    if(io.writePending) {
-      for(u32 index : reverse(range(input.dataLength))) input.write(io.data.bit(index));
-      edge();
-      io.writePending = 0;
-    }
-
-    if(io.erasePending) {
-      edge();
-      io.erasePending = 0;
-    }
+    io.control = 0;
+    io.ready = 1;
 
     input.flush();
     output.flush();
     return;
   }
+}
+
+auto EEPROM::canWrite(n16 command) -> bool {
+  return true;
+}
+
+auto EEPROM::padCommand(n16 command) -> n16 {
+  return command;
+}
+
+auto InternalEEPROM::read(u32 port) -> n8 {
+  n8 data = EEPROM::read(port);
+  if(port == Status) data.bit(7) |= io.protect;
+  return data;
+}
+
+auto InternalEEPROM::canWrite(n16 command) -> bool {
+  // TODO: This is a guess that gets the basic cases (read, write, write lock/unlock) correct.
+  // More testing is required for full accuracy.
+  return !io.protect || !(command & 0xC00) || ((command & 0x3FF) < 0x30);
+}
+
+auto InternalEEPROM::padCommand(n16 command) -> n16 {
+  if(!SoC::ASWAN() && !system.color()) {
+    // Emulate 93C46 EEPROM on 93C86.
+    // TODO: This is a guess that gets the basic cases (read, write, write lock/unlock) correct.
+    // More testing is required for full accuracy.
+    if(command & 0xC0) {
+      return ((command & 0xFFC0) << 4) | (command & 0x3F);
+    } else {
+      return (command << 4);
+    }
+  }
+  
+  return command;
 }
 
 }

--- a/ares/ws/eeprom/eeprom.hpp
+++ b/ares/ws/eeprom/eeprom.hpp
@@ -2,33 +2,38 @@ struct EEPROM : M93LCx6 {
   enum : u32 {
     DataLo,
     DataHi,
-    AddressLo,
-    AddressHi,
+    CommandLo,
+    CommandHi,
     Status,
-    Command = Status,
+    Control = Status,
   };
 
   //eeprom.cpp
   auto power() -> void;
-  auto read(u32 port) -> n8;
+  virtual auto read(u32 port) -> n8;
   auto write(u32 port, n8 data) -> void;
 
   //serialization.cpp
   auto serialize(serializer&) -> void;
 
-private:
-  struct IO {
-    n16 data;
-    n16 address;
+protected:
+  virtual auto canWrite(n16 command) -> bool;
+  virtual auto padCommand(n16 command) -> n16;
 
-    //note: timing is not yet emulated; ready bits always remain set.
-    n1 readReady = 1;
-    n1 writeReady = 1;
-    n1 eraseReady = 1;
-    n1 resetReady = 1;
-    n1 readPending;
-    n1 writePending;
-    n1 erasePending;
-    n1 resetPending;
+  struct IO {
+    n16 read;
+    n16 write;
+    n16 command;
+
+    n1 ready;
+    n1 readComplete;
+    n4 control;
+    n1 protect;
   } io;
+};
+
+struct InternalEEPROM : EEPROM {
+  auto read(u32 port) -> n8 override;
+  auto canWrite(n16 command) -> bool override;
+  auto padCommand(n16 command) -> n16 override;
 };

--- a/ares/ws/eeprom/serialization.cpp
+++ b/ares/ws/eeprom/serialization.cpp
@@ -1,13 +1,10 @@
 auto EEPROM::serialize(serializer& s) -> void {
   M93LCx6::serialize(s);
-  s(io.data);
-  s(io.address);
-  s(io.readReady);
-  s(io.writeReady);
-  s(io.eraseReady);
-  s(io.resetReady);
-  s(io.readPending);
-  s(io.writePending);
-  s(io.erasePending);
-  s(io.resetPending);
+  s(io.read);
+  s(io.write);
+  s(io.command);
+  s(io.ready);
+  s(io.readComplete);
+  s(io.control);
+  s(io.protect);
 }

--- a/ares/ws/system/io.cpp
+++ b/ares/ws/system/io.cpp
@@ -18,12 +18,12 @@ auto System::readIO(n16 address) -> n8 {
     data = eeprom.read(EEPROM::DataHi);
     break;
 
-  case 0x00bc:  //IEEP_ADDRLO
-    data = eeprom.read(EEPROM::AddressLo);
+  case 0x00bc:  //IEEP_CMDLO
+    data = eeprom.read(EEPROM::CommandLo);
     break;
 
-  case 0x00bd:  //IEEP_ADDRHI
-    data = eeprom.read(EEPROM::AddressHi);
+  case 0x00bd:  //IEEP_CMDHI
+    data = eeprom.read(EEPROM::CommandHi);
     break;
 
   case 0x00be:  //IEEP_STATUS
@@ -53,16 +53,16 @@ auto System::writeIO(n16 address, n8 data) -> void {
     eeprom.write(EEPROM::DataHi, data);
     break;
 
-  case 0x00bc:  //IEEP_ADDRLO
-    eeprom.write(EEPROM::AddressLo, data);
+  case 0x00bc:  //IEEP_CMDLO
+    eeprom.write(EEPROM::CommandLo, data);
     break;
 
-  case 0x00bd:  //IEEP_ADDRHI
-    eeprom.write(EEPROM::AddressHi, data);
+  case 0x00bd:  //IEEP_CMDHI
+    eeprom.write(EEPROM::CommandHi, data);
     break;
 
-  case 0x00be:  //IEEP_CMD
-    eeprom.write(EEPROM::Command, data);
+  case 0x00be:  //IEEP_CTRL
+    eeprom.write(EEPROM::Control, data);
     break;
 
   }

--- a/ares/ws/system/serialization.cpp
+++ b/ares/ws/system/serialization.cpp
@@ -1,4 +1,4 @@
-static const string SerializerVersion = "v138.1";
+static const string SerializerVersion = "v139";
 
 auto System::serialize(bool synchronize) -> serializer {
   if(synchronize) scheduler.enter(Scheduler::Mode::Synchronize);

--- a/ares/ws/system/system.hpp
+++ b/ares/ws/system/system.hpp
@@ -104,7 +104,7 @@ struct System : IO {
   } information;
 
   Memory::Readable<n8> bootROM;
-  EEPROM eeprom;
+  InternalEEPROM eeprom;
 
 private:
   struct IO {


### PR DESCRIPTION
* The behaviour of bits 0-3 and 7 in the control/status port were a complete guess and had no reflection in hardware testing. They have been adjusted to match hardware.
* The EEPROM interface always writes and reads out 16 bits to/from the EEPROM, including the initial zeroes in the command value. The M93LCx6 code has been updated to support this case in line with the datasheet.
* The read and write data port have been separated. This was a detail which every community documentation in existence got wrong, so no worries about that one ^^
* Internal EEPROM protection has been implemented.
* The handling of invalid control commands (more than one bit set) has been fixed.
* Emulation of the 93C46-family internal EEPROM on SPHINX in ASWAN mode has been implemented. In particular, this fixes running any mono WonderSwan game which takes advantage of the internal EEPROM on the WonderSwan Color system's compatibility mode.

All of these changes pass the relevant tests in [ws-test-suite](https://github.com/asiekierka/ws-test-suite) (mono/eeprom/internal.ws) both as a WonderSwan and a WonderSwan Color. This isn't 100% accurate (particularly, timing is not reflected; but there are also some questions about more edge case-y behaviour), but it's much closer.