### PR TITLE
optimized 64-bit System V function calls

### DIFF
--- a/nall/nall/recompiler/generic/encoder-calls.hpp
+++ b/nall/nall/recompiler/generic/encoder-calls.hpp
@@ -76,4 +76,88 @@
     if constexpr(!std::is_void_v<R>) type |= SLJIT_ARG_RETURN(SLJIT_ARG_TYPE_W);
     sljit_emit_icall(compiler, SLJIT_CALL, type, SLJIT_IMM, SLJIT_FUNC_ADDR(imm64{function}.data));
   }
+
+  #if defined(ABI_SYSTEMV) and defined(ARCHITECTURE_AMD64)
+  // System V AMD64 ABI compatible function calls.
+
+  // If we use SLJIT's regular SLJIT_CALL, function arguments are expected to be
+  // in registers R0, R1, R2, and R3. The concrete x64 registers chosen in SLJIT
+  // for R0 (RAX) and R2 (RDI) aren't compatible with the Sys V calling convention.
+  // Therefore SLJIT always generates extra instructions to move arguments to the
+  // to the registers expected by the callee.
+
+  // We can avoid that by placing the arguments in the correct registers directly,
+  // and setting the SLJIT_CALL_REG_ARG flag.
+  // Note that this is actually misuse of the API, since the flag is meant for
+  // functions compiled with SLJIT's custom ABI. Nevertheless, it allows us to
+  // skip the two unneeded mov instructions and works just fine on x64.
+  //
+  // Argument placement in the two calling conventions:
+  //
+  //    arg#    0    1    2    3
+  //    Sys V: RDI, RSI, RDX, RCX
+  //    SLJIT: RAX, RSI, RDI, RCX
+  //
+
+  // Note that arg2_reg refers to TMP_REG1 since it maps to RDX, but we store
+  // TMP_REG1 - 1 instead so that it works when passed through SLJIT_R(i) when
+  // setup_arg() calls the reg(TMP_REG1 - 1) constructor.
+
+  static constexpr int call_type = SLJIT_CALL_REG_ARG;
+  static constexpr int arg0_reg = 2;                              // RDI
+  static constexpr int arg1_reg = 1;                              // RSI
+  static constexpr int arg2_reg = SLJIT_NUMBER_OF_REGISTERS + 1;  // RDX
+  static constexpr int arg3_reg = 3;                              // RCX
+  #else
+  // SLJIT's generic SLJIT_CALL convention, compatible with any ABI.
+
+  static constexpr int call_type = SLJIT_CALL;
+  static constexpr int arg0_reg = 0;
+  static constexpr int arg1_reg = 1;
+  static constexpr int arg2_reg = 2;
+  static constexpr int arg3_reg = 3;
+  #endif
+
+  template<typename T>
+  void setup_arg(const reg& dst, const T& src) {
+    if constexpr (std::is_same_v<T, mem>) {
+      // The 'mem' type represents a (base register, offset) pair
+      // Extract the original saved register index from the encoded first operand of mem.
+      sljit_s32 S = SLJIT_EXTRACT_REG(src.fst);
+      sljit_s32 i = SLJIT_NUMBER_OF_REGISTERS - S; // inverse of SLJIT_S(i)
+      lea(dst, sreg(i), src.snd);
+    } else if constexpr (std::is_same_v<T, imm>) {
+      sljit_emit_op1(compiler, SLJIT_MOV32, dst.fst, dst.snd, src.fst, src.snd);
+    } else if constexpr (std::is_same_v<T, imm64>) {
+      sljit_emit_op1(compiler, SLJIT_MOV, dst.fst, dst.snd, SLJIT_IMM, src.data);
+    } else {
+      static_assert(false, "unknown function argument type");
+    }
+  }
+
+  template<typename C, typename V, typename... P, typename... Q>
+  void callf(V (C::*function)(P...), const Q&... args) {
+    static_assert(sizeof...(P) <= 3);
+    static_assert(sizeof...(P) == sizeof...(Q));
+
+    sljit_s32 type = SLJIT_ARG_VALUE(SLJIT_ARG_TYPE_W, 1);
+
+    if constexpr(sizeof...(P) >= 1) {
+      setup_arg(reg(arg1_reg), std::get<0>(std::forward_as_tuple(args...)));
+      type |= SLJIT_ARG_VALUE(SLJIT_ARG_TYPE_W, 2);
+    }
+    if constexpr(sizeof...(P) >= 2) {
+      setup_arg(reg(arg2_reg), std::get<1>(std::forward_as_tuple(args...)));
+      type |= SLJIT_ARG_VALUE(SLJIT_ARG_TYPE_W, 3);
+    }
+    if constexpr(sizeof...(P) >= 3) {
+      setup_arg(reg(arg3_reg), std::get<2>(std::forward_as_tuple(args...)));
+      type |= SLJIT_ARG_VALUE(SLJIT_ARG_TYPE_W, 4);
+    }
+
+    if constexpr(!std::is_void_v<V>) type |= SLJIT_ARG_RETURN(SLJIT_ARG_TYPE_W);
+
+    sljit_emit_op1(compiler, SLJIT_MOV, SLJIT_R(arg0_reg), 0, SLJIT_S0, 0);
+    sljit_emit_icall(compiler, call_type, type, SLJIT_IMM, SLJIT_FUNC_ADDR(imm64{function}.data));
+  }
 //};


### PR DESCRIPTION
The commit messages say it all:

---

When ares switched to SLJIT, some tiny overhead was introduced in every call from guest to host code on 64-bit Linux. This was due to the argument register mapping differing between SLJIT's own convention and the System V AMD64 ABI.
This commit makes the recompiler put function arguments directly in the correct registers.

This commit introduces a new 'callf' template function that accepts recompiler's 'mem' and 'imm' argument types. It abstracts away the register setup so that different host platforms can implement their optimized function calls. This also results in slightly shorter code in the recompiler (see the followup commit).

The SLJIT_CALL_REG_ARG type of call is actually meant for SLJIT's own, optimized calling convention, but since it assumes function arguments are placed in correct registers, it works here. The only other option I could think would've been emitting x64 machine code directly.

In the n64-systemtest ROM, this change shaves off 6% and 10% of the respective VR4300 and RSP  median block sizes:
  
  ```
    VR4300 block size statistics
  
              min   max   mean     median
     before   113   6369  893.93   573
     after    104   5937  881.17   537
  
    RSP block size statistics
  
              min   max   mean     median
     before   97   19196  3941.95  5336
     after    88   17044  3414.06  4606
```  

  Also, on a benchmark with an RSP-intensive homebrew libdragon ROM, this
  change gave about 1% actual runtime speedup.

<img width="778" height="146" alt="image" src="https://github.com/user-attachments/assets/c00683e1-8e3c-4ced-838d-6349bbd692e7" />
