### PR TITLE
n64: handle correct R/W to RDP spans in test mode

### DIFF
--- a/ares/n64/rdp/io.cpp
+++ b/ares/n64/rdp/io.cpp
@@ -137,7 +137,7 @@ auto RDP::IO::readWord(u32 address, Thread& thread) -> u32 {
 
   if(address == 3) {
     //DPS_BUFTEST_DATA
-    data.bit(0,31) = test.data;
+    data.bit(0,31) = test.data[test.address];
   }
 
   self.debugger.ioDPS(Read, address, data);
@@ -167,7 +167,16 @@ auto RDP::IO::writeWord(u32 address, u32 data_, Thread& thread) -> void {
 
   if(address == 3) {
     //DPS_BUFTEST_DATA
-    test.data = data.bit(0,31);
+    u32 value = data.bit(0,31);
+    u32 column = test.address % 4;
+    
+    if(column == 2) {
+      value &= 0xFF;
+    } else if(column == 3) {
+      value = 0;
+    }
+
+    test.data[test.address] = value;
   }
 
   self.debugger.ioDPS(Write, address, data);

--- a/ares/n64/rdp/rdp.hpp
+++ b/ares/n64/rdp/rdp.hpp
@@ -349,8 +349,9 @@ struct RDP : Thread, Memory::RCP<RDP> {
     struct Test {
       n1  enable;
       n7  address;
-      n32 data;
+      array<u32[128]> data;
     } test;
+
   } io{*this};
 };
 

--- a/ares/n64/rdp/serialization.cpp
+++ b/ares/n64/rdp/serialization.cpp
@@ -24,5 +24,5 @@ auto RDP::serialize(serializer& s) -> void {
 
   s(io.test.enable);
   s(io.test.address);
-  s(io.test.data);
+  for(auto& d : io.test.data) s(d);
 }

--- a/ares/n64/system/serialization.cpp
+++ b/ares/n64/system/serialization.cpp
@@ -1,4 +1,4 @@
-static const string SerializerVersion = "v144";
+static const string SerializerVersion = "v145";
 
 auto System::serialize(bool synchronize) -> serializer {
   serializer s;


### PR DESCRIPTION
Fixes a wrong implementation of span buffer access when in RDP test mode.
On hardware, the registers for doing so act as a view into the larger buffer in the RDP itself.
Ares so far assumed it only can hold a single value directly, and was missing masking (https://n64brew.dev/wiki/Reality_Display_Processor/Interface#0x0420_000C_-_DPS_BUFTEST_DATA)

This is tested by a demo i made here: https://github.com/HailToDodongo/repeater64