### PR TITLE
m32x: adjust H32 pixel offset between Gen/MD VDP and 32X VDP

### DIFF
--- a/ares/md/vdp-performance/main.cpp
+++ b/ares/md/vdp-performance/main.cpp
@@ -67,7 +67,7 @@ auto VDP::main() -> void {
   } else if(hcounter() == 0x80) {
     if(vcounter() < screenHeight() && !runAhead()) {
       render();
-      if(Mega32X()) m32x.vdp.scanline(pixels() + 18, vcounter()); //approx 3 and 1/4 pixel offset
+      if(Mega32X()) m32x.vdp.scanline(pixels() + 13, vcounter()); //approx 3 and 1/4 pixel offset in H40 pixels
     }
 
     step(768);

--- a/ares/md/vdp/main.cpp
+++ b/ares/md/vdp/main.cpp
@@ -184,7 +184,7 @@ auto VDP::mainH32() -> void {
   sprite.begin();
   if(dac.pixels) {
     blocks<false, true>();
-    if(Mega32X()) m32x.vdp.scanline(pixels + 18, vcounter()); //approx 3 and 1/4 pixel offset
+    if(Mega32X()) m32x.vdp.scanline(pixels + 13, vcounter()); //approx 3 and 1/4 pixel offset in H40 pixels
     if(MegaLD()) mcd.ld.scanline(dac.pixels, vcounter());
   } else {
     blocks<false, false>();


### PR DESCRIPTION
The adjusted offset is equal to 2.6 H32 pixels / 3.25 H40 pixels.