### PR TITLE
build: Update dependencies

### DIFF
--- a/deps.json
+++ b/deps.json
@@ -1,14 +1,14 @@
 {
     "dependencies": {
         "prebuilt": {
-            "version": "2025-07-14",
+            "version": "2025-08-27",
             "baseUrl": "https://github.com/ares-emulator/ares-deps/releases/download",
             "label": "Pre-Built ares-deps",
             "hashes": {
-                "linux-universal": "c4679098d2a9cd51c1cacb70555e302e78501e481dcaabc060ca16d6f620128f",
-                "macos-universal": "a93cdd3b82b9fcdc7cc0047480a3dcc93f5ca198f48593f52138bba1f5ba6d77",
-                "windows-arm64": "c7d2e1d8f72f5b6add4e68bbbc684248cdc9556f9a27dbdf62a961b890eb52ea",
-                "windows-x64": "5fe3200331dc5d397b4a3080d3d2c86e2ace48e14b51a6e304c5ca75328726b3"
+                "linux-universal": "4a9e8258fc419e3ad41c9a8e8becd748a9d05eacfc4a8f3a47af17881588df97",
+                "macos-universal": "61ad0086b92bcc322074c74ac58e1a1425dc98900c30d0169835913f6f67218a",
+                "windows-arm64": "973088cb4289703f5c1f61c240ea0c691f5c8116d6424a8d300cfd861d57115d",
+                "windows-x64": "a869c0f4c2a873f69b1247f1928be72abf9558b86f03f7931f5844ea1eeb0921"
             }
         }
     },


### PR DESCRIPTION
* Updates SDL to version 3.2.20 on both macOS and Windows
* Updates slang-shaders to ref `c9303dc` on Linux, macOS and Windows
* Updates MoltenVK to 1.4.0 on macOS