### PR TITLE
desktop-ui: avoid overwriting paused status message

### DIFF
--- a/desktop-ui/program/status.cpp
+++ b/desktop-ui/program/status.cpp
@@ -17,7 +17,7 @@ auto Program::updateMessage() -> void {
     presentation.statusLeft.setText();
   }
 
-  if(vblanksPerSecond > 0) {
+  if(vblanksPerSecond > 0 && !paused) {
     presentation.statusRight.setText({ vblanksPerSecond.load(), " VPS" });
   }
 


### PR DESCRIPTION
When pause is toggled on, VPS may be written to the status bar after the "Paused" message, thus overwriting it. Easy fix to avoid that.