### PR TITLE
Keep VI serrate bit enabled when disableVideoInterfaceProcessing is active

### DIFF
--- a/ares/n64/vulkan/vulkan.cpp
+++ b/ares/n64/vulkan/vulkan.cpp
@@ -167,7 +167,7 @@ auto Vulkan::scanoutAsync(bool field) -> bool {
   options.downscale_steps = supersampleScanout ? 16 : 0;
   options.persist_frame_on_invalid_input = true;  //this is a compatibility hack, but I'm not sure what for ...
   if(disableVideoInterfaceProcessing) {
-    options.vi = {false, false, false, false, false, false};
+    options.vi = {false, false, true, false, false, false};
   }
   if(!supersampleScanout){
     options.blend_previous_frame = weaveDeinterlacing;


### PR DESCRIPTION
Should (mostly) fix https://github.com/ares-emulator/ares/issues/2391

Please test to ensure interlaced titles display as expected.

If we wish enhance user experience with this setting in interlaced titles, buffering one interlaced field so the image can be output as a progressive image may be desirable in order to eliminate combing artifacts. It is, however, understood such enhancement may not be in scope for ares.

<img width="640" height="480" alt="Battlezone - Rise of the Black Dogs (USA) 2026-01-27 15-53-37" src="https://github.com/user-attachments/assets/ef58bb03-9ce9-4c7d-b7c5-c1f7e44eefd1" />
<img width="640" height="480" alt="Battlezone - Rise of the Black Dogs (USA) 2026-01-27 15-54-03" src="https://github.com/user-attachments/assets/d3343d52-8d0c-4f81-99d2-b5c0362787dc" />
<img width="640" height="480" alt="N64brew-Jam-2024 2026-01-27 15-45-03" src="https://github.com/user-attachments/assets/7b7393cc-42a7-4fbe-9a5b-ec050c0b6788" />
<img width="640" height="480" alt="N64brew-Jam-2024 2026-01-27 15-50-29" src="https://github.com/user-attachments/assets/b14df556-ea78-42bd-a796-70d4024f40d1" />
<img width="640" height="480" alt="Pokemon Stadium 2 (USA) 2026-01-27 15-51-47" src="https://github.com/user-attachments/assets/2f04acc7-bbc8-4ae6-bdb2-c968384ff183" />
<img width="640" height="480" alt="StarCraft 64 (USA) 2026-01-27 15-41-19" src="https://github.com/user-attachments/assets/596965a3-f364-4c1e-a073-b24ec878c05b" />
<img width="640" height="480" alt="Vigilante 8 - 2nd Offense (USA) 2026-01-27 15-52-56" src="https://github.com/user-attachments/assets/fcc86f08-a200-4790-bd95-22d365274da8" />