### PR TITLE
hiro: fix undefined behavior converting negative coordinates to u32

### DIFF
--- a/hiro/cocoa/widget/widget.cpp
+++ b/hiro/cocoa/widget/widget.cpp
@@ -58,10 +58,10 @@ auto pWidget::setFont(const Font& font) -> void {
 auto pWidget::setGeometry(Geometry geometry) -> void {
   CGFloat windowHeight = [[cocoaView superview] frame].size.height;
   //round coordinates
-  u32 x = geometry.x();
-  u32 y = windowHeight - geometry.y() - geometry.height();
-  u32 width = geometry.width();
-  u32 height = geometry.height();
+  f32 x = geometry.x();
+  f32 y = windowHeight - geometry.y() - geometry.height();
+  f32 width = geometry.width();
+  f32 height = geometry.height();
   [cocoaView setFrame:NSMakeRect(x, y, width, height)];
   [[cocoaView superview] setNeedsDisplay:YES];
   pSizable::setGeometry(geometry);


### PR DESCRIPTION
ubsan on Mac caught an issue in this method: all geometry coordinates are floats out and into Cocoa, but intermediate calculations were being performed with u32 that caused undefined behavior when negative numbers were involved.