### PR TITLE
nall: remove memory ownership from string_view again

### DIFF
--- a/ares/ares/node/debugger/tracer/instruction.hpp
+++ b/ares/ares/node/debugger/tracer/instruction.hpp
@@ -71,7 +71,8 @@ struct Instruction : Tracer {
     if(!enabled()) return;
 
     if(_omitted) {
-      PlatformLog(shared(), {"[Omitted: ", _omitted, "]"});
+      auto message = string{ "[Omitted: ", _omitted, "]" };
+      PlatformLog(shared(), message);
       _omitted = 0;
     }
 

--- a/ares/component/processor/v30mz/disassembler.cpp
+++ b/ares/component/processor/v30mz/disassembler.cpp
@@ -17,7 +17,7 @@ auto V30MZ::disassembleInstruction(u16 ps, u16 pc) -> string {
     return offset;
   };
 
-  auto instruction = [&](string_view name) -> string {
+  auto instruction = [&](string name) -> string {
     if(name.size() >= 7) return name;
     return pad(name, -7);
   };

--- a/ares/n64/cpu/disassembler.cpp
+++ b/ares/n64/cpu/disassembler.cpp
@@ -148,7 +148,7 @@ auto CPU::Disassembler::SPECIAL() -> vector<string> {
   auto rtValue = [&] { return ipuRegisterValue(instruction >> 16 & 31); };
   auto rsValue = [&] { return ipuRegisterValue(instruction >> 21 & 31); };
 
-  auto ALU = [&](string_view name, string_view by) -> vector<string> {
+  auto ALU = [&](string_view name, string by) -> vector<string> {
     return {name, rdName(), rtValue(), by};
   };
 

--- a/ares/n64/rdp/render.cpp
+++ b/ares/n64/rdp/render.cpp
@@ -193,7 +193,8 @@ auto RDP::render() -> void {
     u64 op = fetch();
 
     if(debugger.tracer.command->enabled()) {
-      debugger.command({hex(op, 16L), "  ", commandNames(op >> 56 & 0x3f, "Invalid")});
+      auto message = string{ hex(op, 16L), "  ", commandNames(op >> 56 & 0x3f, "Invalid") };
+      debugger.command(message);
     }
 
     switch(op >> 56 & 0x3f) {

--- a/ares/n64/rsp/disassembler.cpp
+++ b/ares/n64/rsp/disassembler.cpp
@@ -149,7 +149,7 @@ auto RSP::Disassembler::SPECIAL() -> vector<string> {
   auto rtValue = [&] { return ipuRegisterValue(instruction >> 16 & 31); };
   auto rsValue = [&] { return ipuRegisterValue(instruction >> 21 & 31); };
 
-  auto ALU = [&](string_view name, string_view by) -> vector<string> {
+  auto ALU = [&](string_view name, string by) -> vector<string> {
     return {name, rdName(), rtValue(), by};
   };
 

--- a/ares/ngp/psg/psg.cpp
+++ b/ares/ngp/psg/psg.cpp
@@ -6,7 +6,8 @@ PSG psg;
 #include "serialization.cpp"
 
 auto PSG::writePitch(u32 pitch) -> void {
-  apu.debugger.interrupt(string{"writePitch ", pitch & 15, " ", pitch >> 4 & 63});
+  auto message = string{ "writePitch ", pitch & 15, " ", pitch >> 4 & 63 };
+  apu.debugger.interrupt(message);
 }
 
 auto PSG::load(Node::Object parent) -> void {

--- a/ares/ps1/cpu/disassembler.cpp
+++ b/ares/ps1/cpu/disassembler.cpp
@@ -119,7 +119,7 @@ auto CPU::Disassembler::SPECIAL() -> vector<string> {
   auto rtValue = [&] { return ipuRegisterValue(instruction >> 16 & 31); };
   auto rsValue = [&] { return ipuRegisterValue(instruction >> 21 & 31); };
 
-  auto ALU = [&](string_view name, string_view by) -> vector<string> {
+  auto ALU = [&](string_view name, string by) -> vector<string> {
     return {name, rdName(), rtValue(), by};
   };
 

--- a/desktop-ui/game-browser/game-browser.cpp
+++ b/desktop-ui/game-browser/game-browser.cpp
@@ -73,10 +73,11 @@ auto GameBrowserWindow::refresh() -> void {
   gameList.append(TableViewColumn().setText("MAME Name"));
 
   for(auto& game : games) {
-    if(searchInput.text().size()) {
-      if(!game.title.ifind(searchInput.text()) &&
-         !game.board.ifind(searchInput.text()) &&
-         !game.name.ifind(searchInput.text())) continue;
+    auto searchText = searchInput.text();
+    if(searchText.size()) {
+      if(!game.title.ifind(searchText) &&
+         !game.board.ifind(searchText) &&
+         !game.name.ifind(searchText)) continue;
     }
 
     TableViewItem item{&gameList};

--- a/desktop-ui/presentation/presentation.cpp
+++ b/desktop-ui/presentation/presentation.cpp
@@ -548,7 +548,8 @@ auto Presentation::refreshSystemMenu() -> void {
   u32 portsFound = 0;
   for(auto port : ares::Node::enumerate<ares::Node::Port>(emulator->root)) {
     //do not add unsupported ports to the port menu
-    if(emulator->portBlacklist.find(port->name())) continue;
+    auto portName = port->name();
+    if(emulator->portBlacklist.find(portName)) continue;
 
     if(!port->hotSwappable()) continue;
     if(port->type() != "Controller" && port->type() != "Expansion") continue;
@@ -746,7 +747,8 @@ auto Presentation::loadShaders() -> void {
 
   if(settings.video.shader.imatch("None")) {none.setChecked(); settings.video.shader = "None";}
   for(auto item : shaders.objects<MenuCheckItem>()) {
-    if(settings.video.shader.imatch(item.attribute("file"))) {
+    auto temp = item.attribute("file");
+    if(settings.video.shader.imatch(temp)) {
       item.setChecked();
       settings.video.shader = item.attribute("file");
       ruby::video.setShader({location, settings.video.shader});

--- a/desktop-ui/program/platform.cpp
+++ b/desktop-ui/program/platform.cpp
@@ -32,8 +32,9 @@ auto Program::event(ares::Event event) -> void {
 auto Program::log(ares::Node::Debugger::Tracer::Tracer node, string_view message) -> void {
   string channel = string{node->component(), " ", node->name()};
 
-  if(node->prefix()) { message = string{channel, ": ", message}; }
-  if(node->autoLineBreak()) message = string{message, "\n"};
+  string modifiedMessage;
+  if(node->prefix()) { message = modifiedMessage = string{channel, ": ", message}; }
+  if(node->autoLineBreak()) message = modifiedMessage = string{message, "\n"};
 
   if(node->terminal()) {
     print(message);

--- a/desktop-ui/settings/firmware.cpp
+++ b/desktop-ui/settings/firmware.cpp
@@ -28,7 +28,9 @@ auto FirmwareSettings::refresh() -> void {
       item.append(TableViewCell().setText(firmware.type));
       item.append(TableViewCell().setText(firmware.region));
       if(file::exists(firmware.location)) {
-        item.append(TableViewCell().setText(string{firmware.location}.replace(Path::user(), "~/")));
+        auto userPath = Path::user();
+        auto firmwareDisplayPath = string{ firmware.location }.replace(userPath, "~/");
+        item.append(TableViewCell().setText(firmwareDisplayPath));
       } else {
         item.append(TableViewCell().setText("(unset)").setForegroundColor(SystemColor::PlaceholderText));
       }

--- a/desktop-ui/settings/paths.cpp
+++ b/desktop-ui/settings/paths.cpp
@@ -118,12 +118,14 @@ auto PathSettings::construct() -> void {
 auto PathSettings::refresh() -> void {
   //simplifies pathnames by abbreviating the home folder and trailing slash
   auto pathname = [](string name) -> string {
-    if(name.beginsWith(Path::program())) {
-      name.trimLeft(Path::program(), 1L);
+    auto programPath = Path::program();
+    if(name.beginsWith(programPath)) {
+      name.trimLeft(programPath, 1L);
       name.prepend("./");
     }
-    if(name.beginsWith(Path::user())) {
-      name.trimLeft(Path::user(), 1L);
+    auto userPath = Path::user();
+    if(name.beginsWith(userPath)) {
+      name.trimLeft(userPath, 1L);
       name.prepend("~/");
     }
     if(name != "/") name.trimRight("/", 1L);

--- a/desktop-ui/settings/settings.cpp
+++ b/desktop-ui/settings/settings.cpp
@@ -26,14 +26,16 @@ DebugSettings& debugSettings = settingsWindow.debugSettings;
 DriverSettings& driverSettings = settingsWindow.driverSettings;
 
 auto Settings::load() -> void {
-  Markup::Node::operator=(BML::unserialize(string::read(locate("settings.bml")), " "));
+  auto settingsPath = locate("settings.bml");
+  Markup::Node::operator=(BML::unserialize(string::read(settingsPath), " "));
   process(true);
   save();
 }
 
 auto Settings::save() -> void {
   process(false);
-  file::write(locate("settings.bml"), BML::serialize(*this, " "));
+  auto settingsPath = locate("settings.bml");
+  file::write(settingsPath, BML::serialize(*this, " "));
 }
 
 auto Settings::process(bool load) -> void {

--- a/mia/medium/super-famicom.cpp
+++ b/mia/medium/super-famicom.cpp
@@ -89,7 +89,8 @@ auto SuperFamicom::load(string location) -> LoadResult {
   this->manifest = Medium::manifestDatabase(sha256);
   
   if(!manifest) {
-    auto local_manifest = location.replace({".", location.split(".").last()}, ".bml");
+    auto extension = string{ ".", location.split(".").last() };
+    auto local_manifest = location.replace(extension, ".bml");
     if (folder)
       local_manifest = directory.append("manifest.bml");
     if(file::exists(local_manifest)) {

--- a/mia/pak/pak.cpp
+++ b/mia/pak/pak.cpp
@@ -110,7 +110,8 @@ auto Pak::save(string name, string extension, string location) -> bool {
   if(!pak) return false;
   if(!location) location = this->location;
   if(auto save = pak->read(name)) {
-    directory::create(Location::dir(saveLocation(location, name, extension)));
+    auto saveFilePath = saveLocation(location, name, extension);
+    directory::create(Location::dir(saveFilePath));
     if(auto fp = file::open(saveLocation(location, name, extension), file::mode::write)) {
       fp.write({save->data(), save->size()});
       return true;

--- a/mia/program/game-manager.cpp
+++ b/mia/program/game-manager.cpp
@@ -10,7 +10,8 @@ GameManager::GameManager(View* parent) : Panel(parent, Size{~0, ~0}) {
     .selectFolder()
     ) {
       path = location;
-      pathLabel.setText(string{path}.replace(Path::user(), "~/"));
+      auto pathLabelTemp = string{path}.replace(Path::user(), "~/");
+      pathLabel.setText(pathLabelTemp);
       refresh();
     }
   });
@@ -33,7 +34,8 @@ GameManager::GameManager(View* parent) : Panel(parent, Size{~0, ~0}) {
 
 auto GameManager::select(string system) -> void {
   path = {Path::user(), "Emulation/", system, "/"};
-  pathLabel.setText(string{path}.replace(Path::user(), "~/"));
+  auto pathLabelTemp = string{path}.replace(Path::user(), "~/");
+  pathLabel.setText(pathLabelTemp);
   this->system = system;
   refresh();
 }

--- a/mia/program/game-manager.cpp
+++ b/mia/program/game-manager.cpp
@@ -36,7 +36,7 @@ GameManager::GameManager(View* parent) : Panel(parent, Size{~0, ~0}) {
 auto GameManager::select(string system) -> void {
   auto userPath = Path::user();
   path = {userPath, "Emulation/", system, "/"};
-  auto pathLabelTemp = string{path}.replace(Path::user(), "~/");
+  auto pathLabelTemp = string{path}.replace(userPath, "~/");
   pathLabel.setText(pathLabelTemp);
   this->system = system;
   refresh();

--- a/mia/program/game-manager.cpp
+++ b/mia/program/game-manager.cpp
@@ -10,7 +10,8 @@ GameManager::GameManager(View* parent) : Panel(parent, Size{~0, ~0}) {
     .selectFolder()
     ) {
       path = location;
-      auto pathLabelTemp = string{path}.replace(Path::user(), "~/");
+      auto userPath = Path::user();
+      auto pathLabelTemp = string{path}.replace(userPath, "~/");
       pathLabel.setText(pathLabelTemp);
       refresh();
     }
@@ -33,7 +34,8 @@ GameManager::GameManager(View* parent) : Panel(parent, Size{~0, ~0}) {
 }
 
 auto GameManager::select(string system) -> void {
-  path = {Path::user(), "Emulation/", system, "/"};
+  auto userPath = Path::user();
+  path = {userPath, "Emulation/", system, "/"};
   auto pathLabelTemp = string{path}.replace(Path::user(), "~/");
   pathLabel.setText(pathLabelTemp);
   this->system = system;

--- a/nall/nall/locale.hpp
+++ b/nall/nall/locale.hpp
@@ -56,7 +56,8 @@ struct Locale {
       }
     }
     for(u32 index : range(arguments.size())) {
-      input.replace({"{", index, "}"}, arguments[index]);
+      auto placeholderText = string{ "{", index, "}" };
+      input.replace(placeholderText, arguments[index]);
     }
     return input;
   }

--- a/nall/nall/string.hpp
+++ b/nall/nall/string.hpp
@@ -198,6 +198,7 @@ public:
   template<typename T, typename... P> auto prepend(const T&, P&&...) -> type&;
   template<typename... P> auto prepend(const nall::string_format&, P&&...) -> type&;
   template<typename T> auto _prepend(const stringify<T>&) -> type&;
+  template<typename... P> auto append(string&& value, P&&... p) -> string&;
   template<typename T, typename... P> auto append(const T&, P&&...) -> type&;
   template<typename... P> auto append(const nall::string_format&, P&&...) -> type&;
   template<typename T> auto _append(const stringify<T>&) -> type&;

--- a/nall/nall/string.hpp
+++ b/nall/nall/string.hpp
@@ -39,8 +39,7 @@ struct string_view {
   string_view(const char* data);
   string_view(const char* data, u32 size);
   string_view(const string& source);
-  template<typename... P> string_view(P&&... p);
-  ~string_view();
+  string_view(string&& source) = delete;
 
   auto operator=(const string_view& source) -> type&;
   auto operator=(string_view&& source) -> type&;
@@ -57,7 +56,6 @@ struct string_view {
   auto end() const { return &_data[size()]; }
 
 protected:
-  string* _string;
   const char* _data;
   mutable s32 _size;
 };

--- a/nall/nall/string/core.hpp
+++ b/nall/nall/string/core.hpp
@@ -56,6 +56,13 @@ template<typename T, typename... P> inline auto string::append(const T& value, P
   return *this;
 }
 
+template<typename... P> inline auto string::append(string&& value, P&&... p) -> string& {
+  const string& lvalue = value;
+  _append(make_string(lvalue));
+  if constexpr(sizeof...(p) > 0) append(std::forward<P>(p)...);
+  return *this;
+}
+
 template<typename... P> inline auto string::append(const nall::string_format& value, P&&... p) -> string& {
   format(value);
   if constexpr(sizeof...(p)) append(std::forward<P>(p)...);

--- a/nall/nall/string/transform/dml.hpp
+++ b/nall/nall/string/transform/dml.hpp
@@ -112,7 +112,8 @@ inline auto DML::parseBlock(string& block, const string& pathname, u32 depth) ->
 
   //header
   else if(auto depth = count(block, '#')) {
-    auto content = slice(lines.takeLeft(), depth + 1);
+    auto nextLine = lines.takeLeft();
+    auto content = slice(nextLine, depth + 1);
     auto data = markup(content);
     auto name = anchor(content);
     if(depth <= 5) {

--- a/nall/nall/string/view.hpp
+++ b/nall/nall/string/view.hpp
@@ -3,60 +3,40 @@
 namespace nall {
 
 inline string_view::string_view() {
-  _string = nullptr;
   _data = "";
   _size = 0;
 }
 
 inline string_view::string_view(const string_view& source) {
   if(this == &source) return;
-  _string = nullptr;
   _data = source._data;
   _size = source._size;
 }
 
 inline string_view::string_view(string_view&& source) {
   if(this == &source) return;
-  _string = source._string;
   _data = source._data;
   _size = source._size;
-  source._string = nullptr;
 }
 
 inline string_view::string_view(const char* data) {
-  _string = nullptr;
   _data = data;
   _size = -1;  //defer length calculation, as it is often unnecessary
 }
 
 //todo: this collides with eg: {"value: ", (u32)0}
 inline string_view::string_view(const char* data, u32 size) {
-  _string = nullptr;
   _data = data;
   _size = size;
 }
 
 inline string_view::string_view(const string& source) {
-  _string = nullptr;
   _data = source.data();
   _size = source.size();
 }
 
-template<typename... P>
-inline string_view::string_view(P&&... p) {
-  _string = new string{std::forward<P>(p)...};
-  _data = _string->data();
-  _size = _string->size();
-}
-
-inline string_view::~string_view() {
-  if(_string) delete _string;
-}
-
 inline auto string_view::operator=(const string_view& source) -> type& {
   if(this == &source) return *this;
-  if(_string) delete _string;
-  _string = nullptr;
   _data = source._data;
   _size = source._size;
   return *this;
@@ -64,11 +44,8 @@ inline auto string_view::operator=(const string_view& source) -> type& {
 
 inline auto string_view::operator=(string_view&& source) -> type& {
   if(this == &source) return *this;
-  if(_string) delete _string;
-  _string = source._string;
   _data = source._data;
   _size = source._size;
-  source._string = nullptr;
   return *this;
 }
 

--- a/tools/genius/genius.cpp
+++ b/tools/genius/genius.cpp
@@ -163,8 +163,8 @@ auto ListWindow::saveDatabase(string location) -> void {
 
   auto copy = games;
   copy.sort([](auto x, auto y) {
-    auto a = { x.name, "\n", x.region, "\n", x.revision };
-    auto b = { y.name, "\n", y.region, "\n", y.revision };
+    string a = { x.name, "\n", x.region, "\n", x.revision };
+    string b = { y.name, "\n", y.region, "\n", y.revision };
     return string::icompare(a, b) < 0;
   });
 

--- a/tools/genius/genius.cpp
+++ b/tools/genius/genius.cpp
@@ -163,10 +163,9 @@ auto ListWindow::saveDatabase(string location) -> void {
 
   auto copy = games;
   copy.sort([](auto x, auto y) {
-    return string::icompare(
-      {x.name, "\n", x.region, "\n", x.revision},
-      {y.name, "\n", y.region, "\n", y.revision}
-    ) < 0;
+    auto a = { x.name, "\n", x.region, "\n", x.revision };
+    auto b = { y.name, "\n", y.region, "\n", y.revision };
+    return string::icompare(a, b) < 0;
   });
 
   fp.print("database\n");


### PR DESCRIPTION
Removed owning string_view again, this time explicitly removing string_view construction from temporary string objects, which resulted in dangling pointers into temporary string buffers. Temporary strings must now be explicitly saved into named objects with clear lifetimes in order to implicitly convert to a string_view. While implicit conversion to a string_view may be safe in some cases due to the guaranteed lifetime of temporaries in C++ being the full expression, it's easy to still create problems when the conversion to a string_view is implicit, when the caller might believe they have passed in a string which has been copied, when in fact a reference to the provided string objects internal buffers has been captured. It's better to disallow this case, and let the programmer explicitly create an object with a clear lifetime, than risk dangling pointer issues.