### PR TITLE
[N64] Fix pak menu radio selection

### DIFF
--- a/desktop-ui/emulator/nintendo-64.cpp
+++ b/desktop-ui/emulator/nintendo-64.cpp
@@ -231,8 +231,15 @@ auto Nintendo64::portMenu(Menu& portMenu, ares::Node::Port port) -> void {
   pakMenu.setText("Pak");
   Group pakGroup;
 
+  // Initialize all menu items and add them all to the group for appropriate radio selection behavior
+  MenuRadioItem nothing{&pakMenu}, cpak{&pakMenu}, rpak{&pakMenu}, tpak{&pakMenu}, biosensor{&pakMenu};
+  pakGroup.append(nothing);
+  pakGroup.append(cpak);
+  pakGroup.append(rpak);
+  pakGroup.append(tpak);
+  pakGroup.append(biosensor);
+
   // Show Nothing option
-  MenuRadioItem nothing{&pakMenu};;
   nothing.setText("Nothing");
   nothing.setAttribute<ares::Node::Port>("port", port);
   if(!pak) nothing.setChecked();
@@ -249,10 +256,8 @@ auto Nintendo64::portMenu(Menu& portMenu, ares::Node::Port port) -> void {
     }
     presentation.refreshSystemMenu();
   });
-  pakGroup.append(nothing);
 
   // Show Controller Pak option
-  MenuRadioItem cpak{&pakMenu};
   cpak.setAttribute<ares::Node::Port>("port", port);
   cpak.setText("Controller Pak");
   if(pak && pak->name() == "Controller Pak") cpak.setChecked();
@@ -276,10 +281,8 @@ auto Nintendo64::portMenu(Menu& portMenu, ares::Node::Port port) -> void {
     }
     presentation.refreshSystemMenu();
   });
-  pakGroup.append(cpak);
 
   // Show Rumble Pak option
-  MenuRadioItem rpak{&pakMenu};
   rpak.setAttribute<ares::Node::Port>("port", port);
   rpak.setText("Rumble Pak");
   if(pak && pak->name() == "Rumble Pak") rpak.setChecked();
@@ -298,11 +301,9 @@ auto Nintendo64::portMenu(Menu& portMenu, ares::Node::Port port) -> void {
     }
     presentation.refreshSystemMenu();
   });
-  pakGroup.append(rpak);
 
   // Show Transfer Pak option if Game Boy core is available
 #if defined(CORE_GB)
-  MenuRadioItem tpak{&pakMenu};
   tpak.setAttribute<ares::Node::Port>("port", port);
   tpak.setText("Transfer Pak");
   if(pak && pak->name() == "Transfer Pak") tpak.setChecked();
@@ -334,11 +335,9 @@ auto Nintendo64::portMenu(Menu& portMenu, ares::Node::Port port) -> void {
     }
     presentation.refreshSystemMenu();
   });
-  pakGroup.append(tpak);
 #endif
 
   // Show Bio Sensor option
-  MenuRadioItem biosensor{&pakMenu};
   biosensor.setAttribute<ares::Node::Port>("port", port);
   biosensor.setText("Bio Sensor");
   if(pak && pak->name() == "Bio Sensor") biosensor.setChecked();
@@ -357,7 +356,6 @@ auto Nintendo64::portMenu(Menu& portMenu, ares::Node::Port port) -> void {
     }
     presentation.refreshSystemMenu();
   });
-  pakGroup.append(biosensor);
   
   // Show Bio Sensor BPM menu if Bio Sensor is connected
   if(pak && pak->name() == "Bio Sensor") {


### PR DESCRIPTION
This became a problem when changes were made to introduce support for the biosensor pak item, which when chosen adds an additional BPM menu item option to the parent menu, and removes it when a different pak (or nothing) is selected. Previously menu selection would be resolved at the end of the method, but this had to be removed or the removal of the BPM menu wouldn't work correctly. 

The underlying issue was the way in which we created menu radio items in the pak menu. By creating them, setting them up, and then adding them to the group one by one, each created menu radio item had its default checked state set to true as they were currently not part of a group. This led to every item in the pak menu having their checked state set to true, which broke proper radio selection. By creating all menu items at once and adding them all into the appropriate group, the logic that follows to determine which one should be checked will now properly enable the correct menu item while disabling all other items in the group. 