### PR TITLE
Fix loading shaders from the command line

### DIFF
--- a/desktop-ui/presentation/presentation.cpp
+++ b/desktop-ui/presentation/presentation.cpp
@@ -730,16 +730,18 @@ auto Presentation::loadShaders() -> void {
     }
   }
 
-  if(program.startShader) {
+  if(program.startShader && !shaderArgApplied) {
+    shaderArgApplied = true;
     string existingShader = settings.video.shader;
 
+    program.startShader.transform("\\", "/");
     if(!program.startShader.imatch("None")) {
-      settings.video.shader = {location, program.startShader, ".slangp"};
+      settings.video.shader = {program.startShader, ".slangp"};
     } else {
       settings.video.shader = program.startShader;
     }
 
-    if(inode::exists(settings.video.shader)) {
+    if(inode::exists({location, settings.video.shader})) {
       ruby::video.setShader({location, settings.video.shader});
       loadShaders();
     } else if(settings.video.shader.imatch("None")) {
@@ -749,7 +751,8 @@ auto Presentation::loadShaders() -> void {
       hiro::MessageDialog()
           .setTitle("Warning")
           .setAlignment(hiro::Alignment::Center)
-          .setText({ "Requested shader not found: ", settings.video.shader , "\nUsing existing defined shader: ", existingShader })
+          .setText({"Requested shader not found: ", location, settings.video.shader , 
+            "\nUsing existing defined shader: ", location, existingShader})
           .warning();
       settings.video.shader = existingShader;
     }

--- a/desktop-ui/presentation/presentation.hpp
+++ b/desktop-ui/presentation/presentation.hpp
@@ -11,6 +11,7 @@ struct Presentation : Window {
   auto refreshSystemMenu() -> void;
 
   std::vector<string> shaderDirectories;
+  static inline bool shaderArgApplied = false;
 
   MenuBar menuBar{this};
     Menu loadMenu{&menuBar};


### PR DESCRIPTION
When a shader was specified as a command line argument, it would result in the loadShaders() function calling itself in a continuous loop with no exit. Processing the presence of the `--shader` command line argument will now only occur once. Additionally, the shader name stored in the settings.bml file should not include a full path, it should be relative to the shader directory, minus the slangp extension. 

This impacted all platforms, not just Windows (the issue was opened against Windows).

Fixes: https://github.com/ares-emulator/ares/issues/2141