### PR TITLE
Add hotkey to disable/enable selected shader

### DIFF
--- a/desktop-ui/input/hotkeys.cpp
+++ b/desktop-ui/input/hotkeys.cpp
@@ -2,7 +2,7 @@ auto InputManager::createHotkeys() -> void {
   static bool fastForwardVideoBlocking;
   static bool fastForwardAudioBlocking;
   static bool fastForwardAudioDynamic;
-
+  
   hotkeys.push_back(InputHotkey("Toggle Fullscreen").onPress([&] {
     program.videoFullScreenToggle();
   }));
@@ -156,6 +156,17 @@ auto InputManager::createHotkeys() -> void {
   hotkeys.push_back(InputHotkey("Decrease Audio").onPress([&] {
     if(!emulator) return;
     if(settings.audio.volume >= (f64)(0.1)) settings.audio.volume -= (f64)(0.1);
+  }));
+
+  hotkeys.push_back(InputHotkey("Enable/Disable Shader").onPress([&] {
+    if(!emulator) return;
+    if(!settings.video.shader.imatch("None")) {
+      if(ruby::video.shader().imatch("None")) {
+        ruby::video.setShader({locate("Shaders/"), settings.video.shader});
+      } else {
+        ruby::video.setShader("None");
+      }
+    }
   }));
 }
 

--- a/desktop-ui/input/hotkeys.cpp
+++ b/desktop-ui/input/hotkeys.cpp
@@ -158,7 +158,7 @@ auto InputManager::createHotkeys() -> void {
     if(settings.audio.volume >= (f64)(0.1)) settings.audio.volume -= (f64)(0.1);
   }));
 
-  hotkeys.push_back(InputHotkey("Enable/Disable Shader").onPress([&] {
+  hotkeys.push_back(InputHotkey("Toggle Shader Display").onPress([&] {
     if(!emulator) return;
     if(!settings.video.shader.imatch("None")) {
       if(ruby::video.shader().imatch("None")) {

--- a/desktop-ui/input/hotkeys.cpp
+++ b/desktop-ui/input/hotkeys.cpp
@@ -2,7 +2,7 @@ auto InputManager::createHotkeys() -> void {
   static bool fastForwardVideoBlocking;
   static bool fastForwardAudioBlocking;
   static bool fastForwardAudioDynamic;
-  
+
   hotkeys.push_back(InputHotkey("Toggle Fullscreen").onPress([&] {
     program.videoFullScreenToggle();
   }));


### PR DESCRIPTION
Adds a hotkey that allows for enabling/disabling the currently selected shader. This does not erase your currently selected/saved shader. To permanently change shader selection, you still need to use the shader menu or the --shader command line argument.