### PR TITLE
n64: with homebrew header, don't default to install a controller pak

### DIFF
--- a/mia/medium/nintendo-64.cpp
+++ b/mia/medium/nintendo-64.cpp
@@ -829,9 +829,9 @@ auto Nintendo64::analyze(std::vector<u8>& data) -> string {
     read_controller_config(3, controller_4);
 
     if (controller_1 == 0x00 && controller_2 == 0x00 && controller_3 == 0x00 && controller_4 == 0x00) {
-      // No controllers configured, set default used for years as backward compatibility
-      cpaks[0] = true;
-      rpaks[1] = true;
+      // No controllers configured. By default, just enable Rumble Pak as that
+      // doesn't hurt in any way, nor create save files.
+      rpaks[0] = true;
     }
   }
 


### PR DESCRIPTION
When the homebrew header was first introduced, in its first limited spec, Ares defaulted to enable both rumble pak and controller pak: https://github.com/ares-emulator/ares/commit/bc8c308ee96162f5a7068001a0ece83e5f821e16

Back at the time, there wasn't any way to specify that a controller pak was needed by the ROM, and Ares didn't even provide a GUI to install it. So basically this was the only way to allow a homebrew game to use the controller pak at all.

Fast forward 4 years and now we have a GUI to select which pak to install on each controller, and the homebrew header allows to pre-install whatever you want into each port.

In case the user doesn't specify a suggested controller configuration in the homebrew header, the default of using a controller pak has the annoying side effect of creating a useless .sav file next to any ROM. CPak is not very common in homebrew ROMs anyway, so enabling it by default now seems to create more hassle than it solves.