### PR TITLE
UI Cleanup

### DIFF
--- a/desktop-ui/emulator/emulator.cpp
+++ b/desktop-ui/emulator/emulator.cpp
@@ -145,7 +145,7 @@ auto Emulator::load(std::shared_ptr<mia::Pak> pak, string& path) -> string {
   } else if(!program.startGameLoad.empty()) {
     location = program.startGameLoad.front();
     program.startGameLoad.erase(program.startGameLoad.begin()); //pull from the command line if an entry is available
-  } else if(!program.noFilePrompt && !settings.general.noFilePrompt) {
+  } else if(!program.noFilePrompt) {
     BrowserDialog dialog;
     dialog.setTitle({"Load ", pak->name(), " Game"});
     dialog.setPath(path ? path : Path::desktop());

--- a/desktop-ui/emulator/emulators.cpp
+++ b/desktop-ui/emulator/emulators.cpp
@@ -260,6 +260,6 @@ auto Emulator::construct() -> void {
   #endif
 
   std::sort(emulators.begin(), emulators.end(), [](std::shared_ptr<Emulator> a, std::shared_ptr<Emulator> b) { 
-    return (a->name < b->name); 
+    return (a->manufacturer < b->manufacturer); 
   });
 }

--- a/desktop-ui/emulator/emulators.cpp
+++ b/desktop-ui/emulator/emulators.cpp
@@ -260,6 +260,6 @@ auto Emulator::construct() -> void {
   #endif
 
   std::sort(emulators.begin(), emulators.end(), [](std::shared_ptr<Emulator> a, std::shared_ptr<Emulator> b) { 
-    return (a->manufacturer < b->manufacturer); 
+    return (a->manufacturer <= b->manufacturer); 
   });
 }

--- a/desktop-ui/emulator/nintendo-64.cpp
+++ b/desktop-ui/emulator/nintendo-64.cpp
@@ -64,7 +64,7 @@ auto Nintendo64::load() -> LoadResult {
   auto region = Emulator::region();
 
   string name;
-  if(game->pak->attribute("dd").boolean()) {
+  if(game->pak->attribute("dd").boolean() && !settings.general.noFilePrompt) {
     //use 64DD firmware settings
     std::vector<Firmware> firmware;
     for(auto& emulator : emulators) {
@@ -140,7 +140,7 @@ auto Nintendo64::load() -> LoadResult {
       port->connect();
       bool transferPakConnected = false;
       if(auto port = peripheral->find<ares::Node::Port>("Pak")) {
-        if(game->pak->attribute({"port", id+1, "/tpak"}).boolean()) {
+        if(game->pak->attribute({"port", id+1, "/tpak"}).boolean() && !settings.general.noFilePrompt) {
           #if defined(CORE_GB)
           auto transferPak = port->allocate("Transfer Pak");
           port->connect();

--- a/desktop-ui/settings/debug.cpp
+++ b/desktop-ui/settings/debug.cpp
@@ -21,10 +21,8 @@ auto DebugSettings::construct() -> void {
 
     portHint.setText("Safe range: 1024 - 32767").setFont(Font().setSize(7.0)).setForegroundColor(SystemColor::Sublabel);
 
-  ipv4Layout.setAlignment(1);
-    ipv4Label.setText("Use IPv4");
-
     ipv4.setEnabled(true);
+    ipv4.setText("Use IPv4");
     ipv4.setChecked(settings.debugServer.useIPv4);
     ipv4.onToggle([&](){
       settings.debugServer.useIPv4 = ipv4.checked();
@@ -32,10 +30,8 @@ auto DebugSettings::construct() -> void {
       infoRefresh();
     });
 
-  enabledLayout.setAlignment(1);
-    enabledLabel.setText("Enabled");
-
     enabled.setEnabled(true);
+    enabled.setText("Enabled");
     enabled.setChecked(settings.debugServer.enabled);
     enabled.onToggle([&](){
       settings.debugServer.enabled = enabled.checked();

--- a/desktop-ui/settings/emulators.cpp
+++ b/desktop-ui/settings/emulators.cpp
@@ -20,7 +20,7 @@ auto EmulatorSettings::construct() -> void {
     manufacturer.setText(emulator->manufacturer);
   }
   emulatorList.resizeColumns();
-  emulatorList.column(0).setWidth(16);
+  emulatorList.column(0).setWidth(24);
 }
 
 auto EmulatorSettings::eventToggle(TableViewCell cell) -> void {

--- a/desktop-ui/settings/options.cpp
+++ b/desktop-ui/settings/options.cpp
@@ -41,7 +41,7 @@ auto OptionSettings::construct() -> void {
     
   });
   noFilePromptLayout.setAlignment(1).setPadding(12_sx, 0);
-    noFilePromptHint.setText("Suppress secondary file load prompts (equivalent to --no-file-prompt)").setFont(Font().setSize(7.0)).setForegroundColor(SystemColor::Sublabel);
+    noFilePromptHint.setText("Suppress secondary media file load prompts").setFont(Font().setSize(7.0)).setForegroundColor(SystemColor::Sublabel);
 
   nintendo64SettingsLabel.setText("Nintendo 64 Settings").setFont(Font().setBold());
 

--- a/desktop-ui/settings/settings.hpp
+++ b/desktop-ui/settings/settings.hpp
@@ -1,4 +1,4 @@
-#if defined(PLATFORM_WINDOWS)
+#if defined(PLATFORM_WINDOWS) || defined(PLATFORM_MACOS)
   constexpr u32 layoutVertSize = 14;
 #else
   constexpr u32 layoutVertSize = 18;

--- a/desktop-ui/settings/settings.hpp
+++ b/desktop-ui/settings/settings.hpp
@@ -1,3 +1,9 @@
+#if defined(PLATFORM_WINDOWS)
+  constexpr u32 layoutVertSize = 14;
+#else
+  constexpr u32 layoutVertSize = 18;
+#endif
+
 struct Settings : Markup::Node {
   using string = nall::string;
 
@@ -139,30 +145,30 @@ struct VideoSettings : VerticalLayout {
   Label emulatorSettingsLabel{this, Size{~0, 0}, 5};
     HorizontalLayout colorBleedLayout{this, Size{~0, 0}, 5};
       CheckLabel colorBleedOption{&colorBleedLayout, Size{0, 0}, 5};
-      Label colorBleedHint{&colorBleedLayout, Size{~0, 0}};
+      Label colorBleedHint{&colorBleedLayout, Size{~0, layoutVertSize}};
     HorizontalLayout colorEmulationLayout{this, Size{~0, 0}, 5};
       CheckLabel colorEmulationOption{&colorEmulationLayout, Size{0, 0}, 5};
-      Label colorEmulationHint{&colorEmulationLayout, Size{~0, 0}};
+      Label colorEmulationHint{&colorEmulationLayout, Size{~0, layoutVertSize}};
     HorizontalLayout deepBlackBoostLayout{this, Size{~0, 0}, 5};
       CheckLabel deepBlackBoostOption{&deepBlackBoostLayout, Size{0, 0}, 5};
-      Label deepBlackBoostHint{&deepBlackBoostLayout, Size{~0, 0}};
+      Label deepBlackBoostHint{&deepBlackBoostLayout, Size{~0, layoutVertSize}};
     HorizontalLayout interframeBlendingLayout{this, Size{~0, 0}, 5};
       CheckLabel interframeBlendingOption{&interframeBlendingLayout, Size{0, 0}, 5};
-      Label interframeBlendingHint{&interframeBlendingLayout, Size{~0, 0}};
+      Label interframeBlendingHint{&interframeBlendingLayout, Size{~0, layoutVertSize}};
     HorizontalLayout overscanLayout{this, Size{~0, 0}};
       CheckLabel overscanOption{&overscanLayout, Size{0, 0}, 5};
-      Label overscanHint{&overscanLayout, Size{~0, 0}};
+      Label overscanHint{&overscanLayout, Size{~0, layoutVertSize}};
     HorizontalLayout pixelAccuracyLayout{this, Size{~0, 0}};
       CheckLabel pixelAccuracyOption{&pixelAccuracyLayout, Size{0, 0}, 5};
-      Label pixelAccuracyHint{&pixelAccuracyLayout, Size{~0, 0}};
+      Label pixelAccuracyHint{&pixelAccuracyLayout, Size{~0, layoutVertSize}};
   //
   Label renderSettingsLabel{this, Size{~0, 0}, 5};
   HorizontalLayout disableVideoInterfaceProcessingLayout{this, Size{~0, 0}, 5};
     CheckLabel disableVideoInterfaceProcessingOption{&disableVideoInterfaceProcessingLayout, Size{0, 0}, 5};
-    Label disableVideoInterfaceProcessingHint{&disableVideoInterfaceProcessingLayout, Size{0, 0}};
+    Label disableVideoInterfaceProcessingHint{&disableVideoInterfaceProcessingLayout, Size{0, layoutVertSize}};
   HorizontalLayout weaveDeinterlacingLayout{this, Size{~0, 0}, 5};
     CheckLabel weaveDeinterlacingOption{&weaveDeinterlacingLayout, Size{0, 0}, 5};
-    Label weaveDeinterlacingHint{&weaveDeinterlacingLayout, Size{0, 0}};
+    Label weaveDeinterlacingHint{&weaveDeinterlacingLayout, Size{0, layoutVertSize}};
   HorizontalLayout renderQualityLayout{this, Size{~0, 0}, 5};
     RadioLabel renderQuality1x{&renderQualityLayout, Size{0, 0}};
     RadioLabel renderQuality2x{&renderQualityLayout, Size{0, 0}};
@@ -170,9 +176,9 @@ struct VideoSettings : VerticalLayout {
     Group renderQualityGroup{&renderQuality1x, &renderQuality2x, &renderQuality4x};
   HorizontalLayout renderSupersamplingLayout{this, Size{~0, 0}, 5};
     CheckLabel renderSupersamplingOption{&renderSupersamplingLayout, Size{0, 0}, 5};
-    Label renderSupersamplingHint{&renderSupersamplingLayout, Size{0, 0}};
+    Label renderSupersamplingHint{&renderSupersamplingLayout, Size{0, layoutVertSize}};
   HorizontalLayout renderSettingsLayout{this, Size{~0, 0}};
-      Label renderSettingsHint{&renderSettingsLayout, Size{0, 0}};
+      Label renderSettingsHint{&renderSettingsLayout, Size{0, layoutVertSize}};
 };
 
 struct AudioSettings : VerticalLayout {
@@ -255,40 +261,40 @@ struct OptionSettings : VerticalLayout {
   Label commonSettingsLabel{this, Size{~0, 0}, 5};
     HorizontalLayout rewindLayout{this, Size{~0, 0}, 5};
       CheckLabel rewind{&rewindLayout, Size{0, 0}, 5};
-      Label rewindHint{&rewindLayout, Size{~0, 0}};
+      Label rewindHint{&rewindLayout, Size{~0, layoutVertSize}};
     HorizontalLayout runAheadLayout{this, Size{~0, 0}, 5};
       CheckLabel runAhead{&runAheadLayout, Size{0, 0}, 5};
-      Label runAheadHint{&runAheadLayout, Size{~0, 0}};
+      Label runAheadHint{&runAheadLayout, Size{~0, layoutVertSize}};
     HorizontalLayout autoSaveMemoryLayout{this, Size{~0, 0}, 5};
       CheckLabel autoSaveMemory{&autoSaveMemoryLayout, Size{0, 0}, 5};
-      Label autoSaveMemoryHint{&autoSaveMemoryLayout, Size{~0, 0}};
+      Label autoSaveMemoryHint{&autoSaveMemoryLayout, Size{~0, layoutVertSize}};
     HorizontalLayout homebrewModeLayout{this, Size{~0, 0}, 5};
       CheckLabel homebrewMode{&homebrewModeLayout, Size{0, 0}, 5};
-      Label homebrewModeHint{&homebrewModeLayout, Size{~0, 0}};
+      Label homebrewModeHint{&homebrewModeLayout, Size{~0, layoutVertSize}};
     HorizontalLayout forceInterpreterLayout{this, Size{~0, 0}, 5};
       CheckLabel forceInterpreter{&forceInterpreterLayout, Size{0, 0}, 5};
-      Label forceInterpreterHint{&forceInterpreterLayout, Size{0, 0}};
+      Label forceInterpreterHint{&forceInterpreterLayout, Size{0, layoutVertSize}};
     HorizontalLayout noFilePromptLayout{this, Size{~0, 0}, 5};
       CheckLabel noFilePromptOption{&noFilePromptLayout, Size{0, 0}, 5};
-      Label noFilePromptHint{&noFilePromptLayout, Size{0, 0}};
+      Label noFilePromptHint{&noFilePromptLayout, Size{0, layoutVertSize}};
   Label nintendo64SettingsLabel{this, Size{~0, 0}, 5};
     HorizontalLayout nintendo64ExpansionPakLayout{this, Size{~0, 0}, 5};
       CheckLabel nintendo64ExpansionPakOption{&nintendo64ExpansionPakLayout, Size{0, 0}, 5};
-      Label nintendo64ExpansionPakHint{&nintendo64ExpansionPakLayout, Size{0, 0}};
+      Label nintendo64ExpansionPakHint{&nintendo64ExpansionPakLayout, Size{0, layoutVertSize}};
     HorizontalLayout nintendo64ControllerPakBankLayout{this, Size{~0, 0}, 5};
-      Label nintendo64ControllerPakBankLabel{&nintendo64ControllerPakBankLayout, Size{0, 0}};
+      Label nintendo64ControllerPakBankLabel{&nintendo64ControllerPakBankLayout, Size{0, layoutVertSize}};
       ComboButton nintendo64ControllerPakBankOption{&nintendo64ControllerPakBankLayout, Size{0, 0}};
-      Label nintendo64ControllerPakBankHint{&nintendo64ControllerPakBankLayout, Size{0, 0}};
+      Label nintendo64ControllerPakBankHint{&nintendo64ControllerPakBankLayout, Size{0, layoutVertSize}};
 
   Label gameBoyAdvanceSettingsLabel{this, Size{~0, 0}, 5};
     HorizontalLayout gameBoyPlayerLayout{this, Size{~0, 0}, 5};
       CheckLabel gameBoyPlayerOption{&gameBoyPlayerLayout, Size{0, 0}, 5};
-      Label gameBoyPlayerHint{&gameBoyPlayerLayout, Size{0, 0}};
+      Label gameBoyPlayerHint{&gameBoyPlayerLayout, Size{0, layoutVertSize}};
 
   Label megaDriveSettingsLabel{this, Size{~0, 0}, 5};
     HorizontalLayout megaDriveTmssLayout{this, Size{~0, 0}, 5};
       CheckLabel megaDriveTmssOption{&megaDriveTmssLayout, Size{0, 0}, 5};
-      Label megaDriveTmssHint{&megaDriveTmssLayout, Size{0, 0}};
+      Label megaDriveTmssHint{&megaDriveTmssLayout, Size{0, layoutVertSize}};
 };
 
 struct FirmwareSettings : VerticalLayout {
@@ -420,14 +426,12 @@ struct DebugSettings : VerticalLayout {
   HorizontalLayout portLayout{this, Size{~0, 0}};
     Label portLabel{&portLayout, Size{48, 20}};
     LineEdit port{&portLayout, Size{~0, 0}};
-    Label portHint{&portLayout, Size{~0, 0}};
+    Label portHint{&portLayout, Size{~0, layoutVertSize}};
 
   HorizontalLayout ipv4Layout{this, Size{~0, 0}};
-    Label ipv4Label{&ipv4Layout, Size{48, 20}};
     CheckLabel ipv4{&ipv4Layout, Size{~0, 0}};
 
   HorizontalLayout enabledLayout{this, Size{~0, 0}};
-    Label enabledLabel{&enabledLayout, Size{48, 20}};
     CheckLabel enabled{&enabledLayout, Size{~0, 0}};
 
   Label connectInfo{this, Size{~0, 30}, 5};

--- a/desktop-ui/tools/cheats.cpp
+++ b/desktop-ui/tools/cheats.cpp
@@ -115,7 +115,7 @@ auto CheatEditor::refresh() -> void {
   }
 
   cheatList.resizeColumns();
-  cheatList.column(0).setWidth(16);
+  cheatList.column(0).setWidth(24);
 }
 
 auto CheatEditor::unload() -> void {

--- a/desktop-ui/tools/streams.cpp
+++ b/desktop-ui/tools/streams.cpp
@@ -28,7 +28,7 @@ auto StreamManager::reload() -> void {
     item.append(TableViewCell().setText({u32(stream->frequency() + 0.5), "hz"}));
   }
   streamList.resizeColumns();
-  streamList.column(0).setWidth(16);
+  streamList.column(0).setWidth(24);
 }
 
 auto StreamManager::unload() -> void {

--- a/hiro/windows/widget/combo-button.cpp
+++ b/hiro/windows/widget/combo-button.cpp
@@ -44,19 +44,6 @@ auto pComboButton::reset() -> void {
   SendMessage(hwnd, CB_RESETCONTENT, 0, 0);
 }
 
-//Windows overrides the height parameter for a ComboButton's SetWindowPos to be the drop-down list height.
-//the canonical way to set the actual height is through CB_SETITEMHEIGHT. However, doing so is bugged.
-//the ComboButton will end up not being painted for ~500ms after calling ShowWindow(hwnd, SW_NORMAL) on it.
-//thus, implementing windows that use multiple pages of controls via toggling visibility will flicker heavily.
-//as a result, the best we can do is center the actual widget within the requested space.
-auto pComboButton::setGeometry(Geometry geometry) -> void {
-  //since the ComboButton has a fixed height, it will always be the same, even before calling setGeometry() once.
-  RECT rc;
-  GetWindowRect(hwnd, &rc);
-  geometry.setY(geometry.y() + (geometry.height() - (rc.bottom - rc.top)));
-  pWidget::setGeometry({geometry.x(), geometry.y(), geometry.width(), 1});
-}
-
 auto pComboButton::onChange() -> void {
   s32 offset = SendMessage(hwnd, CB_GETCURSEL, 0, 0);
   if(offset == CB_ERR) return;

--- a/hiro/windows/widget/combo-button.hpp
+++ b/hiro/windows/widget/combo-button.hpp
@@ -9,7 +9,6 @@ struct pComboButton : pWidget {
   auto minimumSize() const -> Size override;
   auto remove(sComboButtonItem item) -> void;
   auto reset() -> void override;
-  auto setGeometry(Geometry geometry) -> void override;
 
   auto onChange() -> void;
 };


### PR DESCRIPTION
* Fixes checkboxes in TableView controls that were clipped on Linux systems

* Better alignment of text between control labels and description labels (All OSes)

* Updated Debug checkbox controls to place text on right of control for consistency across the UI 

* Addresses the issue where ComboButton's on Windows would initially render in the wrong location. I don't know why it attempted to recalculate the y coordinate as a workaround. The comment goes against MS documentation, and I couldn't find a reference to any issues with this control working properly. Removing this code to try and offset coordinates corrects the placement of these controls in Input settings, and multiple panels in the Tools window. This fixes: https://github.com/ares-emulator/ares/issues/102