### PR TITLE
fc: improve handling of OAM accesses during rendering

### DIFF
--- a/ares/fc/ppu/memory.cpp
+++ b/ares/fc/ppu/memory.cpp
@@ -124,6 +124,7 @@ auto PPU::writeIO(n16 address, n8 data) -> void {
         (Region::PAL() && io.ly >= 264 && io.ly <= vlines() - 2)) {
       if (enable()) {
         ++sprite.oamMainCounterIndex;
+        sprite.oamMainCounterTiming = 0;
         return;
       }
     }

--- a/ares/fc/ppu/sprite.cpp
+++ b/ares/fc/ppu/sprite.cpp
@@ -76,7 +76,7 @@ auto PPU::cycleSpriteEvaluation() -> void {
   }
 
   if (io.lx <= 320) {
-    u32 index  = ((io.lx - 257) >> 3) << 2 + min((io.lx - 257) & 7, 3);
+    u32 index  = (((io.lx - 257) >> 3) << 2) + min((io.lx - 257) & 7, 3);
 
     sprite.oamMainCounter = 0;
     sprite.oamTempCounter = 0;


### PR DESCRIPTION
Fixes a typo that caused incorrect values of OAMDATA to be read on dots 257-320, and implements a quirk where the lower 2 bits of OAMADDR get cleared when reading OAMDATA.