### PR TITLE
ps1: fix dma interrupt flag calculation

### DIFF
--- a/ares/ps1/dma/irq.cpp
+++ b/ares/ps1/dma/irq.cpp
@@ -2,13 +2,13 @@ auto DMA::IRQ::poll() -> void {
   bool previous = flag;
   flag = force;
   if(enable) {
-    flag |= self.channels[0].irq.flag & self.channels[0].irq.enable;
-    flag |= self.channels[1].irq.flag & self.channels[1].irq.enable;
-    flag |= self.channels[2].irq.flag & self.channels[2].irq.enable;
-    flag |= self.channels[3].irq.flag & self.channels[3].irq.enable;
-    flag |= self.channels[4].irq.flag & self.channels[4].irq.enable;
-    flag |= self.channels[5].irq.flag & self.channels[5].irq.enable;
-    flag |= self.channels[6].irq.flag & self.channels[6].irq.enable;
+    flag |= self.channels[0].irq.flag;
+    flag |= self.channels[1].irq.flag;
+    flag |= self.channels[2].irq.flag;
+    flag |= self.channels[3].irq.flag;
+    flag |= self.channels[4].irq.flag;
+    flag |= self.channels[5].irq.flag;
+    flag |= self.channels[6].irq.flag;
   }
   if(!previous && flag) interrupt.raise(Interrupt::DMA);
   if(!flag) interrupt.lower(Interrupt::DMA);


### PR DESCRIPTION
The topmost bit of the DICR (DMA Interrupt) register should not influenced by the per-channel interrupt enable bits. This flaw was masked in fast boot mode, as it allows title code to begin execution in a pristine state unlike what the BIOS leaves behind.

With this change, the titles that were "fixed" by enabling fast boot mode can now be launched with it disabled.