### PR TITLE
Build: miscellaneous fixups

### DIFF
--- a/ares/component/CMakeLists.txt
+++ b/ares/component/CMakeLists.txt
@@ -138,6 +138,7 @@ component_sources(
   INCLUDED
     processor/arm7tdmi/algorithms.cpp
     processor/arm7tdmi/arm7tdmi.hpp
+    processor/arm7tdmi/coprocessor.cpp
     processor/arm7tdmi/disassembler.cpp
     processor/arm7tdmi/instruction.cpp
     processor/arm7tdmi/instructions-arm.cpp

--- a/ares/n64/CMakeLists.txt
+++ b/ares/n64/CMakeLists.txt
@@ -124,6 +124,7 @@ ares_add_sources(
   CORE #
     n64
   INCLUDED #
+    controller/gamepad/bio-sensor.cpp
     controller/gamepad/gamepad.cpp
     controller/gamepad/gamepad.hpp
     controller/gamepad/transfer-pak.cpp

--- a/ares/sfc/CMakeLists.txt
+++ b/ares/sfc/CMakeLists.txt
@@ -63,6 +63,8 @@ ares_add_sources(
     controller/justifiers/justifiers.hpp
     controller/mouse/mouse.cpp
     controller/mouse/mouse.hpp
+    controller/rumble-gamepad/rumble-gamepad.cpp
+    controller/rumble-gamepad/rumble-gamepad.hpp
     controller/ntt-data-keypad/ntt-data-keypad.cpp
     controller/ntt-data-keypad/ntt-data-keypad.hpp
     controller/super-multitap/super-multitap.cpp

--- a/cmake/common/dependencies_common.cmake
+++ b/cmake/common/dependencies_common.cmake
@@ -5,7 +5,11 @@ include_guard(GLOBAL)
 option(ARES_SKIP_DEPS "Do not fetch prebuilt dependencies" OFF)
 mark_as_advanced(ARES_SKIP_DEPS)
 
-option(ARES_DEBUG_DEPENDENCIES "Fetch precompiled dependency source code and populate debugger initialization files for source view debugging" OFF)
+option(
+  ARES_DEBUG_DEPENDENCIES
+  "Fetch precompiled dependency source code and populate debugger initialization files for source view debugging"
+  OFF
+)
 
 # _check_dependencies: Fetch and extract pre-built ares build dependencies
 function(_check_dependencies)

--- a/cmake/linux/compilerconfig.cmake
+++ b/cmake/linux/compilerconfig.cmake
@@ -26,10 +26,7 @@ if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
     -fno-char8_t
   )
 elseif(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
-  add_compile_options(
-    "${_ares_gcc_common_options}"
-    "$<$<COMPILE_LANGUAGE:CXX>:${_ares_gcc_cxx_options}>"
-  )
+  add_compile_options("${_ares_gcc_common_options}" "$<$<COMPILE_LANGUAGE:CXX>:${_ares_gcc_cxx_options}>")
 endif()
 
 if(ARES_BUILD_LOCAL)

--- a/hiro/cmake/os-linux.cmake
+++ b/hiro/cmake/os-linux.cmake
@@ -23,10 +23,7 @@ else()
     COMMAND ${QT_MOC_EXECUTABLE} -i -o ${CMAKE_CURRENT_SOURCE_DIR}/qt/qt.moc ${CMAKE_CURRENT_SOURCE_DIR}/qt/qt.hpp
   )
 
-  target_link_libraries(
-    hiro
-    PRIVATE X11::X11 Qt6::Core Qt6::Gui Qt6::Widgets
-  )
+  target_link_libraries(hiro PRIVATE X11::X11 Qt6::Core Qt6::Gui Qt6::Widgets)
 
   target_enable_feature(hiro "Qt6 UI backend")
   target_compile_definitions(hiro PUBLIC HIRO_QT=6)

--- a/nall/nall/cmake/sources.cmake
+++ b/nall/nall/cmake/sources.cmake
@@ -14,7 +14,6 @@ target_sources(
     case-range.hpp
     cd.hpp
     chrono.hpp
-    
     directory.cpp
     directory.hpp
     dl.cpp
@@ -29,8 +28,6 @@ target_sources(
     hashset.hpp
     hid.hpp
     image.hpp
-    
-    
     inode.cpp
     inode.hpp
     instance.hpp
@@ -57,7 +54,6 @@ target_sources(
     pointer.hpp
     primitives.hpp
     priority-queue.hpp
-    
     queue.hpp
     random.cpp
     random.hpp
@@ -67,13 +63,10 @@ target_sources(
     run.hpp
     serial.hpp
     serializer.hpp
-    
     set.hpp
     span-helpers.hpp
-
     stdint.hpp
     string.hpp
-    
     terminal.cpp
     terminal.hpp
     thread.cpp
@@ -87,18 +80,43 @@ target_sources(
     view.hpp
 )
 
-target_sources(nall PRIVATE arithmetic/natural.hpp arithmetic/unsigned.hpp)
-
-target_sources(nall PRIVATE beat/single/apply.hpp)
+target_sources(
+  nall
+  PRIVATE #
+    arithmetic/natural.hpp
+    arithmetic/unsigned.hpp
+)
 
 target_sources(
   nall
-  PRIVATE cd/crc16.hpp cd/edc.hpp cd/efm.hpp cd/rspc.hpp cd/scrambler.hpp cd/session.hpp cd/sync.hpp
+  PRIVATE #
+    beat/single/apply.hpp
 )
 
-target_sources(nall PRIVATE cipher/chacha20.hpp)
+target_sources(
+  nall
+  PRIVATE #
+    cd/crc16.hpp
+    cd/edc.hpp
+    cd/efm.hpp
+    cd/rspc.hpp
+    cd/scrambler.hpp
+    cd/session.hpp
+    cd/sync.hpp
+)
 
-target_sources(nall PRIVATE database/odbc.hpp database/sqlite3.hpp)
+target_sources(
+  nall
+  PRIVATE #
+    cipher/chacha20.hpp
+)
+
+target_sources(
+  nall
+  PRIVATE #
+    database/odbc.hpp
+    database/sqlite3.hpp
+)
 
 target_sources(
   nall
@@ -106,67 +124,62 @@ target_sources(
     decode/base.hpp
     decode/base64.hpp
     decode/bmp.hpp
-    
     decode/chd.hpp
     decode/cue.hpp
     decode/gzip.hpp
     decode/html.hpp
-    
     decode/inflate.hpp
-    
     decode/mmi.hpp
-    
     decode/png.hpp
-    
     decode/url.hpp
     decode/wav.hpp
     decode/zip.hpp
 )
 
-target_sources(nall PRIVATE dsp/iir/biquad.hpp dsp/iir/dc-removal.hpp dsp/iir/one-pole.hpp dsp/resampler/cubic.hpp)
-
 target_sources(
   nall
-  PRIVATE
-    elliptic-curve/curve25519.hpp
-    elliptic-curve/ed25519.hpp
-    
-    
+  PRIVATE #
+    dsp/iir/biquad.hpp
+    dsp/iir/dc-removal.hpp
+    dsp/iir/one-pole.hpp
+    dsp/resampler/cubic.hpp
 )
 
- 
+target_sources(
+  nall
+  PRIVATE #
+    elliptic-curve/curve25519.hpp
+    elliptic-curve/ed25519.hpp
+)
 
 target_sources(
   nall
-  PRIVATE
+  PRIVATE #
     encode/base.hpp
     encode/base64.hpp
-    
-    
     encode/html.hpp
-    
-    
-    
     encode/png.hpp
-    
     encode/url.hpp
-    
     encode/zip.hpp
 )
 
-target_sources(nall PRIVATE gdb/Readme.md gdb/server.cpp gdb/server.hpp gdb/watchpoint.hpp)
+target_sources(
+  nall
+  PRIVATE #
+    gdb/Readme.md
+    gdb/server.cpp
+    gdb/server.hpp
+    gdb/watchpoint.hpp
+)
 
 target_sources(
   nall
-  PRIVATE
+  PRIVATE #
     hash/crc16.hpp
     hash/crc32.hpp
     hash/crc64.hpp
     hash/hash.hpp
-    
     hash/sha256.hpp
-    
-    
 )
 
 target_sources(
@@ -183,9 +196,11 @@ target_sources(
     image/utility.hpp
 )
 
- 
-
-target_sources(nall PRIVATE posix/service.hpp)
+target_sources(
+  nall
+  PRIVATE #
+    posix/service.hpp
+)
 
 target_sources(
   nall
@@ -200,7 +215,12 @@ target_sources(
     primitives/types.hpp
 )
 
-target_sources(nall PRIVATE queue/spsc.hpp queue/st.hpp)
+target_sources(
+  nall
+  PRIVATE #
+    queue/spsc.hpp
+    queue/st.hpp
+)
 
 target_sources(
   nall
@@ -208,12 +228,7 @@ target_sources(
     recompiler/amd64/amd64.hpp
     recompiler/amd64/constants.hpp
     recompiler/amd64/emitter.hpp
-    
-    
-    
     recompiler/generic/constants.hpp
-    
-    
     recompiler/generic/generic.hpp
 )
 
@@ -250,7 +265,11 @@ target_sources(
 
 target_sources(
   nall
-  PRIVATE tcptext/tcp-socket.cpp tcptext/tcp-socket.hpp tcptext/tcptext-server.cpp tcptext/tcptext-server.hpp
+  PRIVATE #
+    tcptext/tcp-socket.cpp
+    tcptext/tcp-socket.hpp
+    tcptext/tcptext-server.cpp
+    tcptext/tcptext-server.hpp
 )
 
 target_sources(
@@ -266,6 +285,17 @@ target_sources(
     vfs/vfs.hpp
 )
 
-target_sources(nall PRIVATE cmake/os-macos.cmake cmake/os-windows.cmake cmake/os-linux.cmake cmake/os-freebsd.cmake)
+target_sources(
+  nall
+  PRIVATE #
+    cmake/os-macos.cmake
+    cmake/os-windows.cmake
+    cmake/os-linux.cmake
+    cmake/os-freebsd.cmake
+)
 
-target_sources(nall PRIVATE cmake/sources.cmake)
+target_sources(
+  nall
+  PRIVATE #
+    cmake/sources.cmake
+)

--- a/nall/nall/cmake/sources.cmake
+++ b/nall/nall/cmake/sources.cmake
@@ -69,7 +69,8 @@ target_sources(
     serializer.hpp
     
     set.hpp
-    
+    span-helpers.hpp
+
     stdint.hpp
     string.hpp
     
@@ -82,6 +83,7 @@ target_sources(
     variant.hpp
     varint.hpp
     vfs.hpp
+    vector-helpers.hpp
     view.hpp
 )
 


### PR DESCRIPTION
A number of commits recently added files to ares (ded92545, 0d9ce81d2, ff8bdbcd, ~~92fe0d2e~~, be19b5830, 585e43a94) but did not enumerate them in the CMake build code. This means those files would not be indexed by generated IDE projects, and could also make rebuild detection unreliable. This PR adds them.

Also runs a CMake formatting pass given numerous recent changes to build code generally.

Editorial aside: Ideally both of these processes would be automated, or at least detected via linting on CI, but I have yet to discover a way to do so in a robust way that is also not more trouble than it's worth for developer workflows, so for now they are done manually. 

Contributors should be aware to always add files to CMake manifests when adding new files to the project.