### PR TITLE
build: Build project in C++20 mode

### DIFF
--- a/ares/component/processor/arm7tdmi/instruction.cpp
+++ b/ares/component/processor/arm7tdmi/instruction.cpp
@@ -442,8 +442,8 @@ auto ARM7TDMI::armInitialize() -> void {
 auto ARM7TDMI::thumbInitialize() -> void {
   #define bind(id, name, ...) { \
     assert(!thumbInstruction[id]); \
-    thumbInstruction[id] = [=] { return thumbInstruction##name(__VA_ARGS__); }; \
-    thumbDisassemble[id] = [=] { return thumbDisassemble##name(__VA_ARGS__); }; \
+    thumbInstruction[id] = [=, this] { return thumbInstruction##name(__VA_ARGS__); }; \
+    thumbDisassemble[id] = [=, this] { return thumbDisassemble##name(__VA_ARGS__); }; \
   }
 
   #define pattern(s) \

--- a/ares/component/processor/hg51b/instruction.cpp
+++ b/ares/component/processor/hg51b/instruction.cpp
@@ -1,8 +1,8 @@
 HG51B::HG51B() {
   #define bind(id, name, ...) { \
     if(instructionTable[id]) throw; \
-    instructionTable[id] = [=] { return instruction##name(__VA_ARGS__); }; \
-    disassembleTable[id] = [=] { return disassemble##name(__VA_ARGS__); }; \
+    instructionTable[id] = [=, this] { return instruction##name(__VA_ARGS__); }; \
+    disassembleTable[id] = [=, this] { return disassemble##name(__VA_ARGS__); }; \
   }
 
   #define pattern(s) \

--- a/ares/component/processor/m68000/instruction.cpp
+++ b/ares/component/processor/m68000/instruction.cpp
@@ -10,8 +10,8 @@ auto M68000::instruction() -> void {
 M68000::M68000() {
   #define bind(id, name, ...) { \
     assert(!instructionTable[id]); \
-    instructionTable[id] = [=] { return instruction##name(__VA_ARGS__); }; \
-    disassembleTable[id] = [=] { return disassemble##name(__VA_ARGS__); }; \
+    instructionTable[id] = [=, this] { return instruction##name(__VA_ARGS__); }; \
+    disassembleTable[id] = [=, this] { return disassemble##name(__VA_ARGS__); }; \
   }
 
   #define unbind(id) { \

--- a/ares/component/processor/sh2/recompiler.cpp
+++ b/ares/component/processor/sh2/recompiler.cpp
@@ -705,7 +705,7 @@ auto SH2::Recompiler::emitInstruction(u16 opcode) -> u32 {
 
   //BRA disp
   case range16(0xa0, 0xaf): {
-    checkDelaySlot([=] {
+    checkDelaySlot([=, this] {
       add32(PPC, PC, imm(4 + (i12)d12 * 2));
       mov32(PPM, imm(Branch::Slot));
     });
@@ -714,7 +714,7 @@ auto SH2::Recompiler::emitInstruction(u16 opcode) -> u32 {
 
   //BSR disp
   case range16(0xb0, 0xbf): {
-    checkDelaySlot([=] {
+    checkDelaySlot([=, this] {
       mov32(reg(0), PC);
       mov32(PR, reg(0));
       add32(reg(0), reg(0), imm(4 + (i12)d12 * 2));
@@ -807,7 +807,7 @@ auto SH2::Recompiler::emitInstruction(u16 opcode) -> u32 {
 
   //BT disp
   case 0x89: {
-    checkDelaySlot([=] {
+    checkDelaySlot([=, this] {
       auto skip = cmp32_jump(T, imm(0), flag_eq);
       add32(PPC, PC, imm(4 + (s8)d8 * 2));
       mov32(PPM, imm(Branch::Take));
@@ -818,7 +818,7 @@ auto SH2::Recompiler::emitInstruction(u16 opcode) -> u32 {
 
   //BF disp
   case 0x8b: {
-    checkDelaySlot([=] {
+    checkDelaySlot([=, this] {
       auto skip = cmp32_jump(T, imm(0), flag_ne);
       add32(PPC, PC, imm(4 + (s8)d8 * 2));
       mov32(PPM, imm(Branch::Take));
@@ -829,7 +829,7 @@ auto SH2::Recompiler::emitInstruction(u16 opcode) -> u32 {
 
   //BT/S disp
   case 0x8d: {
-    checkDelaySlot([=] {
+    checkDelaySlot([=, this] {
       auto skip = cmp32_jump(T, imm(0), flag_eq);
       add32(PPC, PC, imm(4 + (s8)d8 * 2));
       mov32(PPM, imm(Branch::Slot));
@@ -840,7 +840,7 @@ auto SH2::Recompiler::emitInstruction(u16 opcode) -> u32 {
 
   //BF/S disp
   case 0x8f: {
-    checkDelaySlot([=] {
+    checkDelaySlot([=, this] {
       auto skip = cmp32_jump(T, imm(0), flag_ne);
       add32(PPC, PC, imm(4 + (s8)d8 * 2));
       mov32(PPM, imm(Branch::Slot));
@@ -875,7 +875,7 @@ auto SH2::Recompiler::emitInstruction(u16 opcode) -> u32 {
 
   //TRAPA #imm
   case 0xc3: {
-    checkDelaySlot([=] {
+    checkDelaySlot([=, this] {
       getSR(reg(2));
       sub32(reg(1), R15, imm(4));
       mov32(R15, reg(1));
@@ -1022,7 +1022,7 @@ auto SH2::Recompiler::emitInstruction(u16 opcode) -> u32 {
 
   //BSRF Rm
   case 0x003: {
-    checkDelaySlot([=] {
+    checkDelaySlot([=, this] {
       mov32(reg(0), PC);
       mov32(PR, reg(0));
       add32(reg(0), reg(0), Rm);
@@ -1059,7 +1059,7 @@ auto SH2::Recompiler::emitInstruction(u16 opcode) -> u32 {
 
   //BRAF Rm
   case 0x023: {
-    checkDelaySlot([=] {
+    checkDelaySlot([=, this] {
       add32(reg(0), PC, Rm);
       add32(reg(0), reg(0), imm(4));
       mov32(PPC, reg(0));
@@ -1168,7 +1168,7 @@ auto SH2::Recompiler::emitInstruction(u16 opcode) -> u32 {
 
   //JSR @Rm
   case 0x40b: {
-    checkDelaySlot([=] {
+    checkDelaySlot([=, this] {
       mov32(PR, PC);
       add32(PPC, Rm, imm(4));
       mov32(PPM, imm(Branch::Slot));
@@ -1370,7 +1370,7 @@ auto SH2::Recompiler::emitInstruction(u16 opcode) -> u32 {
 
   //JMP @Rm
   case 0x42b: {
-    checkDelaySlot([=] {
+    checkDelaySlot([=, this] {
       add32(PPC, Rm, imm(4));
       mov32(PPM, imm(Branch::Slot));
     });
@@ -1405,7 +1405,7 @@ auto SH2::Recompiler::emitInstruction(u16 opcode) -> u32 {
 
   //RTS
   case 0x000b: {
-    checkDelaySlot([=] {
+    checkDelaySlot([=, this] {
       add32(PPC, PR, imm(4));
       mov32(PPM, imm(Branch::Slot));
     });
@@ -1447,7 +1447,7 @@ auto SH2::Recompiler::emitInstruction(u16 opcode) -> u32 {
 
   //RTE
   case 0x002b: {
-    checkDelaySlot([=] {
+    checkDelaySlot([=, this] {
       mov32(reg(1), R15);
       add32(R15, reg(1), imm(4));
       call(readL);

--- a/cmake/common/compiler_common.cmake
+++ b/cmake/common/compiler_common.cmake
@@ -45,6 +45,7 @@ set(CMAKE_VISIBILITY_INLINES_HIDDEN TRUE)
 set(
   _ares_clang_common_options
   -fno-strict-aliasing
+  -fno-char8_t
   -Wblock-capture-autoreleasing
   # -Wswitch
   -Wdeprecated
@@ -100,7 +101,7 @@ set(
   -Wno-delete-non-abstract-non-virtual-dtor
 )
 
-set(_ares_gcc_common_options -fwrapv -fno-strict-aliasing -Wno-unused-result -Wno-stringop-overflow)
+set(_ares_gcc_common_options -fwrapv -fno-strict-aliasing -Wno-unused-result -Wno-stringop-overflow -fno-char8_t)
 
 if(NOT DEFINED CMAKE_COMPILE_WARNING_AS_ERROR)
   set(CMAKE_COMPILE_WARNING_AS_ERROR OFF)

--- a/cmake/common/compiler_common.cmake
+++ b/cmake/common/compiler_common.cmake
@@ -30,10 +30,10 @@ else()
   message(STATUS "Checking if interprocedural optimization is supported - skipped")
 endif()
 
-# Set C and C++ language standards to C17 and C++17
+# Set C and C++ language standards to C17 and C++20
 set(CMAKE_C_STANDARD 17)
 set(CMAKE_C_STANDARD_REQUIRED TRUE)
-set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED TRUE)
 
 # Set symbols to be hidden by default for C and C++

--- a/cmake/windows/compilerconfig.cmake
+++ b/cmake/windows/compilerconfig.cmake
@@ -53,6 +53,7 @@ set(
   /wd4805 # unsafe mix of types in operation
   /MP
   /Zc:__cplusplus
+  /Zc:char8_t-
   /utf-8
   /permissive-
   $<$<NOT:$<CONFIG:Debug>>:/GS->

--- a/desktop-ui/emulator/famicom-disk-system.cpp
+++ b/desktop-ui/emulator/famicom-disk-system.cpp
@@ -77,7 +77,7 @@ auto FamicomDiskSystem::changeDiskState(string state) -> void
   emulator->notify("Ejected");
   if(state != "Ejected") {
     print("Setting disk change timer\n");
-    diskChangeTimer->onActivate([=] {
+    diskChangeTimer->onActivate([=, this] {
       Program::Guard guard;
       print("Disk change timer activated, setting disk state to: ", state, "\n");
       diskChangeTimer->setEnabled(false);

--- a/desktop-ui/emulator/game-boy-advance.cpp
+++ b/desktop-ui/emulator/game-boy-advance.cpp
@@ -41,7 +41,7 @@ auto GameBoyAdvance::load(Menu menu) -> void {
     for(auto& orientation : orientations->readAllowedValues()) {
       MenuRadioItem item{&orientationMenu};
       item.setText(orientation);
-      item.onActivate([=] {
+      item.onActivate([=, this] {
         Program::Guard guard;
         if(auto orientations = root->find<ares::Node::Setting::String>("PPU/Screen/Orientation")) {
           orientations->setValue(orientation);

--- a/desktop-ui/emulator/game-boy.cpp
+++ b/desktop-ui/emulator/game-boy.cpp
@@ -61,7 +61,7 @@ auto GameBoy::load(Menu menu) -> void {
       for(auto& setting : options->readAllowedValues()) {
         MenuRadioItem item{&colorEmulationMenu};
         item.setText(setting);
-        item.onActivate([=] {
+        item.onActivate([=, this] {
           Program::Guard guard;
           if(auto settings = root->find<ares::Node::Setting::String>("PPU/Screen/Color Emulation")) {
             settings->setValue(setting);
@@ -73,7 +73,7 @@ auto GameBoy::load(Menu menu) -> void {
 
     if(auto headphones = root->find<ares::Node::Setting::Boolean>("Headphones")) {
         MenuCheckItem headphoneItem{&menu};
-        headphoneItem.setText("Headphones").setChecked(headphones->value()).onToggle([=] {
+      headphoneItem.setText("Headphones").setChecked(headphones->value()).onToggle([=, this] {
             if(auto headphones = root->find<ares::Node::Setting::Boolean>("Headphones")) {
                 headphones->setValue(headphoneItem.checked());
             }

--- a/desktop-ui/emulator/msx.cpp
+++ b/desktop-ui/emulator/msx.cpp
@@ -92,7 +92,7 @@ auto MSX::load() -> LoadResult {
 auto MSX::load(Menu menu) -> void {
   if(auto playing = root->find<ares::Node::Setting::Boolean>("Tape Deck/Playing")) {
     MenuCheckItem playingItem{&menu};
-    playingItem.setText("Play Tape").setChecked(playing->value()).onToggle([=] {
+    playingItem.setText("Play Tape").setChecked(playing->value()).onToggle([=, this] {
       if(auto playing = root->find<ares::Node::Setting::Boolean>("Tape Deck/Playing")) {
         playing->setValue(playingItem.checked());
       }

--- a/desktop-ui/emulator/wonderswan-color.cpp
+++ b/desktop-ui/emulator/wonderswan-color.cpp
@@ -38,7 +38,7 @@ auto WonderSwanColor::load(Menu menu) -> void {
     for(auto& orientation : orientations->readAllowedValues()) {
       MenuRadioItem item{&orientationMenu};
       item.setText(orientation);
-      item.onActivate([=] {
+      item.onActivate([=, this] {
         Program::Guard guard;
         if(auto orientations = root->find<ares::Node::Setting::String>("PPU/Screen/Orientation")) {
           orientations->setValue(orientation);
@@ -50,7 +50,7 @@ auto WonderSwanColor::load(Menu menu) -> void {
 
   if(auto headphones = root->find<ares::Node::Setting::Boolean>("Headphones")) {
     MenuCheckItem headphoneItem{&menu};
-    headphoneItem.setText("Headphones").setChecked(headphones->value()).onToggle([=] {
+    headphoneItem.setText("Headphones").setChecked(headphones->value()).onToggle([=, this] {
       if(auto headphones = root->find<ares::Node::Setting::Boolean>("Headphones")) {
         headphones->setValue(headphoneItem.checked());
       }

--- a/desktop-ui/emulator/wonderswan.cpp
+++ b/desktop-ui/emulator/wonderswan.cpp
@@ -38,7 +38,7 @@ auto WonderSwan::load(Menu menu) -> void {
     for(auto& orientation : orientations->readAllowedValues()) {
       MenuRadioItem item{&orientationMenu};
       item.setText(orientation);
-      item.onActivate([=] {
+      item.onActivate([=, this] {
         Program::Guard guard;
         if(auto orientations = root->find<ares::Node::Setting::String>("PPU/Screen/Orientation")) {
           orientations->setValue(orientation);
@@ -50,7 +50,7 @@ auto WonderSwan::load(Menu menu) -> void {
 
   if(auto headphones = root->find<ares::Node::Setting::Boolean>("Headphones")) {
     MenuCheckItem headphoneItem{&menu};
-    headphoneItem.setText("Headphones").setChecked(headphones->value()).onToggle([=] {
+    headphoneItem.setText("Headphones").setChecked(headphones->value()).onToggle([=, this] {
       if(auto headphones = root->find<ares::Node::Setting::Boolean>("Headphones")) {
         headphones->setValue(headphoneItem.checked());
       }

--- a/desktop-ui/emulator/zx-spectrum.cpp
+++ b/desktop-ui/emulator/zx-spectrum.cpp
@@ -41,7 +41,7 @@ auto ZXSpectrum::load() -> LoadResult {
 auto ZXSpectrum::load(Menu menu) -> void {
   if(auto playing = root->find<ares::Node::Setting::Boolean>("Tape Deck/Playing")) {
     MenuCheckItem playingItem{&menu};
-      playingItem.setText("Play Tape").setChecked(playing->value()).onToggle([=] {
+    playingItem.setText("Play Tape").setChecked(playing->value()).onToggle([=, this] {
       if(auto playing = root->find<ares::Node::Setting::Boolean>("Tape Deck/Playing")) {
         playing->setValue(playingItem.checked());
       }

--- a/desktop-ui/presentation/presentation.cpp
+++ b/desktop-ui/presentation/presentation.cpp
@@ -17,7 +17,7 @@ Presentation::Presentation() {
   for(u32 multiplier : range(1, multipliers + 1)) {
     MenuRadioItem item{&videoSizeMenu};
     item.setText({multiplier, "x"});
-    item.onActivate([=] {
+    item.onActivate([=, this] {
       settings.video.multiplier = multiplier;
       resizeWindow();
     });
@@ -152,7 +152,7 @@ Presentation::Presentation() {
   saveStateMenu.setText("Save State").setIcon(Icon::Media::Record);
   for(u32 slot : range(9)) {
     MenuItem item{&saveStateMenu};
-    item.setText({"Slot ", 1 + slot}).onActivate([=] {
+    item.setText({"Slot ", 1 + slot}).onActivate([=, this] {
       Program::Guard guard;
       if(program.stateSave(1 + slot)) {
         undoSaveStateMenu.setEnabled(true);
@@ -162,7 +162,7 @@ Presentation::Presentation() {
   loadStateMenu.setText("Load State").setIcon(Icon::Media::Rewind);
   for(u32 slot : range(9)) {
     MenuItem item{&loadStateMenu};
-    item.setText({"Slot ", 1 + slot}).onActivate([=] {
+    item.setText({"Slot ", 1 + slot}).onActivate([=, this] {
       Program::Guard guard;
       if(program.stateLoad(1 + slot)) {
         undoLoadStateMenu.setEnabled(true);
@@ -379,7 +379,7 @@ auto Presentation::loadEmulators() -> void {
       auto location = entry.split(";", 1L)(1);
       item.setIconForFile(location);
       item.setText({Location::base(location).trimRight("/"), " (", system, ")"});
-      item.onActivate([=] {
+      item.onActivate([=, this] {
         Program::Guard guard;
         if(!inode::exists(location)) {
           MessageDialog()
@@ -564,7 +564,7 @@ auto Presentation::refreshSystemMenu() -> void {
       peripheralItem.setAttribute<ares::Node::Port>("port", port);
       peripheralItem.setText("Nothing");
       if(!port->connected()) peripheralItem.setChecked();
-      peripheralItem.onActivate([=] {
+      peripheralItem.onActivate([=, this] {
         auto port = peripheralItem.attribute<ares::Node::Port>("port");
         port->disconnect();
         refreshSystemMenu();
@@ -578,7 +578,7 @@ auto Presentation::refreshSystemMenu() -> void {
       MenuRadioItem peripheralItem{&portMenu};
       peripheralItem.setAttribute<ares::Node::Port>("port", port);
       peripheralItem.setText(peripheral);
-      peripheralItem.onActivate([=] {
+      peripheralItem.onActivate([=, this] {
         auto port = peripheralItem.attribute<ares::Node::Port>("port");
         port->disconnect();
         port->allocate(peripheralItem.text());
@@ -709,7 +709,7 @@ auto Presentation::loadShaders() -> void {
       for(auto &file: files) {
         MenuCheckItem item{&parent};
         item.setAttribute("file", {directory, file});
-        item.setText(string{file}.trimRight(".slangp", 1L)).onToggle([=] {
+        item.setText(string{file}.trimRight(".slangp", 1L)).onToggle([=, this] {
           settings.video.shader = {directory, file};
           ruby::video.setShader({location, settings.video.shader});
           loadShaders();


### PR DESCRIPTION
(based on #2183)

Moves ares from C++17 to C++20.

C++20 deprecates the implicit capture of `this` in lambdas; this PR also resolves warnings related to that. Warnings related to bitwise arithmetic between unnamed enums of different types remain currently unresolved.

Also adds `-fno-char8_t` and its MSVC equivalent to prevent `char8_t` and friends from leaking into the codebase. No ares code currently appears to make use of these types.

Basic testing has been performed on macOS and Windows. Functional issues or changes are not anticipated.