### PR TITLE
n64: fix PIF HLE on RX flag clearing

### DIFF
--- a/ares/n64/pif/hle.cpp
+++ b/ares/n64/pif/hle.cpp
@@ -144,9 +144,10 @@ auto PIF::joyRun() -> void {
       continue;
     }
     u32 recvOffset = offset;
-    n8 recv = ram.read<Byte>(offset++);
+    n8 recv = ram.read<Byte>(offset);
     send &= 0x3f;
     recv &= 0x3f;
+    ram.write<Byte>(offset++, recv);
 
     n8 input[64];
     for(u32 index : range(send)) {


### PR DESCRIPTION
When beginning to execute a joybus frame, PIF clears the RX flags before
the transaction begins, so that errors notified in previous transactions
don't accumulate.

This is only visible in the where an application performs multiple
transactions (SI DMA reads) on the same frame layout (sent via a single
SI DMA write), while controllers are being hotplugged. This is not very
common in Ares, which is probably why it was not noticed before.