### PR TITLE
n64: fix VI bug causing spinloop

### DIFF
--- a/ares/n64/vi/vi.cpp
+++ b/ares/n64/vi/vi.cpp
@@ -113,10 +113,10 @@ auto VI::main() -> void {
         }
       }
 
-      u32 lineDuration = io.quarterLineDuration;
+      u32 lineDuration = io.quarterLineDuration+1;
       if(io.vcounter == 1)
         lineDuration = io.hsyncLeap[io.leapPattern.bit(io.leapCounter)];      
-      step(io.quarterLineDuration);
+      step(lineDuration);
     } else {
       // Arbitrarily call screen->frame() every once in a while to keep the UI responsive.
       // We do that every 200 simulated lines of 0x800 quarter-clocks. This is just arbitrary,


### PR DESCRIPTION
VI_H_TOTAL is defined as the number of cycles per scanline *minus 1*. We forgot to add that 1 back. Besides the minor inaccuracy in timing, we could hit a race condition during initial VI config: if the Ares VI thread ran when the display was turned on (VI_CTRL configured) but VI_H_TOTAL wasn't already configured (and thus defaulted to 0), the thread would spinloop forever because it would step by 0 cycles.

While fixing this, I also noticed that I wasn't properly taking into account leap timings because of a typo; this means that PAL timings were very slightly off.

Fixes #2293