### PR TITLE
myvision: Adjust audio frequency to match real hardware

### DIFF
--- a/ares/myvision/psg/psg.cpp
+++ b/ares/myvision/psg/psg.cpp
@@ -12,7 +12,7 @@ namespace ares::MyVision {
 
     stream = node->append < Node::Audio::Stream > ("PSG");
     stream->setChannels(1);
-    stream->setFrequency(Constants::Colorburst::NTSC / 16);
+    stream->setFrequency(Constants::Colorburst::NTSC / 21);
   }
 
   auto PSG::unload()->void {
@@ -38,8 +38,8 @@ namespace ares::MyVision {
 
   auto PSG::power()->void {
     AY38910::power();
-    //real-hardware clock is unknown, we used the same value as spectrum and MSX as placeholder
-    Thread::create(Constants::Colorburst::NTSC / 16, std::bind_front(&PSG::main, this));
+    // The divider of 21 is a guess, but a good one. Pitch seems the same as real hardware.
+    Thread::create(Constants::Colorburst::NTSC / 21, std::bind_front(&PSG::main, this));
 
     for (uint level: range(16)) {
       volume[level] = 1.0 / pow(2, 1.0 / 2 * (15 - level));


### PR DESCRIPTION
The divider is still unconfirmed, but 21 produces the correct pitch.

References:
https://gitlab.com/jgemu/jollycv/-/blob/master/src/jcv_myvision.c
https://www.youtube.com/watch?v=UqKuNb1Z9Uc
https://www.youtube.com/watch?v=RsNxhfD7iJk