### PR TITLE
Fix glitch in City Hunter ROM in the intro in the performance-mode VDP

### DIFF
--- a/ares/pce/vdp-performance/background.cpp
+++ b/ares/pce/vdp-performance/background.cpp
@@ -9,7 +9,8 @@ auto VDC::Background::scanline(n16 y) -> void {
 }
 
 auto VDC::Background::render(n16 y) -> void {
-  if(!enable) return (void)memset(&output, 0, sizeof(output));
+  // The burstMode check fixes a glitch in the intro of City Hunter. It hasn't been tested in other games.
+  if(!enable || burstMode) return (void)memset(&output, 0, sizeof(output));
 
   for(u32 x = 0; x < vdp.vce.width();) {
     n8  tileX = hoffset >> 3 & width  - 1;

--- a/ares/pce/vdp-performance/serialization.cpp
+++ b/ares/pce/vdp-performance/serialization.cpp
@@ -94,11 +94,13 @@ auto VDC::serialize(serializer& s) -> void {
   s(background.height);
   s(background.hoffset);
   s(background.voffset);
+  s(background.burstMode);
   s(background.latch.vramMode);
   s(background.latch.characterMode);
 
   s(sprite.enable);
   s(sprite.vramMode);
+  s(sprite.burstMode);
   s(sprite.latch.vramMode);
 }
 

--- a/ares/pce/vdp-performance/sprite.cpp
+++ b/ares/pce/vdp-performance/sprite.cpp
@@ -53,7 +53,8 @@ auto VDC::Sprite::scanline(n16 y) -> void {
 }
 
 auto VDC::Sprite::render(n16 y) -> void {
-  if(!enable) return (void)memset(&output, 0, sizeof(output));
+  // The burstMode check fixes a glitch in the intro of City Hunter. It hasn't been tested in other games.
+  if(!enable || burstMode) return (void)memset(&output, 0, sizeof(output));
 
   y += 64;
 

--- a/ares/pce/vdp-performance/vdc.cpp
+++ b/ares/pce/vdp-performance/vdc.cpp
@@ -25,6 +25,7 @@ auto VDC::vsync() -> void {
   }
 
   latch.burstMode = !background.enable && !sprite.enable;
+  background.burstMode = sprite.burstMode = latch.burstMode;
 }
 
 auto VDC::hclock() -> void {

--- a/ares/pce/vdp-performance/vdc.hpp
+++ b/ares/pce/vdp-performance/vdc.hpp
@@ -158,6 +158,7 @@ struct VDC : VDCBase {
     auto render(n16 y) -> void;
 
     n1  enable;
+    n1  burstMode;
     n2  vramMode;  //partially emulated
     n1  characterMode;
     n10 hscroll;
@@ -207,6 +208,7 @@ struct VDC : VDCBase {
     adaptive_array<Object, 16> objects;
 
     n1 enable;
+    n1 burstMode;
     n2 vramMode;  //partially emulated
 
     struct Latch {


### PR DESCRIPTION
We were rendering background and sprites in burst mode, which shouldn't happen.

I'm not the author, I'm just upstreaming changes done a member in our team.