### PR TITLE
desktop-ui: Create program guard for system menu items

### DIFF
--- a/desktop-ui/emulator/famicom-disk-system.cpp
+++ b/desktop-ui/emulator/famicom-disk-system.cpp
@@ -70,6 +70,7 @@ auto FamicomDiskSystem::load(Menu menu) -> void {
 
 auto FamicomDiskSystem::changeDiskState(string state) -> void
 {
+  Program::Guard guard;
   print("Changing disk state to: ", state, "\n");
   //Eject the disk and give the emulator time to react before re-inserting
   print("Ejecting disk\n");
@@ -77,6 +78,7 @@ auto FamicomDiskSystem::changeDiskState(string state) -> void
   if(state != "Ejected") {
     print("Setting disk change timer\n");
     diskChangeTimer->onActivate([=] {
+      Program::Guard guard;
       print("Disk change timer activated, setting disk state to: ", state, "\n");
       diskChangeTimer->setEnabled(false);
       emulator->notify(state);

--- a/desktop-ui/emulator/game-boy-advance.cpp
+++ b/desktop-ui/emulator/game-boy-advance.cpp
@@ -42,6 +42,7 @@ auto GameBoyAdvance::load(Menu menu) -> void {
       MenuRadioItem item{&orientationMenu};
       item.setText(orientation);
       item.onActivate([=] {
+        Program::Guard guard;
         if(auto orientations = root->find<ares::Node::Setting::String>("PPU/Screen/Orientation")) {
           orientations->setValue(orientation);
         }

--- a/desktop-ui/emulator/game-boy.cpp
+++ b/desktop-ui/emulator/game-boy.cpp
@@ -62,6 +62,7 @@ auto GameBoy::load(Menu menu) -> void {
         MenuRadioItem item{&colorEmulationMenu};
         item.setText(setting);
         item.onActivate([=] {
+          Program::Guard guard;
           if(auto settings = root->find<ares::Node::Setting::String>("PPU/Screen/Color Emulation")) {
             settings->setValue(setting);
           }

--- a/desktop-ui/emulator/mega-cd-32x.cpp
+++ b/desktop-ui/emulator/mega-cd-32x.cpp
@@ -116,6 +116,7 @@ auto MegaCD32X::load(Menu menu) -> void {
   MenuItem changeDisc{&menu};
   changeDisc.setIcon(Icon::Device::Optical);
   changeDisc.setText("Change Disc").onActivate([&] {
+    Program::Guard guard;
     save();
     auto tray = root->find<ares::Node::Port>("Mega CD/Disc Tray");
     tray->disconnect();
@@ -126,6 +127,7 @@ auto MegaCD32X::load(Menu menu) -> void {
 
     //give the emulator core a few seconds to notice an empty drive state before reconnecting
     discTrayTimer->onActivate([&] {
+      Program::Guard guard;
       discTrayTimer->setEnabled(false);
       auto tray = root->find<ares::Node::Port>("Mega CD/Disc Tray");
       tray->allocate();

--- a/desktop-ui/emulator/mega-cd.cpp
+++ b/desktop-ui/emulator/mega-cd.cpp
@@ -121,6 +121,7 @@ auto MegaCD::load(Menu menu) -> void {
   MenuItem changeDisc{&menu};
   changeDisc.setIcon(Icon::Device::Optical);
   changeDisc.setText("Change Disc").onActivate([&] {
+    Program::Guard guard;
     save();
     auto tray = root->find<ares::Node::Port>("Mega CD/Disc Tray");
     tray->disconnect();
@@ -131,6 +132,7 @@ auto MegaCD::load(Menu menu) -> void {
 
     //give the emulator core a few seconds to notice an empty drive state before reconnecting
     discTrayTimer->onActivate([&] {
+      Program::Guard guard;
       discTrayTimer->setEnabled(false);
       auto tray = root->find<ares::Node::Port>("Mega CD/Disc Tray");
       tray->allocate();

--- a/desktop-ui/emulator/mega-ld.cpp
+++ b/desktop-ui/emulator/mega-ld.cpp
@@ -106,6 +106,7 @@ auto MegaLD::load(Menu menu) -> void {
 }
 
 auto MegaLD::changeDiskState(const string state) -> void {
+  Program::Guard guard;
   discTrayTimer->setEnabled(false);
   save();
   auto tray = root->find<ares::Node::Port>("Mega CD/Disc Tray");
@@ -114,6 +115,7 @@ auto MegaLD::changeDiskState(const string state) -> void {
   if(state == "No Disc") return;
 
   discTrayTimer->onActivate([&, state] {
+    Program::Guard guard;
     discTrayTimer->setEnabled(false);
     auto tray = root->find<ares::Node::Port>("Mega CD/Disc Tray");
     tray->allocate(state);

--- a/desktop-ui/emulator/nintendo-64.cpp
+++ b/desktop-ui/emulator/nintendo-64.cpp
@@ -188,6 +188,7 @@ auto Nintendo64::load(Menu menu) -> void {
     MenuItem changeDisk{&menu};
     changeDisk.setIcon(Icon::Device::Optical);
     changeDisk.setText("Change Disk").onActivate([&] {
+      Program::Guard guard;
       save();
       auto drive = root->find<ares::Node::Port>("Nintendo 64DD/Disk Drive");
       drive->disconnect();
@@ -198,6 +199,7 @@ auto Nintendo64::load(Menu menu) -> void {
 
       //give the emulator core a few seconds to notice an empty drive state before reconnecting
       diskInsertTimer->onActivate([&] {
+        Program::Guard guard;
         diskInsertTimer->setEnabled(false);
         auto drive = root->find<ares::Node::Port>("Nintendo 64DD/Disk Drive");
         drive->allocate();
@@ -221,6 +223,7 @@ auto Nintendo64::portMenu(Menu& portMenu, ares::Node::Port port) -> void {
   nothing.setText("Nothing");
   nothing.setAttribute<ares::Node::Port>("port", port);
   nothing.onActivate([=] {
+    Program::Guard guard;
     auto port = nothing.attribute<ares::Node::Port>("port");
     const string portName = port->name();
     if(auto port = emulator->root->find<ares::Node::Port>(portName)) {
@@ -235,6 +238,7 @@ auto Nintendo64::portMenu(Menu& portMenu, ares::Node::Port port) -> void {
   cpak.setAttribute<ares::Node::Port>("port", port);
   cpak.setText("Controller Pak");
   cpak.onActivate([=] {
+    Program::Guard guard;
     auto port = cpak.attribute<ares::Node::Port>("port");
     const string portName = port->name();
     if(auto port = emulator->root->find<ares::Node::Port>(portName)) {
@@ -258,6 +262,7 @@ auto Nintendo64::portMenu(Menu& portMenu, ares::Node::Port port) -> void {
   rpak.setAttribute<ares::Node::Port>("port", port);
   rpak.setText("Rumble Pak");
   rpak.onActivate([=] {
+    Program::Guard guard;
     auto port = rpak.attribute<ares::Node::Port>("port");
     const string portName = port->name();
     if(auto port = emulator->root->find<ares::Node::Port>(portName)) {
@@ -276,6 +281,7 @@ auto Nintendo64::portMenu(Menu& portMenu, ares::Node::Port port) -> void {
   tpak.setAttribute<ares::Node::Port>("port", port);
   tpak.setText("Transfer Pak");
   tpak.onActivate([=] {
+    Program::Guard guard;
     auto port = tpak.attribute<ares::Node::Port>("port");
     const string portName = port->name();
     if(auto port = emulator->root->find<ares::Node::Port>(portName)) {

--- a/desktop-ui/emulator/nintendo-64dd.cpp
+++ b/desktop-ui/emulator/nintendo-64dd.cpp
@@ -164,6 +164,7 @@ auto Nintendo64DD::load(Menu menu) -> void {
   MenuItem changeDisk{&menu};
   changeDisk.setIcon(Icon::Device::Optical);
   changeDisk.setText("Change Disk").onActivate([&] {
+    Program::Guard guard;
     save();
     auto drive = root->find<ares::Node::Port>("Nintendo 64DD/Disk Drive");
     drive->disconnect();
@@ -174,6 +175,7 @@ auto Nintendo64DD::load(Menu menu) -> void {
 
     //give the emulator core a few seconds to notice an empty drive state before reconnecting
     diskInsertTimer->onActivate([&] {
+      Program::Guard guard;
       diskInsertTimer->setEnabled(false);
       auto drive = root->find<ares::Node::Port>("Nintendo 64DD/Disk Drive");
       drive->allocate();

--- a/desktop-ui/emulator/playstation.cpp
+++ b/desktop-ui/emulator/playstation.cpp
@@ -138,6 +138,7 @@ auto PlayStation::load(Menu menu) -> void {
   MenuItem changeDisc{&menu};
   changeDisc.setIcon(Icon::Device::Optical);
   changeDisc.setText("Change Disc").onActivate([&] {
+    Program::Guard guard;
     save();
     auto tray = root->find<ares::Node::Port>("PlayStation/Disc Tray");
     tray->disconnect();
@@ -148,6 +149,7 @@ auto PlayStation::load(Menu menu) -> void {
 
     //give the emulator core a few seconds to notice an empty drive state before reconnecting
     discTrayTimer->onActivate([&] {
+      Program::Guard guard;
       discTrayTimer->setEnabled(false);
       auto tray = root->find<ares::Node::Port>("PlayStation/Disc Tray");
       tray->allocate();

--- a/desktop-ui/emulator/wonderswan-color.cpp
+++ b/desktop-ui/emulator/wonderswan-color.cpp
@@ -39,6 +39,7 @@ auto WonderSwanColor::load(Menu menu) -> void {
       MenuRadioItem item{&orientationMenu};
       item.setText(orientation);
       item.onActivate([=] {
+        Program::Guard guard;
         if(auto orientations = root->find<ares::Node::Setting::String>("PPU/Screen/Orientation")) {
           orientations->setValue(orientation);
         }

--- a/desktop-ui/emulator/wonderswan.cpp
+++ b/desktop-ui/emulator/wonderswan.cpp
@@ -39,6 +39,7 @@ auto WonderSwan::load(Menu menu) -> void {
       MenuRadioItem item{&orientationMenu};
       item.setText(orientation);
       item.onActivate([=] {
+        Program::Guard guard;
         if(auto orientations = root->find<ares::Node::Setting::String>("PPU/Screen/Orientation")) {
           orientations->setValue(orientation);
         }


### PR DESCRIPTION
Resolves a number of potential data races when activating system menus that affect the emulator's state.

Strictly speaking, this approach is a bit over-broad, since this means that the actions performed by these menu items will only occur between emulator run loops, while in real life obviously many of these events could occur at any arbitrary time during a system's execution. Until we decide we want to model that type of behavior, though, prefer to resolve these data races in case any of them are crash-prone.