### PR TITLE
gba: implement write protection for HALTCNT

### DIFF
--- a/ares/gba/cpu/io.cpp
+++ b/ares/gba/cpu/io.cpp
@@ -451,8 +451,10 @@ auto CPU::writeIO(n32 address, n8 data) -> void {
     if(data.bit(0)) context.booted = 1;
     return;
   case 0x0400'0301:
-    context.halted  = data.bit(7) == 0;
-    context.stopped = data.bit(7) == 1;
+    if(processor.r15 < 0x0200'0000) {
+      context.halted  = data.bit(7) == 0;
+      context.stopped = data.bit(7) == 1;
+    }
     return;
 
   //MEMCNT_L


### PR DESCRIPTION
Similarly to BIOS read protection, writes to HALTCNT are restricted to when R15 is in the BIOS region (`0x0000'0000` to `0x01ff'ffff`). However, unlike BIOS read protection, this address range does not change when the BIOS and RAM regions are swapped.