### PR TITLE
gba: OBJ mosaic improvements

### DIFF
--- a/ares/gba/ppu/object.cpp
+++ b/ares/gba/ppu/object.cpp
@@ -102,7 +102,7 @@ auto PPU::Objects::outputPixel(u32 x, u32 y) -> void {
   if(!mosaicOffset) {
     mosaicOffset = 1 + io.mosaicWidth;
     mosaic = output;
-  } else if(!mosaic.mosaic || !output.mosaic) {
+  } else if(!mosaic.mosaic || !output.mosaic || (output.priority < mosaic.priority)) {
     mosaic = output;
   }
   mosaicOffset--;

--- a/ares/gba/ppu/ppu.hpp
+++ b/ares/gba/ppu/ppu.hpp
@@ -202,14 +202,16 @@ private:
 
       n1 hblank;   //1 = allow access to OAM during Hblank
       n1 mapping;  //0 = two-dimensional, 1 = one-dimensional
-      n5 mosaicWidth;
-      n5 mosaicHeight;
+      n4 mosaicWidth;
+      n4 mosaicHeight;
     } io;
 
     Pixel lineBuffers[2][240];
     Pixel output;
     Pixel mosaic;
-    u32 mosaicOffset;
+    s32 mosaicY;
+    n4 hmosaicOffset;
+    n4 vmosaicOffset;
   } objects;
 
   struct Window {

--- a/ares/gba/ppu/serialization.cpp
+++ b/ares/gba/ppu/serialization.cpp
@@ -66,7 +66,9 @@ auto PPU::Objects::serialize(serializer& s) -> void {
   s(io.mosaicWidth);
   s(io.mosaicHeight);
 
-  s(mosaicOffset);
+  s(mosaicY);
+  s(hmosaicOffset);
+  s(vmosaicOffset);
 }
 
 auto PPU::Window::serialize(serializer& s) -> void {

--- a/ares/gba/system/serialization.cpp
+++ b/ares/gba/system/serialization.cpp
@@ -1,4 +1,4 @@
-static const string SerializerVersion = "v147";
+static const string SerializerVersion = "v148";
 
 auto System::serialize(bool synchronize) -> serializer {
   if(synchronize) scheduler.enter(Scheduler::Mode::Synchronize);


### PR DESCRIPTION
Fixes some graphical bugs that occurred when modifying sprite vertical mosaic size between scanlines, and when mosaic sprites with different priorities overlapped horizontally.