### PR TITLE
Revert "n64: improve PI DMA accuracy with stricter timings"

### DIFF
--- a/ares/n64/cpu/cpu.cpp
+++ b/ares/n64/cpu/cpu.cpp
@@ -68,7 +68,7 @@ auto CPU::synchronize() -> void {
   queue.step(clocks, [](u32 event) {
     switch(event) {
     case Queue::PI_DMA_Read:   return pi.dmaFinished();
-    case Queue::PI_DMA_Write:  return pi.dmaWrite();
+    case Queue::PI_DMA_Write:  return pi.dmaFinished();
     case Queue::PI_BUS_Write:  return pi.writeFinished();
     case Queue::SI_DMA_Read:   return si.dmaRead();
     case Queue::SI_DMA_Write:  return si.dmaWrite();

--- a/ares/n64/pi/io.cpp
+++ b/ares/n64/pi/io.cpp
@@ -107,14 +107,16 @@ auto PI::ioWrite(u32 address, u32 data_) -> void {
     io.readLength = n24(data);
     io.dmaBusy = 1;
     io.originPc = cpu.ipu.pc;
-    queue.insert(Queue::PI_DMA_Read, dmaReadDuration());
+    queue.insert(Queue::PI_DMA_Read, dmaDuration(true));
     dmaRead();
   }
 
   if(address == 3) {
     //PI_WRITE_LENGTH
     io.writeLength = n24(data);
+    io.dmaBusy = 1;
     io.originPc = cpu.ipu.pc;
+    queue.insert(Queue::PI_DMA_Write, dmaDuration(false));
     dmaWrite();
   }
 

--- a/ares/n64/pi/pi.cpp
+++ b/ares/n64/pi/pi.cpp
@@ -23,7 +23,6 @@ auto PI::power(bool reset) -> void {
   io = {};
   bsd1 = {};
   bsd2 = {};
-  runningDMA = {};
 }
 
 }

--- a/ares/n64/pi/pi.hpp
+++ b/ares/n64/pi/pi.hpp
@@ -22,8 +22,7 @@ struct PI : Memory::RCP<PI> {
   auto dmaRead() -> void;
   auto dmaWrite() -> void;
   auto dmaFinished() -> void;
-  auto dmaReadDuration() -> u32;
-  auto dmaWriteDuration() -> u32;
+  auto dmaDuration(bool read) -> u32;
 
   //io.cpp
   auto ioRead(u32 address) -> u32;
@@ -54,18 +53,6 @@ struct PI : Memory::RCP<PI> {
     n32 busLatch;
     u64 originPc;
   } io;
-
-  struct RunningDMA {
-    n1 firstBlock;
-    i32 maxBlockSize;
-    i32 length;
-    i32 misalign;
-    i32 distEndOfRow;    
-
-    auto blockLen() -> i32 {
-      return min(length, min(maxBlockSize-misalign, distEndOfRow));
-    }    
-  } runningDMA;
 
   struct BSD {
     n8 latency;

--- a/ares/n64/pi/serialization.cpp
+++ b/ares/n64/pi/serialization.cpp
@@ -19,10 +19,4 @@ auto PI::serialize(serializer& s) -> void {
   s(bsd2.pulseWidth);
   s(bsd2.pageSize);
   s(bsd2.releaseDuration);
-
-  s(runningDMA.firstBlock);
-  s(runningDMA.maxBlockSize);
-  s(runningDMA.length);
-  s(runningDMA.misalign);
-  s(runningDMA.distEndOfRow);
 }

--- a/ares/n64/system/serialization.cpp
+++ b/ares/n64/system/serialization.cpp
@@ -1,4 +1,4 @@
-static const string SerializerVersion = "v144.1";
+static const string SerializerVersion = "v144";
 
 auto System::serialize(bool synchronize) -> serializer {
   serializer s;

--- a/nall/nall/priority-queue.hpp
+++ b/nall/nall/priority-queue.hpp
@@ -26,12 +26,10 @@ struct priority_queue<T[Size]> {
 
   template<typename F>
   auto step(u32 clocks, const F& callback) -> void {
-    u32 baseClock = clock;
-    while(size && ge(baseClock+clocks, heap[0].clock)) {
-      clock = heap[0].clock;
+    clock += clocks;
+    while(size && ge(clock, heap[0].clock)) {
       if(auto event = remove()) callback(*event);
     }
-    clock = baseClock + clocks;
   }
 
   auto insert(const T& event, u32 clock) -> bool {


### PR DESCRIPTION
Reverts ares-emulator/ares#2139

This exposed some shortcomings in the pi_dma testrom and caused some compatibility issues; an updated testrom is required