### PR TITLE
gba: only trigger keypad IRQ when input changes

### DIFF
--- a/ares/gba/cpu/cpu.hpp
+++ b/ares/gba/cpu/cpu.hpp
@@ -202,6 +202,7 @@ struct CPU : ARM7TDMI, Thread, IO {
     n1 enable;
     n1 condition;
     n1 flag[10];
+    n1 keyStates[10];
 
     n1 conditionMet;
   } keypad;

--- a/ares/gba/cpu/keypad.cpp
+++ b/ares/gba/cpu/keypad.cpp
@@ -12,13 +12,16 @@ auto CPU::Keypad::run() -> void {
     system.controls.l->value(),
   };
 
+  bool inputHasChanged = false;
   conditionMet = condition;  //0 = OR, 1 = AND
   for(u32 index : range(10)) {
+    if(lookup[index] != keyStates[index]) inputHasChanged = true;
+    keyStates[index] = lookup[index];
     if(!flag[index]) continue;
     n1 input = lookup[index];
     if(condition == 0) conditionMet |= input;
     if(condition == 1) conditionMet &= input;
   }
   
-  if(conditionMet && enable) cpu.setInterruptFlag(CPU::Interrupt::Keypad);
+  if(inputHasChanged && conditionMet && enable) cpu.setInterruptFlag(CPU::Interrupt::Keypad);
 }

--- a/ares/gba/cpu/serialization.cpp
+++ b/ares/gba/cpu/serialization.cpp
@@ -66,6 +66,7 @@ auto CPU::serialize(serializer& s) -> void {
   s(keypad.enable);
   s(keypad.condition);
   for(auto& flag : keypad.flag) s(flag);
+  for(auto& keyState : keypad.keyStates) s(keyState);
   s(keypad.conditionMet);
 
   s(joybus.sc);

--- a/ares/gba/system/serialization.cpp
+++ b/ares/gba/system/serialization.cpp
@@ -1,4 +1,4 @@
-static const string SerializerVersion = "v146.1";
+static const string SerializerVersion = "v147";
 
 auto System::serialize(bool synchronize) -> serializer {
   if(synchronize) scheduler.enter(Scheduler::Mode::Synchronize);


### PR DESCRIPTION
Fixes a bug where keypad IRQs would repeatedly trigger as long as the required inputs were held.