### PR TITLE
pce: fix missing qon linking

### DIFF
--- a/ares/pce/CMakeLists.txt
+++ b/ares/pce/CMakeLists.txt
@@ -1,5 +1,7 @@
 ares_components(huc6280 msm5205)
 
+target_link_libraries(ares PRIVATE qon)
+
 ares_add_sources(
   CORE #
     pce


### PR DESCRIPTION
Building the `pce` core without the `md` core (e.g. via `-DARES_CORES="pce"`) results in the following linker error:
```
ld: error: undefined symbol: qon_decode_header
>>> referenced by ldrom2.cpp:74 (/tmp/ares/ares/pce/pcd/ldrom2.cpp:74)
>>>               pcd.cpp.o:(ares::PCEngine::PCD::LD::load(nall::string)) in archive ares/libares.a

ld: error: undefined symbol: qon_decode_index_entry
>>> referenced by ldrom2.cpp:95 (/tmp/ares/ares/pce/pcd/ldrom2.cpp:95)
>>>               pcd.cpp.o:(ares::PCEngine::PCD::LD::load(nall::string)) in archive ares/libares.a

ld: error: undefined symbol: qon_decode_frame_size
>>> referenced by ldrom2.cpp:2899 (/tmp/ares/ares/pce/pcd/ldrom2.cpp:2899)
>>>               pcd.cpp.o:(ares::PCEngine::PCD::LD::videoFramePrefetchThread()) in archive ares/libares.a
>>> referenced by ldrom2.cpp:2788 (/tmp/ares/ares/pce/pcd/ldrom2.cpp:2788)
>>>               pcd.cpp.o:(ares::PCEngine::PCD::LD::loadCurrentVideoFrameIntoBuffer()) in archive ares/libares.a

ld: error: undefined symbol: qoi2_decode_data
>>> referenced by ldrom2.cpp:2900 (/tmp/ares/ares/pce/pcd/ldrom2.cpp:2900)
>>>               pcd.cpp.o:(ares::PCEngine::PCD::LD::videoFramePrefetchThread()) in archive ares/libares.a
>>> referenced by ldrom2.cpp:2789 (/tmp/ares/ares/pce/pcd/ldrom2.cpp:2789)
>>>               pcd.cpp.o:(ares::PCEngine::PCD::LD::loadCurrentVideoFrameIntoBuffer()) in archive ares/libares.a
```
Contrary to the `md` core, the `pce` core misses an explicit dependency on the `qon` library in `ares/pce/CMakeLists.txt`. This error doesn't show up in the CI because the CI builds all cores and therefore linking against `qon` is established by the `md` core.

This PR adds the missing linkage against `qon` to `pce` in the same way how it's done for `md`.