### PR TITLE
fc: APU fixes

### DIFF
--- a/ares/fc/apu/apu.cpp
+++ b/ares/fc/apu/apu.cpp
@@ -73,7 +73,7 @@ auto APU::tick() -> void {
 }
 
 auto APU::setIRQ() -> void {
-  cpu.apuLine(frame.irqPending | dmc.irqPending);
+  cpu.apuLine((frame.irqPending & ~frame.irqInhibit) | dmc.irqPending);
 }
 
 auto APU::power(bool reset) -> void {
@@ -103,8 +103,7 @@ auto APU::readIO(n16 address) -> n8 {
     //bit 5 is open bus
     data.bit(6) = frame.irqPending;
     data.bit(7) = dmc.irqPending;
-    frame.irqPending = false;
-    setIRQ();
+    frame.delayIRQ = true;
     return data;
   }
 

--- a/ares/fc/apu/apu.hpp
+++ b/ares/fc/apu/apu.hpp
@@ -199,8 +199,8 @@ struct APU : Thread {
     n16 counter;
 
     bool odd;
-    bool delay;
-    n3   delayCounter;
+    bool delayIRQ;
+    bool delayCounter[2];
 
     constexpr static u16 periodNTSC[2][6] = {
       { 7457, 7456, 7458, 7457,    1, 1, },

--- a/ares/fc/apu/framecounter.cpp
+++ b/ares/fc/apu/framecounter.cpp
@@ -2,17 +2,25 @@ auto APU::FrameCounter::main() -> void {
   --counter;
   odd = !odd;
 
-  if (delay && --delayCounter == 0) {
-    delay = false;
-    step = 0;
-    counter = getPeriod() + 2;
-    if (mode == Freq48Hz) {
-      apu.clockHalfFrame();
+  if(!odd) {
+    //IRQ is reset on next GET cycle
+    if(delayIRQ) {
+      delayIRQ = false;
+      irqPending = 0;
+      apu.setIRQ();
     }
+
+    //counter is reloaded on GET cycle after next
+    if(delayCounter[0]) {
+      step = 0;
+      counter = getPeriod();
+      if(mode == Freq48Hz) apu.clockHalfFrame();
+    }
+    delayCounter[0] = delayCounter[1];
+    delayCounter[1] = false;
   }
 
-  if (counter != 0)
-    return;
+  if(counter != 0)  return;
 
   switch(step) {
     case 0:
@@ -29,21 +37,22 @@ auto APU::FrameCounter::main() -> void {
       break;
     case 3:
       step = 4;
-      if (mode == Freq60Hz && irqInhibit == 0)
-        irqPending = 1;
+      if(mode == Freq60Hz) irqPending = 1;
       break;
     case 4:
       step = 5;
       apu.clockHalfFrame();
-      if (mode == Freq60Hz && irqInhibit == 0) {
+      if(mode == Freq60Hz) {
         irqPending = 1;
         apu.setIRQ();
       }
       break;
     case 5:
       step = 0;
-      if (mode == Freq60Hz && irqInhibit == 0)
-        irqPending = 1;
+      if(mode == Freq60Hz) {
+        irqPending = ~irqInhibit;
+        apu.setIRQ();
+      }
       break;
   }
 
@@ -52,30 +61,24 @@ auto APU::FrameCounter::main() -> void {
 
 auto APU::FrameCounter::power(bool reset) -> void {
   irqInhibit = 0;
-  if (!reset) mode = Freq60Hz;
+  if(!reset) mode = Freq60Hz;
 
   irqPending = 0;
   step = 0;
   counter = getPeriod();
 
   odd = true;
-  delay = false;
-  delayCounter = 0;
+  delayIRQ = false;
+  delayCounter[0] = false;
+  delayCounter[1] = false;
 }
 
 auto APU::FrameCounter::write(n8 data) -> void {
   mode = data.bit(7);
-  delay = true;
-
-  // If the write occurs during an APU cycle,
-  // the effects occur 3 CPU cycles after the
-  // $4017 write cycle, and if the write occurs
-  // between APU cycles, the effects occurs 4 CPU
-  // cycles after the write cycle.
-  delayCounter = odd ? 1 : 2;
+  delayCounter[1] = true;
 
   irqInhibit = data.bit(6);
-  if (irqInhibit) {
+  if(irqInhibit) {
     irqPending = 0;
     apu.setIRQ();
   }

--- a/ares/fc/apu/serialization.cpp
+++ b/ares/fc/apu/serialization.cpp
@@ -95,6 +95,6 @@ auto APU::FrameCounter::serialize(serializer& s) -> void {
   s(counter);
 
   s(odd);
-  s(delay);
-  s(delayCounter);
+  s(delayIRQ);
+  for(auto& delay : delayCounter) s(delay);
 }

--- a/ares/fc/cpu/timing.cpp
+++ b/ares/fc/cpu/timing.cpp
@@ -3,9 +3,10 @@ auto CPU::read(n16 address) -> n8 {
     dma(address);
   }
 
-  io.openBus = readBus(address);
+  n8 data = readBus(address);
+  if(address != 0x4015) io.openBus = data;
   step(rate());
-  return io.openBus;
+  return data;
 }
 
 auto CPU::write(n16 address, n8 data) -> void {

--- a/ares/fc/system/serialization.cpp
+++ b/ares/fc/system/serialization.cpp
@@ -1,4 +1,4 @@
-static const string SerializerVersion = "v148";
+static const string SerializerVersion = "v149";
 
 auto System::serialize(bool synchronize) -> serializer {
   if(synchronize) scheduler.enter(Scheduler::Mode::Synchronize);


### PR DESCRIPTION
Implements the following APU edge cases:

- Reading $4015 should not affect open bus
- Frame counter IRQ flag is reset only on the next GET cycle
- Frame counter IRQ flag is briefly set even when the IRQ is suppressed