### PR TITLE
gba: prefetcher should fail reading across 128KiB boundaries

### DIFF
--- a/ares/gba/cpu/bus.cpp
+++ b/ares/gba/cpu/bus.cpp
@@ -45,9 +45,9 @@ inline auto CPU::getBus(u32 mode, n32 address) -> n32 {
     if constexpr(UseDebugger) return readROM<true>(mode, address);
     context.burstActive = checkBurst<IsDMA>(mode);
     context.romAccess = true;
-    if(mode & Prefetch && wait.prefetch) {
-      if(address == prefetch.addr && (!prefetch.empty() || prefetch.ahead)) {
-        prefetchStepInternal(1);
+    if(mode & Prefetch) {
+      if((address & 0x1fffe) && wait.prefetch && address == prefetch.addr && (!prefetch.empty() || prefetch.ahead)) {
+        prefetchStep(1);
         word = prefetchRead();
         if(mode & Word) word |= prefetchRead() << 16;
       } else {

--- a/ares/gba/cpu/cpu.hpp
+++ b/ares/gba/cpu/cpu.hpp
@@ -53,7 +53,6 @@ struct CPU : ARM7TDMI, Thread, IO {
 
   //prefetch.cpp
   auto prefetchSync(u32 mode, n32 address) -> void;
-  auto prefetchStepInternal(u32 clocks) -> void;
   auto prefetchStep(u32 clocks) -> void;
   auto prefetchReset() -> void;
   auto prefetchRead() -> n16;
@@ -266,7 +265,6 @@ struct CPU : ARM7TDMI, Thread, IO {
   struct {
     auto empty() const { return addr == load; }
     auto full() const { return load - addr == 16; }
-    auto size() const { return (load - addr) >> 1; }
 
     n16 slot[8];
     n32 addr;      //read location of slot buffer


### PR DESCRIPTION
Fixes some timing inaccuracies that could occur when the prefetcher attempts to read across a 128KiB boundary.