### PR TITLE
Fix fast forward getting stuck

### DIFF
--- a/desktop-ui/input/hotkeys.cpp
+++ b/desktop-ui/input/hotkeys.cpp
@@ -2,6 +2,7 @@ auto InputManager::createHotkeys() -> void {
   static bool fastForwardVideoBlocking;
   static bool fastForwardAudioBlocking;
   static bool fastForwardAudioDynamic;
+  static bool toggleFastForwardState = false;
 
   hotkeys.push_back(InputHotkey("Toggle Fullscreen").onPress([&] {
     program.videoFullScreenToggle();
@@ -31,20 +32,24 @@ auto InputManager::createHotkeys() -> void {
   hotkeys.push_back(InputHotkey("Fast Forward").onPress([&] {
     Program::Guard guard;
     if(!emulator || program.rewinding) return;
-    program.fastForwarding = true;
-    fastForwardVideoBlocking = ruby::video.blocking();
-    fastForwardAudioBlocking = ruby::audio.blocking();
-    fastForwardAudioDynamic  = ruby::audio.dynamic();
-    ruby::video.setBlocking(false);
-    ruby::audio.setBlocking(false);
-    ruby::audio.setDynamic(false);
+    if(!toggleFastForwardState) {
+      program.fastForwarding = true;
+      fastForwardVideoBlocking = ruby::video.blocking();
+      fastForwardAudioBlocking = ruby::audio.blocking();
+      fastForwardAudioDynamic  = ruby::audio.dynamic();
+      ruby::video.setBlocking(false);
+      ruby::audio.setBlocking(false);
+      ruby::audio.setDynamic(false);
+    }
   }).onRelease([&] {
     Program::Guard guard;
     if(!emulator) return;
-    program.fastForwarding = false;
-    ruby::video.setBlocking(fastForwardVideoBlocking);
-    ruby::audio.setBlocking(fastForwardAudioBlocking);
-    ruby::audio.setDynamic(fastForwardAudioDynamic);
+    if(!toggleFastForwardState) {
+      program.fastForwarding = false;
+      ruby::video.setBlocking(fastForwardVideoBlocking);
+      ruby::audio.setBlocking(fastForwardAudioBlocking);
+      ruby::audio.setDynamic(fastForwardAudioDynamic);
+    }
   }));
 
   hotkeys.push_back(InputHotkey("Toggle Fast Forward").onPress([&] {
@@ -53,6 +58,7 @@ auto InputManager::createHotkeys() -> void {
     program.fastForwarding = !program.fastForwarding;
 
     if (program.fastForwarding) {
+      toggleFastForwardState = true;
       fastForwardVideoBlocking = ruby::video.blocking();
       fastForwardAudioBlocking = ruby::audio.blocking();
       fastForwardAudioDynamic  = ruby::audio.dynamic();
@@ -62,6 +68,7 @@ auto InputManager::createHotkeys() -> void {
       return;
     } 
 
+    toggleFastForwardState = false;
     ruby::video.setBlocking(fastForwardVideoBlocking);
     ruby::audio.setBlocking(fastForwardAudioBlocking);
     ruby::audio.setDynamic(fastForwardAudioDynamic);


### PR DESCRIPTION
Fixes: https://github.com/ares-emulator/ares/issues/1404

If you toggled fast forward on via the hotkey and then hit the fast forward hotkey, it would get stuck in fast forward mode. Hitting the fast forward hotkey while already toggled on will not interfere anymore, and even if the fast forward key is used while toggled on it can now be toggled off. 