### PR TITLE
Fix Controller "Nothing" checked state in portMenu

### DIFF
--- a/desktop-ui/presentation/presentation.cpp
+++ b/desktop-ui/presentation/presentation.cpp
@@ -563,6 +563,7 @@ auto Presentation::refreshSystemMenu() -> void {
     { MenuRadioItem peripheralItem{&portMenu};
       peripheralItem.setAttribute<ares::Node::Port>("port", port);
       peripheralItem.setText("Nothing");
+      if(!port->connected()) peripheralItem.setChecked();
       peripheralItem.onActivate([=] {
         auto port = peripheralItem.attribute<ares::Node::Port>("port");
         port->disconnect();


### PR DESCRIPTION
The code responsible for setting the checked state on controllers is skipped when there is nothing connected to the port:

```cpp
    //check the peripheral item menu option that is currently connected to said port
    if(auto connected = port->connected()) {
      for(auto peripheralItem : peripheralGroup.objects<MenuRadioItem>()) {
        if(peripheralItem.text() == connected->name()) peripheralItem.setChecked();
      }
    }
```

...so when "Nothing" is activated, it has no check:
<img width="1470" height="956" alt="Screenshot 2025-08-25 at 17 10 46" src="https://github.com/user-attachments/assets/5535fbe7-3490-45f9-b8e2-cad5aa801af5" />
