### PR TITLE
Add pseudo fullscreen command line argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ Usage: ./ares [options] game(s)
   --help                 Displays available options and exit
   --terminal             Create new terminal window (Windows only)
   --fullscreen           Start in full screen mode
+  --pseudofullscreen     Start in pseudo full screen mode
   --system system        Specify the system name
   --shader shader        Specify a slang shader to load (requires OpenGL or Metal)
   --setting name=value   Specify a value for a setting

--- a/desktop-ui/desktop-ui.cpp
+++ b/desktop-ui/desktop-ui.cpp
@@ -76,6 +76,8 @@ auto nall::main(Arguments arguments) -> void {
 
   if(arguments.take("--fullscreen")) {
     program.startFullScreen = true;
+  } else if(arguments.take("--pseudofullscreen")) {
+    program.startPseudoFullScreen = true;
   }
 
   if(string system; arguments.take("--system", system)) {
@@ -128,6 +130,7 @@ auto nall::main(Arguments arguments) -> void {
     print("  --terminal           Create new terminal window\n");
 #endif
     print("  --fullscreen         Start in full screen mode\n");
+    print("  --pseudofullscreen   Start in psuedo full screen mode\n");
     print("  --system name        Specify the system name\n");
     print("  --shader name        Specify the name of the shader to use\n");
     print("  --setting name=value Specify a value for a setting\n");

--- a/desktop-ui/program/drivers.cpp
+++ b/desktop-ui/program/drivers.cpp
@@ -62,14 +62,20 @@ auto Program::videoPseudoFullScreenToggle() -> void {
   Program::Guard guard;
   if(ruby::video.fullScreen()) return;
 
+  ruby::video.clear();
   if(!presentation.fullScreen()) {
     presentation.setFullScreen(true);
     presentation.menuBar.setVisible(false);
-    if(!ruby::input.acquired() && ruby::video.hasMonitors().size() == 1) ruby::input.acquire();
+    if(!ruby::input.acquired() && ruby::video.hasMonitors().size() == 1) {
+      ruby::input.acquire();
+    }
   } else {
-    if(ruby::input.acquired()) ruby::input.release();
+    if(ruby::input.acquired()) {
+      ruby::input.release();
+    }
     presentation.menuBar.setVisible(true);
     presentation.setFullScreen(false);
+    presentation.viewport.setFocused();
   }
 }
 

--- a/desktop-ui/program/load.cpp
+++ b/desktop-ui/program/load.cpp
@@ -64,7 +64,7 @@ auto Program::load(string location) -> bool {
   runAheadUpdate();
   presentation.loadEmulator();
   presentation.showIcon(false);
-  if(settings.video.adaptiveSizing) presentation.resizeWindow();
+  if(settings.video.adaptiveSizing  && !startPseudoFullScreen) presentation.resizeWindow();
   manifestViewer.reload();
   cheatEditor.reload();
   memoryEditor.reload();

--- a/desktop-ui/program/program.cpp
+++ b/desktop-ui/program/program.cpp
@@ -30,6 +30,7 @@ auto Program::create() -> void {
         if(emulator->name == startSystem) {
           if(load(emulator, gameToLoad)) {
             if(startFullScreen) videoFullScreenToggle();
+            if(startPseudoFullScreen) videoPseudoFullScreenToggle();
           }
           return;
         }
@@ -39,6 +40,7 @@ auto Program::create() -> void {
     if(auto emulator = identify(gameToLoad)) {
       if(load(emulator, gameToLoad)) {
         if(startFullScreen) videoFullScreenToggle();
+        if(startPseudoFullScreen) videoPseudoFullScreenToggle();
       }
     }
   }
@@ -130,7 +132,7 @@ auto Program::main() -> void {
   //Window operations must be performed from the main thread.
   
   if(_needsResize) {
-    if(settings.video.adaptiveSizing) presentation.resizeWindow();
+    if(settings.video.adaptiveSizing && !startPseudoFullScreen) presentation.resizeWindow();
     _needsResize = false;
   }
 

--- a/desktop-ui/program/program.hpp
+++ b/desktop-ui/program/program.hpp
@@ -57,6 +57,7 @@ struct Program : ares::Platform {
   auto inputDriverUpdate() -> void;
 
   bool startFullScreen = false;
+  bool startPseudoFullScreen = false;
   std::vector<string> startGameLoad;
   bool noFilePrompt = false;
 

--- a/nall/nall/directory.cpp
+++ b/nall/nall/directory.cpp
@@ -96,7 +96,7 @@ NALL_HEADER_INLINE auto directory::resolveSymLink(const string& pathname) -> str
       wchar_t buffer[MAX_PATH];
       memset(buffer, 0, MAX_PATH * sizeof(wchar_t));
       if(GetFinalPathNameByHandle(hFile, buffer, MAX_PATH, 0) < MAX_PATH) {
-        result = slice((const char*)utf8_t(buffer), 4, wcslen(buffer) - 4); //remove "\\?\" prefix
+        result = (slice((const char*)utf8_t(buffer), 4, wcslen(buffer) - 4)).transform("\\", "/"); //remove "\\?\" prefix
       }
       CloseHandle(hFile);
   }


### PR DESCRIPTION
Add a command line option to open a game in pseudo-fullscreen mode for use with frontends. This was requested in our Discord, but I don't think there was an issue opened for it (at least I couldn't find one). 

This also has a fix for something I missed with the symlink PR that impacted loading from the GUI (Windows only). 