### PR TITLE
fc: fix evaluation of sprites not aligned to 4-byte boundaries in OAM

### DIFF
--- a/ares/fc/ppu/sprite.cpp
+++ b/ares/fc/ppu/sprite.cpp
@@ -2,10 +2,11 @@ auto PPU::cycleSpriteEvaluation() -> void {
   if (io.lx == 0) return;
 
   if (io.lx <= 64) {
-    if ((io.lx & 1) == 1)
+    if ((io.lx & 1) == 1) {
       sprite.oamData = 0xff;
-    else
+    } else {
       soam[sprite.oamTempCounter++] = sprite.oamData;
+    }
     return;
   }
 
@@ -17,60 +18,45 @@ auto PPU::cycleSpriteEvaluation() -> void {
 
     if (sprite.oamMainCounterOverflow) {
       ++sprite.oamMainCounterIndex;
-      if (sprite.oamTempCounterOverflow)
-        sprite.oamData = soam[sprite.oamTempCounter];
+      if (sprite.oamTempCounterOverflow) sprite.oamData = soam[sprite.oamTempCounter];
       return;
     }
 
+    s32 ly = io.ly == vlines() - 1 ? -1 : (s32)io.ly;
+    u32 y = ly - sprite.oamData;
+
+    if (sprite.oamTempCounterOverflow) {
+      sprite.oamData = soam[sprite.oamTempCounter];
+    } else {
+      soam[sprite.oamTempCounter] = sprite.oamData;
+    }
+
     if (sprite.oamTempCounterTiming == 0) {
-      s32 ly = io.ly == vlines() - 1 ? -1 : (s32)io.ly;
-      u32 y = ly - sprite.oamData;
-
       if (sprite.oamTempCounterOverflow) {
-        sprite.oamData = soam[sprite.oamTempCounter];
-
         if (y >= io.spriteHeight) {
-          if (++sprite.oamMainCounterIndex == 0)
-            sprite.oamMainCounterOverflow = true;
+          if (++sprite.oamMainCounterIndex == 0) sprite.oamMainCounterOverflow = true;
           ++sprite.oamMainCounterTiming;
           return;
         }
 
         sprite.spriteOverflow = 1;
-        ++sprite.oamTempCounter;
-        ++sprite.oamMainCounterTiming;
-        return;
-      }
+      } else {
+        if (y >= io.spriteHeight) {
+          sprite.oamMainCounterTiming = 0;
+          if (++sprite.oamMainCounterIndex == 0) sprite.oamMainCounterOverflow = true;
+          return;
+        }
 
-      soam[sprite.oamTempCounter] = sprite.oamData;
-      if (y >= io.spriteHeight) {
-        if (++sprite.oamMainCounterIndex == 0)
-          sprite.oamMainCounterOverflow = true;
-        return;
+        // first sprite evaluated should be treated as sprite zero
+        latch.oamId[sprite.oamTempCounterIndex] = (io.lx == 66) ? 0 : 1;
       }
-
-      latch.oamId[sprite.oamTempCounterIndex] = sprite.oamMainCounterIndex;
       ++sprite.oamTempCounter;
-      ++sprite.oamMainCounterTiming;
+      if (++sprite.oamMainCounter == 0) sprite.oamMainCounterOverflow = true;
     } else {
-      if (sprite.oamTempCounterOverflow) {
-        sprite.oamData = soam[sprite.oamTempCounter];
-        ++sprite.oamTempCounter;
-        ++sprite.oamMainCounterTiming;
-        return;
-      }
-
-      soam[sprite.oamTempCounter] = sprite.oamData;
       ++sprite.oamTempCounter;
-      ++sprite.oamMainCounterTiming;
-
-      if (sprite.oamTempCounterTiming == 0) {
-        if (++sprite.oamMainCounterIndex == 0)
-          sprite.oamMainCounterOverflow = true;
-
-        if (sprite.oamTempCounter == 0)
-          sprite.oamTempCounterOverflow = true;
-      }
+      if (++sprite.oamMainCounter == 0) sprite.oamMainCounterOverflow = true;
+      if (sprite.oamTempCounter == 0) sprite.oamTempCounterOverflow = true;
+      if (sprite.oamTempCounterTiming == 0 && y >= io.spriteHeight) sprite.oamMainCounterTiming = 0;
     }
     return;
   }


### PR DESCRIPTION
Fixes two test cases in the [AccuracyCoin](https://github.com/100thCoin/AccuracyCoin) test ROM.