### PR TITLE
Improve N64 controller accessory handling

### DIFF
--- a/ares/n64/controller/gamepad/gamepad.hpp
+++ b/ares/n64/controller/gamepad/gamepad.hpp
@@ -2,6 +2,7 @@ struct Gamepad : Controller {
   Node::Port port;
   Node::Peripheral slot;
   VFS::Pak pak;
+  b1 pakDetectLatched;
   u8 bank;
   Memory::Writable ram;  //Toshiba TC55257DFL-85V
   Node::Input::Rumble motor;


### PR DESCRIPTION
**Extracted from https://github.com/ares-emulator/ares/pull/2166**

1. Properly reports the 0x03 status when a new N64 controller accessory has been inserted, which tells the software to re-detect the accessory type.
2. Properly prevents N64 accessory read/write commands to a newly-inserted Pak until identify is called.
3. Improves the N64 accessory read/write commands to accurately handle non-standard data lengths.

## Detecting an accessory change

N64 software's ability to determine when an accessory has changed relies on either:
* Controller disconnect is reported, which requires at least one "status" or "controller read" command between unplugging the current controller and plugging in the new one.
* 0x02 (Pak Absent) status is reported, which requires at least one "status" command between removing the current accessory and connecting the new one.
* 0x03 (Pak Inserted) status is reported, which allows detection of instantaneous accessory swaps.

Validated with the LibDragon joypadtest example ROM: [joypadtest.z64.zip](https://github.com/user-attachments/files/21976967/joypadtest.z64.zip)
To exercise, switch between "Controller Pak" and "Rumble Pak" in the "Controller Port 1" > "Pak" sub-menu. The detected accessory should change.

## Non-standard accessory read/write length

[The console behavior findings are posted in the N64brew Discord](https://discord.com/channels/205520502922543113/1336835549901885482/1411034121731309729)

## Menu improvements

This PR includes some additional cleanup of the `Nintendo64::portMenu` function:
* Hide "Pak" submenu when Mouse is connected
* Hide "Transfer Pak" option when Game Boy core is disabled
* Refactor "set currently enabled pak" logic
* Switch Paks without disconnecting + reconnecting Gamepad

