### PR TITLE
Fix Dip Switches menu on Linux

### DIFF
--- a/desktop-ui/presentation/presentation.cpp
+++ b/desktop-ui/presentation/presentation.cpp
@@ -520,7 +520,7 @@ auto Presentation::refreshSystemMenu() -> void {
 
   //Build the Dip Switch menu if the emulator core has a DIP Switches node
   if(auto dipSwitches = ares::Node::find<ares::Node::Object>(emulator->root, "DIP Switches")) {
-    Menu dipSwitchMenu;
+    Menu dipSwitchMenu{&systemMenu};
     dipSwitchMenu.setText("DIP Switches");
     
     for(auto dip : ares::Node::enumerate<ares::Node::Setting::Boolean>(emulator->root)) {
@@ -550,8 +550,6 @@ auto Presentation::refreshSystemMenu() -> void {
         });
       }
     }
-
-    if(dipSwitchMenu.actionCount() > 0) systemMenu.append(dipSwitchMenu);
   }
   if(systemMenu.actionCount() > 0) systemMenu.append(MenuSeparator());
 


### PR DESCRIPTION
The DIP Switches menu on Linux failed to render properly (no sub-menu options available). This fixes the menu hierarchy so that all options are visible/available on all platforms. 

Fixes: https://github.com/ares-emulator/ares/issues/1894