### PR TITLE
recompiler: remove static_assert(false) from a template

### DIFF
--- a/nall/nall/recompiler/generic/encoder-calls.hpp
+++ b/nall/nall/recompiler/generic/encoder-calls.hpp
@@ -128,10 +128,9 @@
       lea(dst, sreg(i), src.snd);
     } else if constexpr (std::is_same_v<T, imm>) {
       sljit_emit_op1(compiler, SLJIT_MOV32, dst.fst, dst.snd, src.fst, src.snd);
-    } else if constexpr (std::is_same_v<T, imm64>) {
-      sljit_emit_op1(compiler, SLJIT_MOV, dst.fst, dst.snd, SLJIT_IMM, src.data);
     } else {
-      static_assert(false, "unknown function argument type");
+      static_assert(std::is_same_v<T, imm64>, "unknown function argument type");
+      sljit_emit_op1(compiler, SLJIT_MOV, dst.fst, dst.snd, SLJIT_IMM, src.data);
     }
   }
 


### PR DESCRIPTION
This is a fix that was supposed to go in as part of https://github.com/ares-emulator/ares/pull/2133 but got missing due to a rebase mishap.

---

I had to change the setup_arg template function to check unknown types a bit differently because static_assert is evaluated before instantiation https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2023/p2593r1.html

GCC evaluated the always failing assert before the constexprs leading to it, resulting in a compilation failure. As a workaround, we can move the 'imm64' case inside the else block and check for the type there, which also catches unhandled types at compile time.