### PR TITLE
Expose option to not prompt for secondary media in GUI

### DIFF
--- a/desktop-ui/emulator/emulator.cpp
+++ b/desktop-ui/emulator/emulator.cpp
@@ -146,7 +146,7 @@ auto Emulator::load(std::shared_ptr<mia::Pak> pak, string& path) -> string {
   } else if(!program.startGameLoad.empty()) {
     location = program.startGameLoad.front();
     program.startGameLoad.erase(program.startGameLoad.begin()); //pull from the command line if an entry is available
-  } else if(!program.noFilePrompt) {
+  } else if(!program.noFilePrompt && !settings.general.noFilePrompt) {
     BrowserDialog dialog;
     dialog.setTitle({"Load ", pak->name(), " Game"});
     dialog.setPath(path ? path : Path::desktop());

--- a/desktop-ui/settings/options.cpp
+++ b/desktop-ui/settings/options.cpp
@@ -51,7 +51,7 @@ auto OptionSettings::construct() -> void {
   nintendo64ExpansionPakLayout.setAlignment(1).setPadding(12_sx, 0);
     nintendo64ExpansionPakHint.setText("Enable/Disable the 4MB Expansion Pak").setFont(Font().setSize(7.0)).setForegroundColor(SystemColor::Sublabel);
 
-  for (auto& opt : array<string[4]>{"32KiB (Default)", "128KiB (Datel 1Meg)", "512KiB (Datel 4Meg)", "1984KiB (Maximum)"}) {
+  for(auto& opt : array<string[4]>{"32KiB (Default)", "128KiB (Datel 1Meg)", "512KiB (Datel 4Meg)", "1984KiB (Maximum)"}) {
     ComboButtonItem item{&nintendo64ControllerPakBankOption};
     item.setText(opt);
     if (opt == settings.nintendo64.controllerPakBankString) {

--- a/desktop-ui/settings/options.cpp
+++ b/desktop-ui/settings/options.cpp
@@ -9,32 +9,39 @@ auto OptionSettings::construct() -> void {
     program.rewindReset();
   }).doToggle();
   rewindLayout.setAlignment(1).setPadding(12_sx, 0);
-      rewindHint.setText("Allows you to reverse time via the rewind hotkey").setFont(Font().setSize(7.0)).setForegroundColor(SystemColor::Sublabel);
+    rewindHint.setText("Allows you to reverse time via the rewind hotkey").setFont(Font().setSize(7.0)).setForegroundColor(SystemColor::Sublabel);
 
   runAhead.setText("Run-Ahead").setEnabled(co_serializable()).setChecked(settings.general.runAhead && co_serializable()).onToggle([&] {
     settings.general.runAhead = runAhead.checked() && co_serializable();
     program.runAheadUpdate();
   });
   runAheadLayout.setAlignment(1).setPadding(12_sx, 0);
-      runAheadHint.setText("Removes one frame of input lag, but doubles system requirements").setFont(Font().setSize(7.0)).setForegroundColor(SystemColor::Sublabel);
+    runAheadHint.setText("Removes one frame of input lag, but doubles system requirements").setFont(Font().setSize(7.0)).setForegroundColor(SystemColor::Sublabel);
 
   autoSaveMemory.setText("Auto-Save Memory Periodically").setChecked(settings.general.autoSaveMemory).onToggle([&] {
     settings.general.autoSaveMemory = autoSaveMemory.checked();
   });
   autoSaveMemoryLayout.setAlignment(1).setPadding(12_sx, 0);
-      autoSaveMemoryHint.setText("Helps safeguard game saves from being lost").setFont(Font().setSize(7.0)).setForegroundColor(SystemColor::Sublabel);
+    autoSaveMemoryHint.setText("Helps safeguard game saves from being lost").setFont(Font().setSize(7.0)).setForegroundColor(SystemColor::Sublabel);
 
   homebrewMode.setText("Homebrew Development Mode").setChecked(settings.general.homebrewMode).onToggle([&] {
     settings.general.homebrewMode = homebrewMode.checked();
   });
   homebrewModeLayout.setAlignment(1).setPadding(12_sx, 0);
-      homebrewModeHint.setText("Activate core-specific features to help homebrew developers").setFont(Font().setSize(7.0)).setForegroundColor(SystemColor::Sublabel);
+    homebrewModeHint.setText("Activate core-specific features to help homebrew developers").setFont(Font().setSize(7.0)).setForegroundColor(SystemColor::Sublabel);
 
   forceInterpreter.setText("Force Interpreter").setChecked(settings.general.forceInterpreter).onToggle([&] {
     settings.general.forceInterpreter = forceInterpreter.checked();
   });
   forceInterpreterLayout.setAlignment(1).setPadding(12_sx, 0);
-      forceInterpreterHint.setText("(Slow) Enable interpreter for cores that default to a recompiler").setFont(Font().setSize(7.0)).setForegroundColor(SystemColor::Sublabel);
+    forceInterpreterHint.setText("(Slow) Enable interpreter for cores that default to a recompiler").setFont(Font().setSize(7.0)).setForegroundColor(SystemColor::Sublabel);
+
+  noFilePromptOption.setText("Disable requests for loading additional media").setChecked(settings.general.noFilePrompt).onToggle([&] {
+    settings.general.noFilePrompt = noFilePromptOption.checked();
+    
+  });
+  noFilePromptLayout.setAlignment(1).setPadding(12_sx, 0);
+    noFilePromptHint.setText("Suppress secondary file load prompts (equivalent to --no-file-prompt)").setFont(Font().setSize(7.0)).setForegroundColor(SystemColor::Sublabel);
 
   nintendo64SettingsLabel.setText("Nintendo 64 Settings").setFont(Font().setBold());
 
@@ -42,7 +49,7 @@ auto OptionSettings::construct() -> void {
     settings.nintendo64.expansionPak = nintendo64ExpansionPakOption.checked();
   });
   nintendo64ExpansionPakLayout.setAlignment(1).setPadding(12_sx, 0);
-      nintendo64ExpansionPakHint.setText("Enable/Disable the 4MB Expansion Pak").setFont(Font().setSize(7.0)).setForegroundColor(SystemColor::Sublabel);
+    nintendo64ExpansionPakHint.setText("Enable/Disable the 4MB Expansion Pak").setFont(Font().setSize(7.0)).setForegroundColor(SystemColor::Sublabel);
 
   for (auto& opt : array<string[4]>{"32KiB (Default)", "128KiB (Datel 1Meg)", "512KiB (Datel 4Meg)", "1984KiB (Maximum)"}) {
     ComboButtonItem item{&nintendo64ControllerPakBankOption};
@@ -79,8 +86,8 @@ auto OptionSettings::construct() -> void {
     }
   });
   nintendo64ControllerPakBankLayout.setAlignment(1).setPadding(12_sx, 0);
-      nintendo64ControllerPakBankLabel.setText("Controller Pak Size:");
-      nintendo64ControllerPakBankHint.setText("Sets the size of a newly created Controller Pak's available memory").setFont(Font().setSize(7.0)).setForegroundColor(SystemColor::Sublabel);
+    nintendo64ControllerPakBankLabel.setText("Controller Pak Size:");
+    nintendo64ControllerPakBankHint.setText("Sets the size of a newly created Controller Pak's available memory").setFont(Font().setSize(7.0)).setForegroundColor(SystemColor::Sublabel);
 
   gameBoyAdvanceSettingsLabel.setText("Game Boy Advance Settings").setFont(Font().setBold());
 

--- a/desktop-ui/settings/settings.cpp
+++ b/desktop-ui/settings/settings.cpp
@@ -106,6 +106,7 @@ auto Settings::process(bool load) -> void {
   bind(boolean, "General/AutoSaveMemory", general.autoSaveMemory);
   bind(boolean, "General/HomebrewMode", general.homebrewMode);
   bind(boolean, "General/ForceInterpreter", general.forceInterpreter);
+  bind(boolean, "General/NoFilePrompt", general.noFilePrompt);
 
   bind(natural, "Rewind/Length", rewind.length);
   bind(natural, "Rewind/Frequency", rewind.frequency);

--- a/desktop-ui/settings/settings.hpp
+++ b/desktop-ui/settings/settings.hpp
@@ -73,6 +73,7 @@ struct Settings : Markup::Node {
     bool autoSaveMemory = true;
     bool homebrewMode = false;
     bool forceInterpreter = false;
+    bool noFilePrompt = false;
   } general;
 
   struct Rewind {
@@ -267,6 +268,9 @@ struct OptionSettings : VerticalLayout {
     HorizontalLayout forceInterpreterLayout{this, Size{~0, 0}, 5};
       CheckLabel forceInterpreter{&forceInterpreterLayout, Size{0, 0}, 5};
       Label forceInterpreterHint{&forceInterpreterLayout, Size{0, 0}};
+    HorizontalLayout noFilePromptLayout{this, Size{~0, 0}, 5};
+      CheckLabel noFilePromptOption{&noFilePromptLayout, Size{0, 0}, 5};
+      Label noFilePromptHint{&noFilePromptLayout, Size{0, 0}};
   Label nintendo64SettingsLabel{this, Size{~0, 0}, 5};
     HorizontalLayout nintendo64ExpansionPakLayout{this, Size{~0, 0}, 5};
       CheckLabel nintendo64ExpansionPakOption{&nintendo64ExpansionPakLayout, Size{0, 0}, 5};
@@ -274,7 +278,6 @@ struct OptionSettings : VerticalLayout {
     HorizontalLayout nintendo64ControllerPakBankLayout{this, Size{~0, 0}, 5};
       Label nintendo64ControllerPakBankLabel{&nintendo64ControllerPakBankLayout, Size{0, 0}};
       ComboButton nintendo64ControllerPakBankOption{&nintendo64ControllerPakBankLayout, Size{0, 0}};
-      // LineEdit nintendo64ControllerPakBankOption{&nintendo64ControllerPakBankLayout, Size{40, 0}};
       Label nintendo64ControllerPakBankHint{&nintendo64ControllerPakBankLayout, Size{0, 0}};
 
   Label gameBoyAdvanceSettingsLabel{this, Size{~0, 0}, 5};


### PR DESCRIPTION
We have a command line option `--no-file-prompt` that suppresses requests to load secondary media (e.g. N64DD), but the option wasn't available to GUI. This adds an option in Settings > Options to disable secondary load requests and save preferences to the settings.bml file.