### PR TITLE
gba: step CPU 1 cycle at a time while halted

### DIFF
--- a/ares/gba/cpu/cpu.cpp
+++ b/ares/gba/cpu/cpu.cpp
@@ -46,7 +46,7 @@ auto CPU::main() -> void {
   if(halted()) {
     dmaRun();
     if(!(irq.enable[0] & irq.flag[0])) {
-      return step(4);
+      return step(1);
     }
     step(2);
     context.halted = false;


### PR DESCRIPTION
Removes a speedup in the GBA core that was detrimental to accuracy. Testing on Linux, the performance cost is more than offset by the recent UI threading rework.