### PR TITLE
Windows OpenGL 4.6 Core Profile Driver

### DIFF
--- a/ruby/video/glx.cpp
+++ b/ruby/video/glx.cpp
@@ -276,6 +276,8 @@ private:
       return false;
     }
 
+    print("OpenGL Version: ", (const char*)glGetString(GL_VERSION), ", GLSL: ", (const char*)glGetString(GL_SHADING_LANGUAGE_VERSION),"\n");
+
     glXSwapInterval(self.blocking);
 
     //read attributes of frame buffer for later use, as requested attributes from above are not always granted

--- a/ruby/video/video.cpp
+++ b/ruby/video/video.cpp
@@ -197,7 +197,8 @@ auto Video::create(string driver) -> bool {
   #endif
 
   #if defined(VIDEO_WGL)
-  if(driver == "OpenGL 3.2") self.instance = std::make_unique<VideoWGL>(*this);
+  if(driver == "OpenGL 3.2") self.instance = std::make_unique<VideoWGL>(*this, 3, 2);
+  if(driver == "OpenGL 4.6") self.instance = std::make_unique<VideoWGL>(*this, 4, 6);
   #endif
   
   #if defined(VIDEO_METAL)
@@ -213,7 +214,7 @@ auto Video::hasDrivers() -> std::vector<string> {
   return {
 
   #if defined(VIDEO_WGL)
-  "OpenGL 3.2",
+  "OpenGL 3.2", "OpenGL 4.6",
   #endif
 
   #if defined(VIDEO_DIRECT3D9)


### PR DESCRIPTION
This adds an OpenGL 4.6 video driver for Windows users. This is to allow for shaders that require support for newer versions of OpenGL in order to function properly. Default/optimal driver on Windows will remain as OpenGL 3.2. 

Linux may benefit from additional changes, but this is currently unclear and more testing on more hardware/drivers is required. Using the latest Mesa drivers, requesting the 3.2 version as we do currently enables 4.5 functionality, which should be new enough for any shader. Nvidia, AMD, & Intel hasn't been tested yet. A debug print statement has been added that will output OGL version and GLSL version to assist with gathering info going forward. 

macOS supports up to OpenGL 4.1 and has been deprecated for a long time. Use the Metal driver. 