### PR TITLE
Use GBC core with N64 transfer pak to allow both GB & GBC saves

### DIFF
--- a/desktop-ui/emulator/nintendo-64.cpp
+++ b/desktop-ui/emulator/nintendo-64.cpp
@@ -146,7 +146,7 @@ auto Nintendo64::load() -> LoadResult {
           port->connect();
 
           if(auto slot = transferPak->find<ares::Node::Port>("Cartridge Slot")) {
-            gb = mia::Medium::create("Game Boy");
+            gb = mia::Medium::create("Game Boy Color");
             string tmpPath;
             if(gb->load(Emulator::load(gb, tmpPath)) == successful) {
               slot->allocate();
@@ -291,7 +291,7 @@ auto Nintendo64::portMenu(Menu& portMenu, ares::Node::Port port) -> void {
           port->connect();
 
           if(auto slot = transferPak->find<ares::Node::Port>("Cartridge Slot")) {
-            emulator->gb = mia::Medium::create("Game Boy");
+            emulator->gb = mia::Medium::create("Game Boy Color");
             string tmpPath;
             if(emulator->gb->load(emulator->load(emulator->gb, tmpPath)) == successful) {
               slot->allocate();

--- a/desktop-ui/emulator/nintendo-64dd.cpp
+++ b/desktop-ui/emulator/nintendo-64dd.cpp
@@ -125,7 +125,7 @@ auto Nintendo64DD::load() -> LoadResult {
           port->connect();
 
           if(auto slot = transferPak->find<ares::Node::Port>("Cartridge Slot")) {
-            gb = mia::Medium::create("Game Boy");
+            gb = mia::Medium::create("Game Boy Color");
             string tmpPath;
             if(gb->load(Emulator::load(gb, tmpPath)) == successful) {
               slot->allocate();


### PR DESCRIPTION
Since the GBC core has support for both .gb & .gbc roms, using this core will allow for the use of both game/save types with the N64 transfer pak. 

Fixes: https://github.com/ares-emulator/ares/issues/2009