### PR TITLE
[SFC] Add support for GBC titles to the Super Game Boy

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ When started from the command-line, ares accepts a few options.
 Usage: ./ares [options] game(s)
 
   --help                 Displays available options and exit
+  --terminal             Create new terminal window (Windows only)
   --fullscreen           Start in full screen mode
   --system system        Specify the system name
   --shader shader        Specify a slang shader to load (requires OpenGL or Metal)

--- a/desktop-ui/emulator/super-famicom.cpp
+++ b/desktop-ui/emulator/super-famicom.cpp
@@ -130,7 +130,7 @@ auto SuperFamicom::load() -> LoadResult {
     port->connect();
 
     if(auto slot = cartridge->find<ares::Node::Port>("Super Game Boy/Cartridge Slot")) {
-      gb = mia::Medium::create("Game Boy");
+      gb = mia::Medium::create("Game Boy Color");
       if(gb->load(Emulator::load(gb, settings.paths.superFamicom.gameBoy)) == successful) {
         slot->allocate();
         slot->connect();


### PR DESCRIPTION
Previously the Super Game Boy would only allow loading of Game Boy titles. This adds support for Game Boy Color game support as well.

Also a small update to the readme I noticed was missing.