### PR TITLE
Add ability to change disc for ldrom2 titles

### DIFF
--- a/ares/pce/pcd/pcd.cpp
+++ b/ares/pce/pcd/pcd.cpp
@@ -26,7 +26,7 @@ auto PCD::load(Node::Object parent) -> void {
     tray->setType("Compact Disc");
   }
   tray->setHotSwappable(true);
-  tray->setAllocate([&](auto name) { return allocate(tray); });
+  tray->setAllocate([&](auto name) { return allocate(tray, name); });
   tray->setConnect([&] { return connect(); });
   tray->setDisconnect([&] { return disconnect(); });
 
@@ -99,9 +99,11 @@ auto PCD::unload() -> void {
   node.reset();
 }
 
-auto PCD::allocate(Node::Port parent) -> Node::Peripheral {
+auto PCD::allocate(Node::Port parent, string name) -> Node::Peripheral {
   if (Model::LaserActive()) {
-    return disc = parent->append<Node::Peripheral>("Laserdisc");
+    disc = parent->append<Node::Peripheral>("Laserdisc");
+    disc->setAttribute("media", name);
+    return disc;
   }
   return disc = parent->append<Node::Peripheral>("PC Engine CD Disc");
 }
@@ -142,6 +144,9 @@ auto PCD::disconnect() -> void {
   fd.reset();
   pak.reset();
   disc.reset();
+  if(Model::LaserActive()) {
+    ld.notifyDiscEjected();
+  }
 }
 
 auto PCD::save() -> void {

--- a/ares/pce/pcd/pcd.hpp
+++ b/ares/pce/pcd/pcd.hpp
@@ -34,7 +34,7 @@ struct PCD : Thread {
   auto load(Node::Object) -> void;
   auto unload() -> void;
 
-  auto allocate(Node::Port) -> Node::Peripheral;
+  auto allocate(Node::Port, string name) -> Node::Peripheral;
   auto connect() -> void;
   auto disconnect() -> void;
 


### PR DESCRIPTION
The ability to change discs for LDROM2 titles was missing originally and is now being added.

Fixes: https://github.com/ares-emulator/ares/issues/2388