### PR TITLE
Fix symbolic links to files for rom loading

### DIFF
--- a/cmake/windows/compilerconfig.cmake
+++ b/cmake/windows/compilerconfig.cmake
@@ -37,7 +37,7 @@ else()
   endif()
 endif()
 
-add_compile_definitions(_WIN32_WINNT=0x0601) #global
+add_compile_definitions(_WIN32_WINNT=0x0A00) #global
 
 option(
   ARES_MINGW_USE_DWARF_SYMBOLS

--- a/desktop-ui/emulator/emulator.cpp
+++ b/desktop-ui/emulator/emulator.cpp
@@ -160,7 +160,7 @@ auto Emulator::load(std::shared_ptr<mia::Pak> pak, string& path) -> string {
     filters.trimRight(":", 1L);
     filters.prepend(pak->name(), "|");
     dialog.setFilters({filters, "All|*"});
-    location = program.openFile(dialog);
+    location = directory::resolveSymLink(program.openFile(dialog));
   }
 
   if(location) {

--- a/nall/nall/arguments.hpp
+++ b/nall/nall/arguments.hpp
@@ -61,6 +61,7 @@ inline auto Arguments::construct() -> void {
 
   //normalize path and file arguments
   for(auto& argument : arguments) {
+    argument = directory::resolveSymLink(argument);
     if(directory::exists(argument)) {
       argument.transform("\\", "/").trimRight("/").append("/");
       argument = Path::real(argument);

--- a/nall/nall/directory.cpp
+++ b/nall/nall/directory.cpp
@@ -87,4 +87,30 @@ NALL_HEADER_INLINE auto directory::ufiles(const string& pathname, const string& 
 
 #endif
 
+NALL_HEADER_INLINE auto directory::resolveSymLink(const string& pathname) -> string {
+  string result = pathname;
+#if defined (PLATFORM_WINDOWS)
+  HANDLE hFile = CreateFile(utf16_t(result.data()), GENERIC_READ, FILE_SHARE_READ, NULL, OPEN_EXISTING, 0, NULL);
+  if (hFile != INVALID_HANDLE_VALUE)
+  {
+      wchar_t buffer [MAX_PATH];
+      memset(buffer, 0, MAX_PATH * sizeof(wchar_t));
+      if (GetFinalPathNameByHandle(hFile, buffer, MAX_PATH, 0) < MAX_PATH) {
+        result = slice((const char*)utf8_t(buffer), 4, wcslen(buffer) - 4); //remove "\\?\" prefix
+      }
+      CloseHandle(hFile);
+  }
+#else
+  struct stat sb = {};
+  if (lstat(result.data(), &sb) != -1 && S_ISLNK(sb.st_mode)) {
+    char buffer[PATH_MAX];
+    memset(buffer, 0, PATH_MAX);
+    if(readlink(result.data(), buffer, PATH_MAX) < PATH_MAX) {
+      result = string{buffer};
+    }
+  }
+#endif
+  return result;
+}
+
 }

--- a/nall/nall/directory.cpp
+++ b/nall/nall/directory.cpp
@@ -91,18 +91,18 @@ NALL_HEADER_INLINE auto directory::resolveSymLink(const string& pathname) -> str
   string result = pathname;
 #if defined (PLATFORM_WINDOWS)
   HANDLE hFile = CreateFile(utf16_t(result.data()), GENERIC_READ, FILE_SHARE_READ, NULL, OPEN_EXISTING, 0, NULL);
-  if (hFile != INVALID_HANDLE_VALUE)
+  if(hFile != INVALID_HANDLE_VALUE)
   {
-      wchar_t buffer [MAX_PATH];
+      wchar_t buffer[MAX_PATH];
       memset(buffer, 0, MAX_PATH * sizeof(wchar_t));
-      if (GetFinalPathNameByHandle(hFile, buffer, MAX_PATH, 0) < MAX_PATH) {
+      if(GetFinalPathNameByHandle(hFile, buffer, MAX_PATH, 0) < MAX_PATH) {
         result = slice((const char*)utf8_t(buffer), 4, wcslen(buffer) - 4); //remove "\\?\" prefix
       }
       CloseHandle(hFile);
   }
 #else
   struct stat sb = {};
-  if (lstat(result.data(), &sb) != -1 && S_ISLNK(sb.st_mode)) {
+  if(lstat(result.data(), &sb) != -1 && S_ISLNK(sb.st_mode)) {
     char buffer[PATH_MAX];
     memset(buffer, 0, PATH_MAX);
     if(readlink(result.data(), buffer, PATH_MAX) < PATH_MAX) {

--- a/nall/nall/directory.hpp
+++ b/nall/nall/directory.hpp
@@ -1,7 +1,6 @@
 #pragma once
 
 #include <nall/file.hpp>
-#include <functional>
 #include <nall/inode.hpp>
 #include <nall/intrinsics.hpp>
 #include <nall/string.hpp>
@@ -26,6 +25,7 @@ struct directory : inode {
   static auto create(const string& pathname, u32 permissions = 0755) -> bool;  //recursive
   static auto remove(const string& pathname) -> bool;  //recursive
   static auto exists(const string& pathname) -> bool;
+  static auto resolveSymLink(const string& pathname) -> string;
 
   static auto folders(const string& pathname, const string& pattern = "*") -> std::vector<string> {
     auto folders = directory::ufolders(pathname, pattern);


### PR DESCRIPTION
The path handling in ares would always treat anything past the last trailing separator as the file name. This wasn't true in the case of a symlink pointing to a file. This will now be checked prior to path processing and the symlink will be resolved to its full path prior to processing. This results in no modifcation to existing directory/file/path handling in nall so it should be safe. 

With this in place, loading  a rom from a path with a symlink that involves either a symlink'ed directory or file in the path does what you would expect. This works when loading from a command line, or loading via the GUI. It should work across all operating systems, but I was unable to verify on MacOS (although I believe it should work). 

Fixes: https://github.com/ares-emulator/ares/issues/2201