### PR TITLE
gba: fix handling of repeat bit during immediate DMA transfers

### DIFF
--- a/ares/gba/cpu/dma.cpp
+++ b/ares/gba/cpu/dma.cpp
@@ -93,8 +93,11 @@ auto CPU::DMAC::Channel::write() -> void {
   if(!latch.length()) {
     active = false;
     if(targetMode == 3) latch.target = target;
-    if(repeat == 1) latch.length = length;
-    if(repeat == 0) enable = false;
+    if(repeat == 0 || timingMode == 0) {
+      enable = false;
+    } else {
+      latch.length = length;
+    }
   }
 
   cpu.dmac.writeCycle = false;


### PR DESCRIPTION
The repeat bit should not have any effect on immediate DMA transfers.

Fixes multiple issues, including #868 and #1872.