### PR TITLE
add option to print version string

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ When started from the command-line, ares accepts a few options.
 Usage: ./ares [options] game(s)
 
   --help                 Displays available options and exit
+  --version              Displays the version string of the application
   --terminal             Create new terminal window (Windows only)
   --fullscreen           Start in full screen mode
   --pseudofullscreen     Start in pseudo full screen mode

--- a/desktop-ui/desktop-ui.cpp
+++ b/desktop-ui/desktop-ui.cpp
@@ -132,6 +132,7 @@ auto nall::main(Arguments arguments) -> void {
     print("Usage: ares [OPTIONS]... game(s)\n\n");
     print("Options:\n");
     print("  --help                Displays available options and exit\n");
+    print("  --version             Displays the version string of the application");
 #if defined(PLATFORM_WINDOWS)
     print("  --terminal            Create new terminal window\n");
 #endif
@@ -151,6 +152,11 @@ auto nall::main(Arguments arguments) -> void {
       print(emulator->name, ", ");
     }
     print("\n");
+    return;
+  }
+
+  if(arguments.take("--version")) {
+    print("\n", ares::Version, "\n");
     return;
   }
 

--- a/desktop-ui/desktop-ui.cpp
+++ b/desktop-ui/desktop-ui.cpp
@@ -129,10 +129,10 @@ auto nall::main(Arguments arguments) -> void {
   }
 
   if(arguments.take("--help")) {
-    print("Usage: ares [OPTIONS]... game(s)\n\n");
+    print("\n Usage: ares [OPTIONS]... game(s)\n\n");
     print("Options:\n");
     print("  --help                Displays available options and exit\n");
-    print("  --version             Displays the version string of the application");
+    print("  --version             Displays the version string of the application\n");
 #if defined(PLATFORM_WINDOWS)
     print("  --terminal            Create new terminal window\n");
 #endif
@@ -151,7 +151,7 @@ auto nall::main(Arguments arguments) -> void {
     for(auto& emulator : emulators) {
       print(emulator->name, ", ");
     }
-    print("\n");
+    print("\n\nares version ", ares::Version, "\n");
     return;
   }
 

--- a/desktop-ui/presentation/presentation.cpp
+++ b/desktop-ui/presentation/presentation.cpp
@@ -551,8 +551,9 @@ auto Presentation::refreshSystemMenu() -> void {
         });
       }
     }
+
+    systemMenu.append(MenuSeparator());
   }
-  if(systemMenu.actionCount() > 0) systemMenu.append(MenuSeparator());
 
   u32 portsFound = 0;
   for(auto port : ares::Node::enumerate<ares::Node::Port>(emulator->root)) {

--- a/nall/nall/main.cpp
+++ b/nall/nall/main.cpp
@@ -37,6 +37,7 @@ auto main(int argc, char** argv) -> int {
   #endif
 
   #if defined(PLATFORM_WINDOWS)
+  WSACleanup();
   CoUninitialize();
   #endif
   return EXIT_SUCCESS;


### PR DESCRIPTION
Adds a '--version' option to print the ares version string to the command line. 

Also fixes an issue where two separators could be added to the emulator specific menu, e.g. the LaserActive (Sega PAC). 