### PR TITLE
arm7tdmi: implement R15 misalignment and clean up LDM/STM

### DIFF
--- a/ares/component/processor/arm7tdmi/arm7tdmi.cpp
+++ b/ares/component/processor/arm7tdmi/arm7tdmi.cpp
@@ -20,7 +20,7 @@ ARM7TDMI::ARM7TDMI() {
 
 auto ARM7TDMI::power() -> void {
   processor = {};
-  processor.r15.modify = [&] { pipeline.reload = true; };
+  processor.r15.modify = [&] { processor.r15.data &= ~1; pipeline.reload = true; };
   processor.rNULL.modify = [&] { processor.rNULL.data = 0; };
   processor.spsrNULL.readonly = true;
   pipeline = {};

--- a/ares/component/processor/arm7tdmi/instruction.cpp
+++ b/ares/component/processor/arm7tdmi/instruction.cpp
@@ -1,11 +1,8 @@
 auto ARM7TDMI::reload() -> void {
-  u32 mask = !cpsr().t ? 3 : 1;
   u32 size = !cpsr().t ? Word : Half;
-
   pipeline.reload = false;
   endBurst();
-  r(15).data &= ~mask;
-  pipeline.fetch.address = r(15) & ~mask;
+  pipeline.fetch.address = r(15);
   pipeline.fetch.instruction = read(Prefetch | size, pipeline.fetch.address);
   fetch();
 }
@@ -17,11 +14,9 @@ auto ARM7TDMI::fetch() -> void {
   pipeline.decode.thumb = cpsr().t;
   pipeline.decode.irq = !cpsr().i;
 
-  u32 mask = !cpsr().t ? 3 : 1;
   u32 size = !cpsr().t ? Word : Half;
-
   r(15).data += size >> 3;
-  pipeline.fetch.address = r(15) & ~mask;
+  pipeline.fetch.address = r(15);
   pipeline.fetch.instruction = read(Prefetch | size, pipeline.fetch.address);
 }
 

--- a/ares/gba/cpu/bus.cpp
+++ b/ares/gba/cpu/bus.cpp
@@ -48,6 +48,7 @@ inline auto CPU::getBus(u32 mode, n32 address) -> n32 {
     mode = cartMode(mode, address);
     context.romAccess = true;
     if(mode & Prefetch && wait.prefetch) {
+      if(mode & Word) address &= ~3;  //prevents misaligned PC from reading incorrect values
       if(mode & Nonsequential && prefetch.cycle == 0 && prefetch.empty()) prefetchReset();
       prefetchSync(address);
       prefetchStep(1);


### PR DESCRIPTION
Allows bit 1 of R15 to be set in ARM mode.

The updated LDM/STM implementations are functionally identical to the previous versions, but are significantly shorter and require less special-casing.