### PR TITLE
[SFC] Resize board vector so that there are 2 entries minimum

### DIFF
--- a/mia/medium/super-famicom.cpp
+++ b/mia/medium/super-famicom.cpp
@@ -255,6 +255,7 @@ auto SuperFamicom::analyze(std::vector<u8>& rom) -> string {
   s +={"  board:    ", board(), "\n"};
 
   auto board = nall::split(this->board().trimRight("#A", 1L), "-");
+  if(board.size() <= 1) { board.resize(2); }
 
   if(auto size = romSize()) {
     if(board[0] == "SPC7110" && size > 0x100000) {


### PR DESCRIPTION
When using the operator() accessor for the nall::vector implementation, it would always allocate up to the offset requested so there was always a valid result returned. std::vector does not behave like this. The code to analyze SFC boards in mia as written always expects this boards vector to always have at least two valid entries. So there is a check now that will resize this vector if it is smaller. 