### PR TITLE
Import & export settings in the UI

### DIFF
--- a/desktop-ui/cmake/sources.cmake
+++ b/desktop-ui/cmake/sources.cmake
@@ -39,6 +39,7 @@ target_sources(
     settings/paths.cpp
     settings/settings.hpp
     settings/video.cpp
+    settings/importexport.cpp
 )
 
 target_sources(

--- a/desktop-ui/presentation/presentation.cpp
+++ b/desktop-ui/presentation/presentation.cpp
@@ -150,6 +150,9 @@ Presentation::Presentation() {
   debugSettingsAction.setText("Debug" ELLIPSIS).setIcon(Icon::Device::Network).onActivate([&] {
     settingsWindow.show("Debug");
   });
+  importExportAction.setText("Settings File" ELLIPSIS).setIcon(Icon::Action::Save).onActivate([&] {
+    settingsWindow.show("Settings File");
+  });
 
   toolsMenu.setVisible(false).setText("Tools");
   saveStateMenu.setText("Save State").setIcon(Icon::Media::Record);

--- a/desktop-ui/presentation/presentation.hpp
+++ b/desktop-ui/presentation/presentation.hpp
@@ -61,6 +61,7 @@ struct Presentation : Window {
       MenuItem pathSettingsAction{&settingsMenu};
       MenuItem driverSettingsAction{&settingsMenu};
       MenuItem debugSettingsAction{&settingsMenu};
+      MenuItem importExportAction{&settingsMenu};
     Menu toolsMenu{&menuBar};
       Menu saveStateMenu{&toolsMenu};
       Menu loadStateMenu{&toolsMenu};

--- a/desktop-ui/program/program.hpp
+++ b/desktop-ui/program/program.hpp
@@ -41,6 +41,7 @@ struct Program : ares::Platform {
   auto captureScreenshot(const u32* data, u32 pitch, u32 width, u32 height) -> void;
   auto openFile(BrowserDialog&) -> string;
   auto selectFolder(BrowserDialog&) -> string;
+  auto saveFile(BrowserDialog& dialog) -> string;
 
   //drivers.cpp
   auto videoDriverUpdate() -> void;

--- a/desktop-ui/program/utility.cpp
+++ b/desktop-ui/program/utility.cpp
@@ -73,3 +73,13 @@ auto Program::selectFolder(BrowserDialog& dialog) -> string {
   window.setParent(dialog.alignmentWindow());
   return window.directory();
 }
+
+auto Program::saveFile(BrowserDialog& dialog) -> string {
+  Program::Guard guard;
+  BrowserWindow window;
+  window.setTitle(dialog.title());
+  window.setPath(dialog.path());
+  window.setFilters(dialog.filters());
+  window.setParent(dialog.alignmentWindow());
+  return window.save();
+}

--- a/desktop-ui/settings/importexport.cpp
+++ b/desktop-ui/settings/importexport.cpp
@@ -1,0 +1,60 @@
+auto ImportExportSettings::construct() -> void {
+  setCollapsible();
+  useImported.setText("Set Imported File As Current Settings File");
+  useImported.setChecked(settings.video.colorBleed).onToggle([&] { imported = useImported.checked(); });
+  refresh();
+
+  importButton.setText("Import" ELLIPSIS).onActivate([&] {
+    Program::Guard guard;
+    BrowserDialog dialog;
+    dialog.setTitle("Import Settings");
+    dialog.setPath(settings.paths.home);
+    dialog.setFilters({"bml|*.bml"});
+    dialog.setAlignment(settingsWindow);
+    if(auto location = program.openFile(dialog)) {
+      string currentSavePath = settings.filePath;
+      settings.filePath = location;
+      settings.load();
+      if(!imported) settings.filePath = currentSavePath;
+      videoSettings.construct();
+      audioSettings.construct();
+      inputSettings.construct();
+      hotkeySettings.construct();
+      emulatorSettings.construct();
+      optionSettings.construct();
+      firmwareSettings.construct();
+      pathSettings.construct();
+      driverSettings.construct();
+      debugSettings.construct();
+      importExportSettings.construct();
+    }
+  });
+  
+  exportButton.setText("Export" ELLIPSIS).onActivate([&] {
+    Program::Guard guard;
+    BrowserDialog dialog;
+    dialog.setTitle("Export Settings");
+    dialog.setPath(settings.paths.home);  
+    dialog.setFilters({"bml|*.bml"});
+    dialog.setAlignment(settingsWindow);
+    if(auto location = program.saveFile(dialog)) {
+      string currentSavePath = settings.filePath;
+      settings.filePath = location;
+      settings.save();
+      settings.filePath = currentSavePath;
+    }
+  });
+}
+
+auto ImportExportSettings::refresh() -> void {
+  settings.save();
+  settingsFileLabel.setText({"Current File: ", settings.filePath}).setFont(Font().setBold());
+  settingsView.setEditable(false).setFont(Font().setFamily(Font::Mono));
+  settingsView.setText(BML::serialize(settings, " "));
+}
+
+auto ImportExportSettings::setVisible(bool visible) -> ImportExportSettings& {
+  if(visible) refresh();
+  VerticalLayout::setVisible(visible);
+  return *this;
+}

--- a/desktop-ui/settings/settings.cpp
+++ b/desktop-ui/settings/settings.cpp
@@ -10,6 +10,7 @@
 #include "paths.cpp"
 #include "drivers.cpp"
 #include "debug.cpp"
+#include "importexport.cpp"
 #include "home.cpp"
 
 Settings settings;
@@ -25,6 +26,7 @@ FirmwareSettings& firmwareSettings = settingsWindow.firmwareSettings;
 PathSettings& pathSettings = settingsWindow.pathSettings;
 DebugSettings& debugSettings = settingsWindow.debugSettings;
 DriverSettings& driverSettings = settingsWindow.driverSettings;
+ImportExportSettings& importExportSettings = settingsWindow.importExportSettings;
 
 auto Settings::load() -> void {
   Markup::Node::operator=(BML::unserialize(string::read(filePath), " "));
@@ -215,6 +217,7 @@ auto SettingsWindow::initialize() -> void {
   panelList.append(ListViewItem().setText("Paths").setIcon(Icon::Emblem::Folder));
   panelList.append(ListViewItem().setText("Drivers").setIcon(Icon::Place::Settings));
   panelList.append(ListViewItem().setText("Debug").setIcon(Icon::Device::Network));
+  panelList.append(ListViewItem().setText("Settings File").setIcon(Icon::Action::Save));
   panelList->setUsesSidebarStyle();
   panelList.onChange([&] { eventChange(); });
 
@@ -228,6 +231,7 @@ auto SettingsWindow::initialize() -> void {
   panelContainer.append(pathSettings, Size{~0, ~0});
   panelContainer.append(driverSettings, Size{~0, ~0});
   panelContainer.append(debugSettings, Size{~0, ~0});
+  panelContainer.append(importExportSettings, Size{~0, ~0});
   panelContainer.append(homePanel, Size{~0, ~0});
 
   videoSettings.construct();
@@ -240,6 +244,7 @@ auto SettingsWindow::initialize() -> void {
   pathSettings.construct();
   driverSettings.construct();
   debugSettings.construct();
+  importExportSettings.construct();
   homePanel.construct();
 
   setDismissable();
@@ -279,6 +284,7 @@ auto SettingsWindow::eventChange() -> void {
   pathSettings.setVisible(false);
   driverSettings.setVisible(false);
   debugSettings.setVisible(false);
+  importExportSettings.setVisible(false);
   homePanel.setVisible(false);
 
   bool found = false;
@@ -293,6 +299,7 @@ auto SettingsWindow::eventChange() -> void {
     if(item.text() == "Paths"    ) found = true, pathSettings.setVisible();
     if(item.text() == "Drivers"  ) found = true, driverSettings.setVisible();
     if(item.text() == "Debug"    ) found = true, debugSettings.setVisible();
+    if(item.text() == "Settings File") found = true, importExportSettings.setVisible(); 
   }
   if(!found) homePanel.setVisible();
 

--- a/desktop-ui/settings/settings.hpp
+++ b/desktop-ui/settings/settings.hpp
@@ -437,6 +437,22 @@ struct DebugSettings : VerticalLayout {
   Label connectInfo{this, Size{~0, 30}, 5};
 };
 
+struct ImportExportSettings : VerticalLayout {
+  auto construct() -> void;
+  auto refresh() -> void;
+  auto setVisible(bool visible = true) -> ImportExportSettings&;
+
+  Label settingsFileLabel{this, Size{~0, 0}, 5};
+  TextEdit settingsView{this, Size{~0, ~0}};
+  HorizontalLayout controlsLayout{this, Size{~0, 0}};
+    CheckLabel useImported{&controlsLayout, Size{~0, 0}, 5};
+    Canvas spacer{&controlsLayout, Size{1, 0}};
+    Button importButton{&controlsLayout, Size{80, 0}};
+    Button exportButton{&controlsLayout, Size{80, 0}};
+  
+  bool imported = false;
+};
+
 struct HomePanel : VerticalLayout {
   auto construct() -> void;
 
@@ -460,6 +476,7 @@ struct SettingsWindow : Window {
       PathSettings pathSettings;
       DriverSettings driverSettings;
       DebugSettings debugSettings;
+      ImportExportSettings importExportSettings;
       HomePanel homePanel;
   
   bool initialized = false;
@@ -481,3 +498,4 @@ extern FirmwareSettings& firmwareSettings;
 extern PathSettings& pathSettings;
 extern DriverSettings& driverSettings;
 extern DebugSettings& debugSettings;
+extern ImportExportSettings& importExportSettings;

--- a/desktop-ui/tools/tape.cpp
+++ b/desktop-ui/tools/tape.cpp
@@ -16,7 +16,7 @@ auto TapeViewer::construct() -> void {
     dialog.setTitle("New Tape");
     dialog.setPath(settings.paths.home);
     dialog.setAlignment(presentation);
-    dialog.setFilters({"*.wav"});
+    dialog.setFilters({"wav|*.wav"});
     if (auto location = dialog.saveFile()) {
       if (Encode::WAV::mono<s16>(location, std::span<s16>(), 44100)) {
         if (emulator->loadTape(tape, location)) {


### PR DESCRIPTION
Adds the ability to import and export settings to/from bml files in the UI. This can be found under `Settings > Settings File...`.

Fixes: https://github.com/ares-emulator/ares/issues/2267