### PR TITLE
Stay in pseudo-fullscreen when game is reset

### DIFF
--- a/desktop-ui/program/drivers.cpp
+++ b/desktop-ui/program/drivers.cpp
@@ -69,6 +69,7 @@ auto Program::videoPseudoFullScreenToggle() -> void {
     if(!ruby::input.acquired() && ruby::video.hasMonitors().size() == 1) {
       ruby::input.acquire();
     }
+    startPseudoFullScreen = true;
   } else {
     if(ruby::input.acquired()) {
       ruby::input.release();
@@ -76,6 +77,7 @@ auto Program::videoPseudoFullScreenToggle() -> void {
     presentation.menuBar.setVisible(true);
     presentation.setFullScreen(false);
     presentation.viewport.setFocused();
+    startPseudoFullScreen = false;
   }
 }
 


### PR DESCRIPTION
This fixes an issue where if you were in pseudo-fullscreen mode and reset a game, it would drop you back into a normal window and the menu bar would be missing. Resetting a game now while in pseudo-fullscreen mode will stay in this mode. Note that fullscreen already works properly and didn't need to be modified.