### PR TITLE
Add command line option to specify a save state slot to load

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ Usage: ./ares [options] game(s)
   --dump-all-settings    Show a list of all existing settings and exit
   --no-file-prompt       Do not prompt to load (optional) additional roms (eg: 64DD)
   --settings-file path   Specify a settings file override (settings.bml)
+  --save-state slot      Specify a save state slot to load (1-9)
 ```
 
 The --system option is useful when the system type cannot be auto-detected.

--- a/desktop-ui/desktop-ui.cpp
+++ b/desktop-ui/desktop-ui.cpp
@@ -97,6 +97,12 @@ auto nall::main(Arguments arguments) -> void {
     settings.filePath = settingsFile;
   }
 
+  if(string savestate; arguments.take("--save-state", savestate)) {
+    if(savestate.length() == 1 && savestate[0] >= '1' && savestate[0] <= '9') {
+      program.startSaveStateSlot = savestate;
+    }
+  }
+
   inputManager.create();
   Emulator::construct();
 
@@ -125,17 +131,19 @@ auto nall::main(Arguments arguments) -> void {
   if(arguments.take("--help")) {
     print("Usage: ares [OPTIONS]... game(s)\n\n");
     print("Options:\n");
-    print("  --help               Displays available options and exit\n");
+    print("  --help                Displays available options and exit\n");
 #if defined(PLATFORM_WINDOWS)
-    print("  --terminal           Create new terminal window\n");
+    print("  --terminal            Create new terminal window\n");
 #endif
-    print("  --fullscreen         Start in full screen mode\n");
-    print("  --pseudofullscreen   Start in psuedo full screen mode\n");
-    print("  --system name        Specify the system name\n");
-    print("  --shader name        Specify the name of the shader to use\n");
-    print("  --setting name=value Specify a value for a setting\n");
-    print("  --dump-all-settings  Show a list of all existing settings and exit\n");
-    print("  --no-file-prompt     Do not prompt to load (optional) additional roms (eg: 64DD)\n");
+    print("  --fullscreen          Start in full screen mode\n");
+    print("  --pseudofullscreen    Start in psuedo full screen mode\n");
+    print("  --system name         Specify the system name\n");
+    print("  --shader name         Specify the name of the shader to use\n");
+    print("  --setting name=value  Specify a value for a setting\n");
+    print("  --dump-all-settings   Show a list of all existing settings and exit\n");
+    print("  --no-file-prompt      Do not prompt to load (optional) additional roms (eg: 64DD)\n");
+    print("  --settings-file path  Specify a settings file override (settings.bml)\n");
+    print("  --save-state slot     Specify a save state slot to load (1-9)\n");
     print("\n");
     print("Available Systems:\n");
     print("  ");

--- a/desktop-ui/program/load.cpp
+++ b/desktop-ui/program/load.cpp
@@ -103,6 +103,10 @@ auto Program::load(string location) -> bool {
 
   configuration = emulator->root->attribute("configuration");
 
+  if(program.startSaveStateSlot) {
+    stateLoad(program.startSaveStateSlot.integer());
+  }
+
   return true;
 }
 

--- a/desktop-ui/program/load.cpp
+++ b/desktop-ui/program/load.cpp
@@ -104,7 +104,9 @@ auto Program::load(string location) -> bool {
   configuration = emulator->root->attribute("configuration");
 
   if(program.startSaveStateSlot) {
-    stateLoad(program.startSaveStateSlot.integer());
+    if(stateLoad(program.startSaveStateSlot.integer())) {
+      state.slot = program.startSaveStateSlot.integer();
+    }
   }
 
   return true;

--- a/desktop-ui/program/program.hpp
+++ b/desktop-ui/program/program.hpp
@@ -63,6 +63,7 @@ struct Program : ares::Platform {
 
   string startSystem;
   string startShader;
+  string startSaveStateSlot;
 
   std::vector<ares::Node::Video::Screen> screens;
   std::vector<ares::Node::Audio::Stream> streams;


### PR DESCRIPTION
Requested by frontend devs, this adds the ability to automatically load a save state slot (1-9) from the command line. 