### PR TITLE
Exclude additional systems from using Run-Ahead

### DIFF
--- a/ares/gba/apu/serialization.cpp
+++ b/ares/gba/apu/serialization.cpp
@@ -57,7 +57,7 @@ auto APU::serialize(serializer& s) -> void {
   s(wave.frequency);
   s(wave.counter);
   s(wave.initialize);
-  s(wave.pattern);
+  for(auto& p : wave.pattern) s(p);
   s(wave.enable);
   s(wave.output);
   s(wave.patternaddr);
@@ -85,8 +85,8 @@ auto APU::serialize(serializer& s) -> void {
   s(sequencer.volume);
   s(sequencer.lvolume);
   s(sequencer.rvolume);
-  s(sequencer.lenable);
-  s(sequencer.renable);
+  for(auto& l :sequencer.lenable) s(l);
+  for(auto& r: sequencer.renable) s(r);
   s(sequencer.masterenable);
   s(sequencer.base);
   s(sequencer.step);
@@ -97,7 +97,7 @@ auto APU::serialize(serializer& s) -> void {
 
   for(auto& f : fifo) {
     s(f.buffer);
-    s(f.samples);
+    for(auto& sa : f.samples) s(sa);
     s(f.active);
     s(f.output);
     s(f.rdoffset);

--- a/ares/gba/cartridge/serialization.cpp
+++ b/ares/gba/cartridge/serialization.cpp
@@ -12,6 +12,7 @@ auto Cartridge::MROM::serialize(serializer& s) -> void {
   s(mask);
   s(pageAddr);
   s(burst);
+  s(mirror);
 }
 
 auto Cartridge::SRAM::serialize(serializer& s) -> void {

--- a/ares/gba/cpu/serialization.cpp
+++ b/ares/gba/cpu/serialization.cpp
@@ -110,7 +110,7 @@ auto CPU::serialize(serializer& s) -> void {
   s(openBus.data);
   s(openBus.iwramData);
 
-  s(prefetch.slot);
+  for(auto& slot : prefetch.slot) s(slot);
   s(prefetch.addr);
   s(prefetch.load);
   s(prefetch.wait);

--- a/ares/gba/player/serialization.cpp
+++ b/ares/gba/player/serialization.cpp
@@ -1,4 +1,6 @@
 auto Player::serialize(serializer& s) -> void {
+  Thread::serialize(s);
+  
   s(status.enable);
   s(status.rumble);
 

--- a/ares/gba/system/serialization.cpp
+++ b/ares/gba/system/serialization.cpp
@@ -1,4 +1,4 @@
-static const string SerializerVersion = "v148";
+static const string SerializerVersion = "v148.1";
 
 auto System::serialize(bool synchronize) -> serializer {
   if(synchronize) scheduler.enter(Scheduler::Mode::Synchronize);

--- a/ares/ngp/cpu/serialization.cpp
+++ b/ares/ngp/cpu/serialization.cpp
@@ -182,6 +182,7 @@ auto CPU::serialize(serializer& s) -> void {
   s(ff6.flipOnCompare7);
   s(ff6.flipOnCapture3);
   s(ff6.flipOnCapture4);
+  s(ff6.output);
 
   s(t5.enable);
   s(t5.mode);
@@ -254,8 +255,7 @@ auto CPU::serialize(serializer& s) -> void {
   s(adc.repeat);
   s(adc.busy);
   s(adc.end);
-  s(adc.result);
-
+  for(auto& r : adc.result) s(r);
   s(rtc.counter);
   s(rtc.enable);
   s(rtc.second);

--- a/ares/ngp/kge/serialization.cpp
+++ b/ares/ngp/kge/serialization.cpp
@@ -58,8 +58,12 @@ auto KGE::Plane::serialize(serializer& s) -> void {
 
   s(hscroll);
   s(vscroll);
-  s(palette[0]);
-  s(palette[1]);
+  
+  for(auto& p : palette) {
+    for(auto& q : p) {
+      s(q);
+    }
+  }
 }
 
 auto KGE::Sprite::serialize(serializer& s) -> void {
@@ -91,11 +95,16 @@ auto KGE::Sprite::serialize(serializer& s) -> void {
 
   s(hscroll);
   s(vscroll);
-  s(palette);
+
+  for(auto& p : palette) {
+    for(auto& q : p) {
+      s(q);
+    }
+  }
 }
 
 auto KGE::DAC::serialize(serializer& s) -> void {
-  s(colors);
+  for(auto& color : colors) s(color);
   s(colorMode);
   s(negate);
 }

--- a/ares/ngp/system/serialization.cpp
+++ b/ares/ngp/system/serialization.cpp
@@ -1,4 +1,4 @@
-static const string SerializerVersion = "v131";
+static const string SerializerVersion = "v132";
 
 auto System::serialize(bool synchronize) -> serializer {
   if(synchronize) scheduler.enter(Scheduler::Mode::Synchronize);

--- a/desktop-ui/program/utility.cpp
+++ b/desktop-ui/program/utility.cpp
@@ -32,9 +32,16 @@ auto Program::runAheadUpdate() -> void {
   runAhead = settings.general.runAhead;
   if(!emulator) return;
   if(emulator->name == "Game Boy Advance") runAhead = false;  //crashes immediately
+  if(emulator->name == "Neo Geo Pocket") runAhead = false;  //white screen
+  if(emulator->name == "Neo Geo Pocket Color") runAhead = false;  //white screen
   if(emulator->name == "Nintendo 64") runAhead = false;  //too demanding
   if(emulator->name == "Nintendo 64DD") runAhead = false;  //too demanding
   if(emulator->name == "PlayStation") runAhead = false;  //too demanding
+  if(emulator->name == "SuperGrafx CD") runAhead = false; //too demanding
+  if(emulator->name == "Mega 32X") runAhead = false;  //too demanding
+  if(emulator->name == "Mega CD 32X") runAhead = false;  //too demanding
+  if(emulator->name == "Sega Saturn") runAhead = false;  //too demanding
+  if(emulator->name == "Arcade" && emulator->game->pak->attribute("board") == "nintendo/aleck64") runAhead = false;  //hangs, too demanding
 }
 
 auto Program::captureScreenshot(const u32* data, u32 pitch, u32 width, u32 height) -> void {

--- a/nall/nall/gdb/server.cpp
+++ b/nall/nall/gdb/server.cpp
@@ -115,7 +115,7 @@ namespace nall::GDB {
     char cmdPrefix = cmdName.size() > 0 ? cmdName(0) : ' ';
 
     if constexpr(GDB_LOG_MESSAGES) {
-      print("GDB <: %s\n", cmdBuffer.data());
+      printf("GDB <: %s\n", cmdBuffer.data());
     }
 
     switch(cmdPrefix)


### PR DESCRIPTION
Add additional systems to the list of systems where run-ahead isn't supported. This helps prevents users facing performance issues (some cores are too demanding) or running into issues with a few cores that won't work if run-ahead is enabled.

GBA, NGP, & NGPC should be able to work, but don't due to different issues. Assumed to be related to save states, so I went through both systems and corrected any issues I saw but unfortunately this didn't fix the issue. GBA, crashes due to a missing scheduler thread, and NGP/NGPC runs but shows a white screen and no audio with run-ahead. 