### PR TITLE
arm7tdmi: specify undefined instructions more strictly

### DIFF
--- a/ares/component/processor/arm7tdmi/arm7tdmi.hpp
+++ b/ares/component/processor/arm7tdmi/arm7tdmi.hpp
@@ -84,6 +84,7 @@ struct ARM7TDMI {
   auto armInstructionMoveSignedRegister(n4, n1, n4, n4, n1, n1, n1, n1) -> void;
   auto armInstructionMoveToCoprocessorFromRegister(n4, n3, n4, n4, n4, n3) -> void;
   auto armInstructionMoveToRegisterFromCoprocessor(n4, n3, n4, n4, n4, n3) -> void;
+  auto armInstructionMoveToRegisterFromRegister(n4, n4) -> void;
   auto armInstructionMoveToRegisterFromStatus(n4, n1) -> void;
   auto armInstructionMoveToStatusFromImmediate(n8, n4, n4, n1) -> void;
   auto armInstructionMoveToStatusFromRegister(n4, n2, n5, n4, n1) -> void;
@@ -276,6 +277,7 @@ struct ARM7TDMI {
   auto armDisassembleMoveSignedRegister(n4, n1, n4, n4, n1, n1, n1, n1) -> string;
   auto armDisassembleMoveToCoprocessorFromRegister(n4, n3, n4, n4, n4, n3) -> string;
   auto armDisassembleMoveToRegisterFromCoprocessor(n4, n3, n4, n4, n4, n3) -> string;
+  auto armDisassembleMoveToRegisterFromRegister(n4, n4) -> string;
   auto armDisassembleMoveToRegisterFromStatus(n4, n1) -> string;
   auto armDisassembleMoveToStatusFromImmediate(n8, n4, n4, n1) -> string;
   auto armDisassembleMoveToStatusFromRegister(n4, n2, n5, n4, n1) -> string;

--- a/ares/component/processor/arm7tdmi/disassembler.cpp
+++ b/ares/component/processor/arm7tdmi/disassembler.cpp
@@ -230,6 +230,11 @@ auto ARM7TDMI::armDisassembleMoveToRegisterFromCoprocessor
     ", cr", cn, ", cr", cm, ", ", op2};
 }
 
+auto ARM7TDMI::armDisassembleMoveToRegisterFromRegister
+(n4 d, n4 n) -> string {
+  return {"mov", _c, " ", _r[d], ",", _r[n]};
+}
+
 auto ARM7TDMI::armDisassembleMoveToRegisterFromStatus
 (n4 d, n1 mode) -> string {
   return {"mrs", _c, " ", _r[d], ",", mode ? "spsr" : "cpsr"};

--- a/ares/component/processor/arm7tdmi/instruction.cpp
+++ b/ares/component/processor/arm7tdmi/instruction.cpp
@@ -420,15 +420,28 @@ auto ARM7TDMI::armInitialize() -> void {
   #undef arguments
 
   #define arguments
-  for(n12 id : range(4096)) {
-    if(armInstruction[id]) continue;
-    auto opcode = pattern(".... ???? ???? ---- ---- ---- ???? ----") | id.bit(0,3) << 4 | id.bit(4,11) << 20;
+  for(n8 _ : range(256)) {
+    //architecturally undefined
+    auto opcode = pattern(".... 011? ???? ---- ---- ---- ???1 ----") | _.bit(0,2) << 5 | _.bit(3,7) << 20;
+    bind(opcode, Undefined);
+  }
+  for(n8 _ : range(256)) {
+    //load to coprocessor
+    auto opcode = pattern(".... 110? ???1 ---- ---- ---- ???? ----") | _.bit(0,3) << 4 | _.bit(4,7) << 21;
+    bind(opcode, Undefined);
+  }
+  for(n8 _ : range(256)) {
+    //store from coprocessor
+    auto opcode = pattern(".... 110? ???0 ---- ---- ---- ???? ----") | _.bit(0,3) << 4 | _.bit(4,7) << 21;
     bind(opcode, Undefined);
   }
   #undef arguments
 
   #undef bind
   #undef pattern
+
+  //check that all encodings are bound
+  for(n12 index : range(4096)) assert(armInstruction[index]);
 }
 
 auto ARM7TDMI::thumbInitialize() -> void {

--- a/ares/component/processor/arm7tdmi/instruction.cpp
+++ b/ares/component/processor/arm7tdmi/instruction.cpp
@@ -84,9 +84,9 @@ auto ARM7TDMI::armInitialize() -> void {
     opcode.bit(12,15),  /* d */ \
     opcode.bit(16,19),  /* field */ \
     opcode.bit(22)      /* mode */
-  for(n2 _ : range(4))
+  for(n3 _ : range(8))
   for(n1 mode : range(2)) {
-    auto opcode = pattern(".... 0001 0?10 ???? ???? ---- 0??1 ????") | _ << 5 | mode << 22;
+    auto opcode = pattern(".... 0001 0??0 ???? ???? ---- 0??1 ????") | _.bit(0,1) << 5 | _.bit(2) << 21 | mode << 22;
     bind(opcode, BranchExchangeRegister);
   }
   #undef arguments
@@ -330,6 +330,16 @@ auto ARM7TDMI::armInitialize() -> void {
   for(n3 op1 : range(8)) {
     auto opcode = pattern(".... 1110 ???1 ???? ???? ???? ???1 ????") | op2 << 5 | op1 << 21;
     bind(opcode, MoveToRegisterFromCoprocessor);
+  }
+  #undef arguments
+
+  #define arguments \
+    opcode.bit(12,15),  /* d */ \
+    opcode.bit(16,19)   /* n */
+  for(n5 _ : range(32)) {
+    //undocumented instruction, equivalent to "mov rd, rn"
+    auto opcode = pattern(".... 0011 0?00 ???? ???? ---- ???? ----") | _.bit(0,3) << 4 | _.bit(4) << 22;
+    bind(opcode, MoveToRegisterFromRegister);
   }
   #undef arguments
 

--- a/ares/component/processor/arm7tdmi/instructions-arm.cpp
+++ b/ares/component/processor/arm7tdmi/instructions-arm.cpp
@@ -276,6 +276,11 @@ auto ARM7TDMI::armInstructionMoveToRegisterFromCoprocessor
   r(d) = MRC[cpid](cm, op2, cn, op1);
 }
 
+auto ARM7TDMI::armInstructionMoveToRegisterFromRegister
+(n4 d, n4 n) -> void {
+  r(d) = r(n);
+}
+
 auto ARM7TDMI::armInstructionMoveToRegisterFromStatus
 (n4 d, n1 mode) -> void {
   r(d) = (mode && cpsr().m != PSR::USR && cpsr().m != PSR::SYS) ? spsr() : cpsr();


### PR DESCRIPTION
- Adds instruction encodings for BX with bit 21 clear, and for an undocumented `mov rd, rn` instruction
- Uses specific encodings for undefined instructions, rather than binding them to unused encodings, and then asserts that all encodings have been bound