### PR TITLE
gba: improve handling of MEMCNT register

### DIFF
--- a/ares/gba/cpu/cpu.hpp
+++ b/ares/gba/cpu/cpu.hpp
@@ -69,7 +69,6 @@ struct CPU : ARM7TDMI, Thread, IO {
   auto setDMA(u32 mode, n32 address, n32 word) -> void;
   auto lock() -> void override;
   auto unlock() -> void override;
-  auto waitEWRAM(u32 mode) -> u32;
   auto waitCartridge(n32 address, bool sequential) -> u32;
   template<bool IsDMA> auto checkBurst(u32 mode) -> bool;
 
@@ -77,10 +76,10 @@ struct CPU : ARM7TDMI, Thread, IO {
   auto readIO(n32 address) -> n8 override;
   auto writeIO(n32 address, n8 byte) -> void override;
 
-  auto readIWRAM(u32 mode, n32 address) -> n32;
+  template<bool UseDebugger> auto readIWRAM(u32 mode, n32 address) -> n32;
   auto writeIWRAM(u32 mode, n32 address, n32 word) -> void;
 
-  auto readEWRAM(u32 mode, n32 address) -> n32;
+  template<bool UseDebugger> auto readEWRAM(u32 mode, n32 address) -> n32;
   auto writeEWRAM(u32 mode, n32 address, n32 word) -> void;
 
   template<bool UseDebugger> auto readPRAM(u32 mode, n32 address) -> n32;
@@ -249,7 +248,8 @@ struct CPU : ARM7TDMI, Thread, IO {
 
   struct Memory {
     n1 biosSwap;
-    n3 unknown1;
+    n2 unknown1;
+    n1 cgbBootRomDisable;
     n1 ewram = 1;
     n4 ewramWait = 13;
     n4 unknown2;

--- a/ares/gba/cpu/io.cpp
+++ b/ares/gba/cpu/io.cpp
@@ -229,9 +229,10 @@ auto CPU::readIO(n32 address) -> n8 {
 
   //MEMCNT_L
   case 0x0400'0800: return (
-    memory.biosSwap << 0
-  | memory.unknown1 << 1
-  | memory.ewram    << 5
+    memory.biosSwap          << 0
+  | memory.unknown1          << 1
+  | memory.cgbBootRomDisable << 3
+  | memory.ewram             << 5
   );
   case 0x0400'0801: return 0;
 
@@ -457,9 +458,10 @@ auto CPU::writeIO(n32 address, n8 data) -> void {
   //MEMCNT_L
   //MEMCNT_H
   case 0x0400'0800:
-    memory.biosSwap = data.bit(0);
-    memory.unknown1 = data.bit(1,3);
-    memory.ewram    = data.bit(5);
+    memory.biosSwap          = data.bit(0);
+    memory.unknown1          = data.bit(1,2);
+    memory.cgbBootRomDisable = data.bit(3);
+    memory.ewram             = data.bit(5);
     return;
   case 0x0400'0801: return;
   case 0x0400'0802: return;

--- a/ares/gba/cpu/memory.cpp
+++ b/ares/gba/cpu/memory.cpp
@@ -1,51 +1,73 @@
+template <bool UseDebugger>
 auto CPU::readIWRAM(u32 mode, n32 address) -> n32 {
-  if(mode & Word) return readIWRAM(Half, address &~ 2) << 0 | readIWRAM(Half, address | 2) << 16;
-  if(mode & Half) return readIWRAM(Byte, address &~ 1) << 0 | readIWRAM(Byte, address | 1) <<  8;
+  if constexpr(!UseDebugger) prefetchStep(1);
+  n32 word;
+  if(mode & Word) {
+    address &= 0x7ffc;
+    word = iwram[address + 0] << 0 | iwram[address + 1] << 8 | iwram[address + 2] << 16 | iwram[address + 3] << 24;
+  } else if(mode & Half) {
+    address &= 0x7ffe;
+    word = iwram[address + 0] << 0 | iwram[address + 1] << 8;
+  } else {
+    address &= 0x7fff;
+    word = iwram[address];
+  }
 
-  return iwram[address & 0x7fff];
+  return word;
 }
 
 auto CPU::writeIWRAM(u32 mode, n32 address, n32 word) -> void {
+  prefetchStep(1);
   if(mode & Word) {
-    writeIWRAM(Half, address &~2, word >>  0);
-    writeIWRAM(Half, address | 2, word >> 16);
+    address &= 0x7ffc;
+    iwram[address + 0] = word >>  0;
+    iwram[address + 1] = word >>  8;
+    iwram[address + 2] = word >> 16;
+    iwram[address + 3] = word >> 24;
     return;
+  } else if(mode & Half) {
+    address &= 0x7ffe;
+    iwram[address + 0] = word >> 0;
+    iwram[address + 1] = word >> 8;
+  } else {
+    address &= 0x7fff;
+    iwram[address] = word;
   }
-
-  if(mode & Half) {
-    writeIWRAM(Byte, address &~1, word >>  0);
-    writeIWRAM(Byte, address | 1, word >>  8);
-    return;
-  }
-
-  iwram[address & 0x7fff] = word;
 }
 
+template <bool UseDebugger>
 auto CPU::readEWRAM(u32 mode, n32 address) -> n32 {
-  if(!memory.ewram) return readIWRAM(mode, address);
+  if(!memory.ewram) return readIWRAM<UseDebugger>(mode, address);
+  if(mode & Word) return readEWRAM<UseDebugger>(Half, address &~ 2) << 0 | readEWRAM<UseDebugger>(Half, address | 2) << 16;
 
-  if(mode & Word) return readEWRAM(Half, address &~ 2) << 0 | readEWRAM(Half, address | 2) << 16;
-  if(mode & Half) return readEWRAM(Byte, address &~ 1) << 0 | readEWRAM(Byte, address | 1) <<  8;
+  if constexpr(!UseDebugger) prefetchStep(16 - memory.ewramWait);
+  n16 half;
+  address &= 0x3ffff;
+  if(mode & Half) {
+    half = ewram[address & ~1] << 0 | ewram[address | 1] << 8;
+  } else {
+    half = ewram[address];
+  }
 
-  return ewram[address & 0x3ffff];
+  return half;
 }
 
 auto CPU::writeEWRAM(u32 mode, n32 address, n32 word) -> void {
   if(!memory.ewram) return writeIWRAM(mode, address, word);
-
   if(mode & Word) {
     writeEWRAM(Half, address &~2, word >>  0);
     writeEWRAM(Half, address | 2, word >> 16);
     return;
   }
 
+  prefetchStep(16 - memory.ewramWait);
+  address &= 0x3ffff;
   if(mode & Half) {
-    writeEWRAM(Byte, address &~1, word >>  0);
-    writeEWRAM(Byte, address | 1, word >>  8);
-    return;
+    ewram[address & ~1] = word >> 0;
+    ewram[address |  1] = word >> 8;
+  } else {
+    ewram[address & 0x3ffff] = word;
   }
-
-  ewram[address & 0x3ffff] = word;
 }
 
 template <bool UseDebugger>
@@ -53,10 +75,12 @@ auto CPU::readPRAM(u32 mode, n32 address) -> n32 {
   if(mode & Word) return readPRAM<UseDebugger>(Half, address & ~2) << 0 | readPRAM<UseDebugger>(Half, address | 2) << 16;
 
   //stall until PPU is no longer accessing PRAM (minimum 1 cycle)
-  do {
-    prefetchStep(1);
-    synchronize(ppu);
-  } while(ppu.pramContention());
+  if constexpr(!UseDebugger) {
+    do {
+      prefetchStep(1);
+      synchronize(ppu);
+    } while(ppu.pramContention());
+  }
 
   return ppu.readPRAM(mode, address);
 }
@@ -82,10 +106,12 @@ auto CPU::readVRAM(u32 mode, n32 address) -> n32 {
   if(mode & Word) return readVRAM<UseDebugger>(Half, address & ~2) << 0 | readVRAM<UseDebugger>(Half, address | 2) << 16;
 
   //stall until PPU is no longer accessing VRAM (minimum 1 cycle)
-  do {
-    prefetchStep(1);
-    synchronize(ppu);
-  } while(ppu.vramContention(address));
+  if constexpr(!UseDebugger) {
+    do {
+      prefetchStep(1);
+      synchronize(ppu);
+    } while(ppu.vramContention(address));
+  }
 
   return ppu.readVRAM(mode, address);
 }

--- a/ares/gba/cpu/serialization.cpp
+++ b/ares/gba/cpu/serialization.cpp
@@ -101,6 +101,7 @@ auto CPU::serialize(serializer& s) -> void {
 
   s(memory.biosSwap);
   s(memory.unknown1);
+  s(memory.cgbBootRomDisable);
   s(memory.ewram);
   s(memory.ewramWait);
   s(memory.unknown2);

--- a/ares/gba/system/serialization.cpp
+++ b/ares/gba/system/serialization.cpp
@@ -1,4 +1,4 @@
-static const string SerializerVersion = "v146";
+static const string SerializerVersion = "v146.1";
 
 auto System::serialize(bool synchronize) -> serializer {
   if(synchronize) scheduler.enter(Scheduler::Mode::Synchronize);


### PR DESCRIPTION
Fixes a couple bugs with how ares handles MEMCNT, namely:
- I/O accesses at addresses `0x04000801` through `0x04000803` were erroneously treated as open bus
- Accessing IWRAM at addresses `0x02000000` through `0x02ffffff` when EWRAM is disabled should use IWRAM access timings

Also fixes a bug where instruction tracer accesses to VRAM and PRAM could advance the CPU state.