### PR TITLE
n64: implement support for region-free ROMs (homebrew extension)

### DIFF
--- a/desktop-ui/emulator/emulator.cpp
+++ b/desktop-ui/emulator/emulator.cpp
@@ -45,11 +45,10 @@ auto Emulator::region() -> string {
     if(!regions.empty()) {
       for(auto &prefer: preferredRegions) {
         if(std::ranges::find(regions, prefer) != regions.end()) return prefer; //NTSC-U, NTSC-J or PAL
+        if(prefer == "NTSC-U" || prefer == "NTSC-J") {
+          if(std::ranges::find(regions, string("NTSC")) != regions.end()) return "NTSC";
+        }
       }
-
-      //Handle generic "NTSC" region.
-      //NOTE: we don't need to check PAL because the above check covered it
-      if(std::ranges::find(regions, string{"NTSC"}) != regions.end()) return "NTSC";
 
       //If no preferred region was found, return the first region in the list
       //NOTE: required for 'unsual' regions like NTSC-DEV for 64DD

--- a/mia/medium/nintendo-64.cpp
+++ b/mia/medium/nintendo-64.cpp
@@ -258,6 +258,7 @@ auto Nintendo64::analyze(std::vector<u8>& data) -> string {
   case 'X': region = "PAL";  break;  //Europe
   case 'Y': region = "PAL";  break;  //Europe
   case 'Z': region = "PAL";  break;  //Europe
+  case 0:   region = "NTSC,PAL,MPAL"; break;  //region free (respect user preference)
   }
 
   if(region != "NTSC") {
@@ -771,7 +772,16 @@ auto Nintendo64::analyze(std::vector<u8>& data) -> string {
     if(config.bit(4,7) == 6) {sram = 128_KiB;}
     if(config.bit(0) == 1)   {rtc = true;}
 
-    //Advanced Homebrew ROM Header
+    //region free. The ROM will work on any region, irrespective of what is
+    //specified in the region code byte. So declare all regions (keeping 
+    //implicit preference for original region), so that Ares will respect
+    //user's preference.
+    if(config.bit(1) == 1) {
+      if(region == "NTSC") region = "NTSC,PAL,MPAL";
+      if(region == "PAL")  region = "PAL,NTSC,MPAL";
+      if(region == "MPAL") region = "MPAL,NTSC,PAL";
+    }
+
     //Controllers
     n8 controller_1 = data[0x34];
     n8 controller_2 = data[0x35];


### PR DESCRIPTION
The advanced homebrew header (https://n64brew.dev/wiki/ROM_Header) specifies a bit to mark a ROM as "region free", meaning that it can be booted in all regions. Ares now has a region preference option, so that option can be respected for the region free ROMs.