### PR TITLE
[FC] Add noise channel to save state serialization

### DIFF
--- a/ares/fc/apu/serialization.cpp
+++ b/ares/fc/apu/serialization.cpp
@@ -3,6 +3,7 @@ auto APU::serialize(serializer& s) -> void {
   s(pulse1);
   s(pulse2);
   s(triangle);
+  s(noise);
   s(dmc);
   s(frame);
 }

--- a/ares/fc/system/serialization.cpp
+++ b/ares/fc/system/serialization.cpp
@@ -1,4 +1,4 @@
-static const string SerializerVersion = "v150";
+static const string SerializerVersion = "v151";
 
 auto System::serialize(bool synchronize) -> serializer {
   if(synchronize) scheduler.enter(Scheduler::Mode::Synchronize);


### PR DESCRIPTION
The noise channel in the famicom was not being serialized into the save state. This PR adds the noise channel. This has been missing in ares since it was created, and is also missing in the current version of higan.