### PR TITLE
Fix optnone attribute warning when building with GCC

### DIFF
--- a/nall/nall/platform.hpp
+++ b/nall/nall/platform.hpp
@@ -159,8 +159,13 @@ namespace nall {
   #define MSG_NOSIGNAL 0
 #endif
 
-#if defined(COMPILER_CLANG) || defined(COMPILER_GCC)
+#if defined(COMPILER_CLANG) 
   #define no_optimize __attribute__((optnone))
+#elif defined(COMPILER_GCC)
+  #define no_optimize __attribute__((optimize("O0")))
+#endif 
+
+#if defined(COMPILER_CLANG) || defined(COMPILER_GCC)
   #define NALL_NOINLINE __attribute__((noinline))
   #define alwaysinline inline __attribute__((always_inline))
   #define NALL_USED __attribute__((used))


### PR DESCRIPTION
This fixes the last warnings seen when compiling with GCC, which were `warning: ‘optnone’ attribute directive ignored`

There are still two unreachable code warnings but they are part of zstd, a dependency for libchdr. I checked the latest version of zstd and the code has not changed.

This is the last remaining problem as described in issue: https://github.com/ares-emulator/ares/issues/1818