### PR TITLE
Fix crash opening about window

### DIFF
--- a/desktop-ui/presentation/presentation.cpp
+++ b/desktop-ui/presentation/presentation.cpp
@@ -229,6 +229,7 @@ Presentation::Presentation() {
   helpMenu.setText("Help");
   aboutAction.setText("About" ELLIPSIS).setIcon(Icon::Prompt::Question).onActivate([&] {
     multiFactorImage logo(Resource::Ares::Logo1x, Resource::Ares::Logo2x);
+    Program::Guard guard;
     AboutDialog()
     .setName(ares::Name)
     .setLogo(logo)

--- a/hiro/extension/about-dialog.cpp
+++ b/hiro/extension/about-dialog.cpp
@@ -148,7 +148,7 @@ auto AboutDialog::show() -> void {
   if(!state.website) websiteLayout.setVisible(false);
 
   window.setTitle({"About ", state.name ? state.name : Application::name()});
-  window.setSize({max(320_sx, layout.minimumSize().width()), layout.minimumSize().height()});
+  window.setSize({max(480_sx, layout.minimumSize().width()), layout.minimumSize().height()});
   window.setResizable(false);
   window.setAlignment(state.relativeTo, state.alignment);
   window.setDismissable();


### PR DESCRIPTION
Opening the about box while a game was running could result in ares crashing. 

I'm also increasing the size of the about box because the version string was being cutoff on Linux. 