### PR TITLE
arm7tdmi: improved handling of PSR edge cases

### DIFF
--- a/ares/component/processor/arm7tdmi/arm7tdmi.cpp
+++ b/ares/component/processor/arm7tdmi/arm7tdmi.cpp
@@ -21,6 +21,8 @@ ARM7TDMI::ARM7TDMI() {
 auto ARM7TDMI::power() -> void {
   processor = {};
   processor.r15.modify = [&] { pipeline.reload = true; };
+  processor.rNULL.modify = [&] { processor.rNULL.data = 0; };
+  processor.spsrNULL.readonly = true;
   pipeline = {};
   carry = 0;
   irq = 0;

--- a/ares/component/processor/arm7tdmi/arm7tdmi.hpp
+++ b/ares/component/processor/arm7tdmi/arm7tdmi.hpp
@@ -69,7 +69,7 @@ struct ARM7TDMI {
   auto armMoveToStatus(n4 field, n1 source, n32 data) -> void;
 
   auto armInstructionBranch(i24, n1) -> void;
-  auto armInstructionBranchExchangeRegister(n4, n4, n4) -> void;
+  auto armInstructionBranchExchangeRegister(n4, n4, n4, n1) -> void;
   auto armInstructionCoprocessorDataProcessing(n4, n3, n4, n4, n4, n4) -> void;
   auto armInstructionDataImmediate(n8, n4, n4, n4, n1, n4) -> void;
   auto armInstructionDataImmediateShift(n4, n2, n5, n4, n4, n1, n4) -> void;
@@ -261,7 +261,7 @@ struct ARM7TDMI {
 
   //disassembler.cpp
   auto armDisassembleBranch(i24, n1) -> string;
-  auto armDisassembleBranchExchangeRegister(n4, n4, n4) -> string;
+  auto armDisassembleBranchExchangeRegister(n4, n4, n4, n1) -> string;
   auto armDisassembleCoprocessorDataProcessing(n4, n3, n4, n4, n4, n4) -> string;
   auto armDisassembleDataImmediate(n8, n4, n4, n4, n1, n4) -> string;
   auto armDisassembleDataImmediateShift(n4, n2, n5, n4, n4, n1, n4) -> string;

--- a/ares/component/processor/arm7tdmi/arm7tdmi.hpp
+++ b/ares/component/processor/arm7tdmi/arm7tdmi.hpp
@@ -150,19 +150,29 @@ struct ARM7TDMI {
     };
 
     operator u32() const {
-      return m << 0 | t << 5 | f << 6 | i << 7 | v << 28 | c << 29 | z << 30 | n << 31;
+      return m << 0 | 1 << 4 | t << 5 | f << 6 | i << 7 | v << 28 | c << 29 | z << 30 | n << 31;
     }
 
     auto operator=(n32 data) -> PSR& {
-      m = data.bit(0,4);
-      t = data.bit(5);
-      f = data.bit(6);
-      i = data.bit(7);
-      v = data.bit(28);
-      c = data.bit(29);
-      z = data.bit(30);
-      n = data.bit(31);
+      set(0b1111, data);
       return *this;
+    }
+
+    auto set(n4 field, n32 data) -> void {
+      if(readonly) return;
+      if(field.bit(0)) {
+        m = data.bit(0,4) | 0x10;
+        t = data.bit(5);
+        f = data.bit(6);
+        i = data.bit(7);
+      }
+
+      if(field.bit(3)) {
+        v = data.bit(28);
+        c = data.bit(29);
+        z = data.bit(30);
+        n = data.bit(31);
+      }
     }
 
     //serialization.cpp
@@ -176,6 +186,8 @@ struct ARM7TDMI {
     b1 c;  //carry
     b1 z;  //zero
     b1 n;  //negative
+
+    b1 readonly;
   };
 
   struct Processor {
@@ -184,6 +196,8 @@ struct ARM7TDMI {
 
     GPR r0, r1, r2, r3, r4, r5, r6, r7, r8, r9, r10, r11, r12, r13, r14, r15;
     PSR cpsr;
+    GPR rNULL;  //read-only, used when no register is mapped to r(13) or r(14)
+    PSR spsrNULL;  //read-only, used when no SPSR is mapped
 
     struct FIQ {
       GPR r8, r9, r10, r11, r12, r13, r14;

--- a/ares/component/processor/arm7tdmi/disassembler.cpp
+++ b/ares/component/processor/arm7tdmi/disassembler.cpp
@@ -64,7 +64,7 @@ auto ARM7TDMI::armDisassembleBranch
 }
 
 auto ARM7TDMI::armDisassembleBranchExchangeRegister
-(n4 m, n4 d, n4 field) -> string {
+(n4 m, n4 d, n4 field, n1 mode) -> string {
   return {"bx", _c, " ", _r[m]};
 }
 

--- a/ares/component/processor/arm7tdmi/instruction.cpp
+++ b/ares/component/processor/arm7tdmi/instruction.cpp
@@ -82,9 +82,11 @@ auto ARM7TDMI::armInitialize() -> void {
   #define arguments \
     opcode.bit( 0, 3),  /* m */ \
     opcode.bit(12,15),  /* d */ \
-    opcode.bit(16,19)   /* field */
-  for(n2 _ : range(4)) {
-    auto opcode = pattern(".... 0001 0010 ???? ???? ---- 0??1 ????") | _ << 5;
+    opcode.bit(16,19),  /* field */ \
+    opcode.bit(22)      /* mode */
+  for(n2 _ : range(4))
+  for(n1 mode : range(2)) {
+    auto opcode = pattern(".... 0001 0?10 ???? ???? ---- 0??1 ????") | _ << 5 | mode << 22;
     bind(opcode, BranchExchangeRegister);
   }
   #undef arguments

--- a/ares/component/processor/arm7tdmi/instructions-arm.cpp
+++ b/ares/component/processor/arm7tdmi/instructions-arm.cpp
@@ -24,24 +24,12 @@ auto ARM7TDMI::armALU(n4 mode, n4 d, n32 rn, n32 rm) -> void {
 }
 
 auto ARM7TDMI::armMoveToStatus(n4 field, n1 mode, n32 data) -> void {
-  if(mode && (cpsr().m == PSR::USR || cpsr().m == PSR::SYS)) return;
-  PSR& psr = mode ? spsr() : cpsr();
-
-  if(field.bit(0)) {
-    if(mode || privileged()) {
-      psr.m = data.bit(0,4) | 0x10;
-      psr.t = data.bit(5);
-      psr.f = data.bit(6);
-      psr.i = data.bit(7);
-      if(!mode && psr.t) r(15).data += 2;
-    }
-  }
-
-  if(field.bit(3)) {
-    psr.v = data.bit(28);
-    psr.c = data.bit(29);
-    psr.z = data.bit(30);
-    psr.n = data.bit(31);
+  if(mode) {
+    spsr().set(field, data);
+  } else {
+    if(!privileged()) field.bit(0) = 0;
+    cpsr().set(field, data);
+    if(cpsr().t) r(15).data += 2;
   }
 }
 

--- a/ares/component/processor/arm7tdmi/instructions-arm.cpp
+++ b/ares/component/processor/arm7tdmi/instructions-arm.cpp
@@ -42,12 +42,13 @@ auto ARM7TDMI::armInstructionBranch
 }
 
 auto ARM7TDMI::armInstructionBranchExchangeRegister
-(n4 m, n4 d, n4 field) -> void {
+(n4 m, n4 d, n4 field, n1 mode) -> void {
   n32 address = r(m);
   if((field & 0b1001) == 0b1001) {
-    cpsr().t = address.bit(0);
+    PSR& psr = mode ? spsr() : cpsr();
+    psr.t = address.bit(0);
   } else {
-    armMoveToStatus(field, 0, address);
+    armMoveToStatus(field, mode, address);
   }
   r(d) = address;
 }

--- a/ares/component/processor/arm7tdmi/registers.cpp
+++ b/ares/component/processor/arm7tdmi/registers.cpp
@@ -14,20 +14,24 @@ inline auto ARM7TDMI::r(n4 index) -> GPR& {
   case 11: return processor.cpsr.m == PSR::FIQ ? processor.fiq.r11 : processor.r11;
   case 12: return processor.cpsr.m == PSR::FIQ ? processor.fiq.r12 : processor.r12;
   case 13: switch(processor.cpsr.m) {
+    case PSR::USR: return processor.r13;
     case PSR::FIQ: return processor.fiq.r13;
     case PSR::IRQ: return processor.irq.r13;
     case PSR::SVC: return processor.svc.r13;
     case PSR::ABT: return processor.abt.r13;
     case PSR::UND: return processor.und.r13;
-    default: return processor.r13;
+    case PSR::SYS: return processor.r13;
+    default: return processor.rNULL;
   }
   case 14: switch(processor.cpsr.m) {
+    case PSR::USR: return processor.r14;
     case PSR::FIQ: return processor.fiq.r14;
     case PSR::IRQ: return processor.irq.r14;
     case PSR::SVC: return processor.svc.r14;
     case PSR::ABT: return processor.abt.r14;
     case PSR::UND: return processor.und.r14;
-    default: return processor.r14;
+    case PSR::SYS: return processor.r14;
+    default: return processor.rNULL;
   }
   case 15: return processor.r15;
   }
@@ -46,7 +50,7 @@ inline auto ARM7TDMI::spsr() -> PSR& {
   case PSR::ABT: return processor.abt.spsr;
   case PSR::UND: return processor.und.spsr;
   }
-  throw;
+  return processor.spsrNULL;
 }
 
 inline auto ARM7TDMI::privileged() const -> bool {

--- a/ares/component/processor/arm7tdmi/serialization.cpp
+++ b/ares/component/processor/arm7tdmi/serialization.cpp
@@ -24,6 +24,8 @@ auto ARM7TDMI::Processor::serialize(serializer& s) -> void {
   s(r14.data);
   s(r15.data);
   s(cpsr);
+  s(rNULL.data);
+  s(spsrNULL);
   s(fiq.r8.data);
   s(fiq.r9.data);
   s(fiq.r10.data);
@@ -55,6 +57,7 @@ auto ARM7TDMI::PSR::serialize(serializer& s) -> void {
   s(c);
   s(z);
   s(n);
+  s(readonly);
 }
 
 auto ARM7TDMI::Pipeline::serialize(serializer& s) -> void {

--- a/ares/gba/system/serialization.cpp
+++ b/ares/gba/system/serialization.cpp
@@ -1,4 +1,4 @@
-static const string SerializerVersion = "v144.1";
+static const string SerializerVersion = "v144.2";
 
 auto System::serialize(bool synchronize) -> serializer {
   if(synchronize) scheduler.enter(Scheduler::Mode::Synchronize);

--- a/ares/sfc/system/serialization.cpp
+++ b/ares/sfc/system/serialization.cpp
@@ -1,4 +1,4 @@
-static const string SerializerVersion = "v143.1";
+static const string SerializerVersion = "v144";
 
 auto System::serialize(bool synchronize) -> serializer {
   if(synchronize) scheduler.enter(Scheduler::Mode::Synchronize);


### PR DESCRIPTION
When the CPSR mode field is set to an invalid mode, SP (R13), LR (R14), and SPSR are not mapped to any register. Therefore, writes to them should fail, and reading them should return zero (or 0x00000010 in the case of SPSR).

Update: Also implemented a new edge case for BX instructions, where setting bit 22 causes SPSR to be modified rather than CPSR.