### PR TITLE
[N64] Add Cubivore English translation to N64 DB

### DIFF
--- a/mia/medium/nintendo-64.cpp
+++ b/mia/medium/nintendo-64.cpp
@@ -452,6 +452,7 @@ auto Nintendo64::analyze(std::vector<u8>& data) -> string {
 
   //128KB Flash
   if(id == "NCC") {flash = 128_KiB; rpak = true;}                          //Command & Conquer
+  if(id == "NCV") {flash = 128_KiB;}                                       //Cubivore [English translation/patch of Doubutsu Banchou (J)]
   if(id == "NDA") {flash = 128_KiB; cpak = true;}                          //Derby Stallion 64
   if(id == "NAF") {flash = 128_KiB; cpak = true; rtc = true;}              //Doubutsu no Mori
   if(id == "NJF") {flash = 128_KiB; rpak = true;}                          //Jet Force Gemini [Star Twins (J)]


### PR DESCRIPTION
After lots of discussion in Discord, it seems we would need to add this to our internal DB based on the patch heavily modifying the header. This adds support for Cubivore (Doubutsu Banchou with the English patch applied). 