### PR TITLE
ares: Set up color settings before calling `colors()`

### DIFF
--- a/ares/gb/ppu/ppu.cpp
+++ b/ares/gb/ppu/ppu.cpp
@@ -30,14 +30,14 @@ auto PPU::load(Node::Object parent) -> void {
     screen->refreshRateHint(4 * 1024 * 1024, 456, 154);
 
     if(Model::GameBoy()) {
-      screen->colors(1 << 2, {&PPU::colorGameBoy, this});
-      screen->setFillColor(0);
-
       colorEmulationDMG = screen->append<Node::Setting::String>("Color Emulation", "Game Boy", [&](auto value) {
         screen->resetPalette();
       });
       colorEmulationDMG->setAllowedValues({"Game Boy", "Game Boy Pocket", "RGB"});
       colorEmulationDMG->setDynamic(true);
+
+      screen->colors(1 << 2, {&PPU::colorGameBoy, this});
+      screen->setFillColor(0);
 
       interframeBlending = screen->append<Node::Setting::Boolean>("Interframe Blending", true, [&](auto value) {
         screen->setInterframeBlending(value);
@@ -46,13 +46,13 @@ auto PPU::load(Node::Object parent) -> void {
     }
 
     if(Model::GameBoyColor()) {
-      screen->colors(1 << 15, {&PPU::colorGameBoyColor, this});
-      screen->setFillColor(0x7fff);
-
       colorEmulationCGB = screen->append<Node::Setting::Boolean>("Color Emulation", true, [&](auto value) {
         screen->resetPalette();
       });
       colorEmulationCGB->setDynamic(true);
+
+      screen->colors(1 << 15, {&PPU::colorGameBoyColor, this});
+      screen->setFillColor(0x7fff);
 
       interframeBlending = screen->append<Node::Setting::Boolean>("Interframe Blending", true, [&](auto value) {
         screen->setInterframeBlending(value);

--- a/ares/gba/ppu/ppu.cpp
+++ b/ares/gba/ppu/ppu.cpp
@@ -24,17 +24,18 @@ auto PPU::load(Node::Object parent) -> void {
   node = parent->append<Node::Object>("PPU");
 
   screen = node->append<Node::Video::Screen>("Screen", 240, 160);
+
+  colorEmulation = screen->append<Node::Setting::Boolean>("Color Emulation", true, [&](auto value) {
+    screen->resetPalette();
+  });
+  colorEmulation->setDynamic(true);
+
   screen->colors(1 << 15, {&PPU::color, this});
   screen->setSize(240, 160);
   screen->setScale(1.0, 1.0);
   screen->setAspect(1.0, 1.0);
   screen->setViewport(0, 0, 240, 160);
   screen->refreshRateHint(system.frequency() / 4, 308, 228);
-
-  colorEmulation = screen->append<Node::Setting::Boolean>("Color Emulation", true, [&](auto value) {
-    screen->resetPalette();
-  });
-  colorEmulation->setDynamic(true);
 
   interframeBlending = screen->append<Node::Setting::Boolean>("Interframe Blending", true, [&](auto value) {
     screen->setInterframeBlending(value);

--- a/ares/ms/vdp/vdp.cpp
+++ b/ares/ms/vdp/vdp.cpp
@@ -27,15 +27,15 @@ auto VDP::load(Node::Object parent) -> void {
   screen->refreshRateHint(system.colorburst() * 15, 3420, Region::PAL() ? 313 : 262);
 
   if(Display::CRT()) {
-    screen->colors(1 << 6, {&VDP::colorMasterSystem, this});
-    screen->setSize(284, screenHeight());
-    screen->setScale(1.0, 1.0);
-    Region::PAL() ? screen->setAspect(19.0, 14.0) : screen->setAspect(8.0, 7.0);
-
     colorEmulation = screen->append<Node::Setting::Boolean>("Color Emulation", true, [&](auto value) {
       screen->resetPalette();
     });
     colorEmulation->setDynamic(true);
+
+    screen->colors(1 << 6, {&VDP::colorMasterSystem, this});
+    screen->setSize(284, screenHeight());
+    screen->setScale(1.0, 1.0);
+    Region::PAL() ? screen->setAspect(19.0, 14.0) : screen->setAspect(8.0, 7.0);
   }
 
   if(Display::LCD()) {

--- a/ares/pce/vdp-performance/vdp.cpp
+++ b/ares/pce/vdp-performance/vdp.cpp
@@ -24,16 +24,17 @@ auto VDP::load(Node::Object parent) -> void {
   node = parent->append<Node::Object>("VDP");
 
   screen = node->append<Node::Video::Screen>("Screen", 1365, 263);
-  screen->colors(1 << 10, {&VDP::color, this});
-  screen->setSize(1128, 263);
-  screen->setScale(0.25, 1.0);
-  screen->setAspect(8.0, 7.0);
-  screen->refreshRateHint(60); // TODO: More accurate refresh rate hint
 
   colorEmulation = screen->append<Node::Setting::Boolean>("Color Emulation", true, [&](auto value) {
     screen->resetPalette();
   });
   colorEmulation->setDynamic(true);
+
+  screen->colors(1 << 10, {&VDP::color, this});
+  screen->setSize(1128, 263);
+  screen->setScale(0.25, 1.0);
+  screen->setAspect(8.0, 7.0);
+  screen->refreshRateHint(60); // TODO: More accurate refresh rate hint
 
   vce.debugger.load(vce, parent);
   vdc0.debugger.load(vdc0, parent); if(Model::SuperGrafx())

--- a/ares/pce/vdp/vdp.cpp
+++ b/ares/pce/vdp/vdp.cpp
@@ -39,16 +39,15 @@ auto VDP::load(Node::Object parent) -> void {
   node = parent->append<Node::Object>("VDP");
 
   screen = node->append<Node::Video::Screen>("Screen", 1365, 263);
+  colorEmulation = screen->append<Node::Setting::Boolean>("Color Emulation", true, [&](auto value) {
+    screen->resetPalette();
+  });
+  colorEmulation->setDynamic(true);
   screen->colors(1 << 10, {&VDP::color, this});
   screen->setSize(1128, 263);
   screen->setScale(0.25, 1.0);
   screen->setAspect(8.0, 7.0);
   screen->refreshRateHint(60); // TODO: More accurate refresh rate hint
-
-  colorEmulation = screen->append<Node::Setting::Boolean>("Color Emulation", true, [&](auto value) {
-    screen->resetPalette();
-  });
-  colorEmulation->setDynamic(true);
 
   vce.debugger.load(vce, node);
   vdc0.debugger.load(vdc0, node); if(Model::SuperGrafx())

--- a/ares/sfc/ppu-performance/ppu.cpp
+++ b/ares/sfc/ppu-performance/ppu.cpp
@@ -23,6 +23,10 @@ auto PPU::load(Node::Object parent) -> void {
   node = parent->append<Node::Object>("PPU");
 
   screen = node->append<Node::Video::Screen>("Screen", 564, height() * 2);
+  deepBlackBoost = screen->append<Node::Setting::Boolean>("Deep Black Boost", true, [&](auto value) {
+    screen->resetPalette();
+  });
+  deepBlackBoost->setDynamic(true);
   screen->colors(1 << 19, {&PPU::color, this});
   screen->setSize(564, height() * 2);
   screen->setScale(0.5, 0.5);
@@ -32,10 +36,6 @@ auto PPU::load(Node::Object parent) -> void {
   vramSize = node->append<Node::Setting::Natural>("VRAM", 64_KiB);
   vramSize->setAllowedValues({64_KiB, 128_KiB});
 
-  deepBlackBoost = screen->append<Node::Setting::Boolean>("Deep Black Boost", true, [&](auto value) {
-    screen->resetPalette();
-  });
-  deepBlackBoost->setDynamic(true);
   debugger.load(node);
 }
 

--- a/ares/sfc/ppu/ppu.cpp
+++ b/ares/sfc/ppu/ppu.cpp
@@ -34,6 +34,12 @@ auto PPU::load(Node::Object parent) -> void {
   node = parent->append<Node::Object>("PPU");
 
   screen = node->append<Node::Video::Screen>("Screen", 564, height() * 2);
+
+  deepBlackBoost = screen->append<Node::Setting::Boolean>("Deep Black Boost", true, [&](auto value) {
+    screen->resetPalette();
+  });
+  deepBlackBoost->setDynamic(true);
+
   screen->colors(1 << 19, {&PPU::color, this});
   screen->setSize(564, height() * 2);
   screen->setScale(0.5, 0.5);
@@ -48,11 +54,6 @@ auto PPU::load(Node::Object parent) -> void {
 
   vramSize = node->append<Node::Setting::Natural>("VRAM", 64_KiB);
   vramSize->setAllowedValues({64_KiB, 128_KiB});
-
-  deepBlackBoost = screen->append<Node::Setting::Boolean>("Deep Black Boost", true, [&](auto value) {
-    screen->resetPalette();
-  });
-  deepBlackBoost->setDynamic(true);
 
   debugger.load(node);
 }

--- a/ares/ws/ppu/ppu.cpp
+++ b/ares/ws/ppu/ppu.cpp
@@ -28,16 +28,17 @@ auto PPU::load(Node::Object parent) -> void {
   const u32 height = 144 + (Model::WonderSwan() ? 13 : 0);
 
   screen = node->append<Node::Video::Screen>("Screen", width, height);
-  screen->colors(1 << 12, {&PPU::color, this});
-  screen->setSize(width, height);
-  screen->setScale(1.0, 1.0);
-  screen->setAspect(1.0, 1.0);
-  screen->setFillColor(SoC::ASWAN() ? 0xfff : 0);
 
   colorEmulation = screen->append<Node::Setting::Boolean>("Color Emulation", true, [&](auto value) {
     screen->resetPalette();
   });
   colorEmulation->setDynamic(true);
+
+  screen->colors(1 << 12, {&PPU::color, this});
+  screen->setSize(width, height);
+  screen->setScale(1.0, 1.0);
+  screen->setAspect(1.0, 1.0);
+  screen->setFillColor(SoC::ASWAN() ? 0xfff : 0);
 
   interframeBlending = screen->append<Node::Setting::Boolean>("Interframe Blending", true, [&](auto value) {
     screen->setInterframeBlending(value);


### PR DESCRIPTION
778a327 caused the palette to be refreshed on any screen function that reset the palette, including `colors()`. In core initialization, several cores would call `colors()` before initializing the values of settings like Color Emulation or Deep Black Boost, which are depended on in those cores `color` functions. This PR initializes those settings prior to the `colors()` calls in those cores. Put more simply, if a core calls `colors()`, it must be ready for the `color` function it provided to be called.