### PR TITLE
Make lambda under emulators.cpp more concise and strict

### DIFF
--- a/desktop-ui/emulator/emulators.cpp
+++ b/desktop-ui/emulator/emulators.cpp
@@ -259,7 +259,7 @@ auto Emulator::construct() -> void {
   emulators.push_back(std::make_shared<ZXSpectrum128>());
   #endif
 
-  std::sort(emulators.begin(), emulators.end(), [](std::shared_ptr<Emulator> a, std::shared_ptr<Emulator> b) { 
-    return (a->manufacturer <= b->manufacturer); 
+  std::ranges::sort(emulators, [](std::shared_ptr<Emulator> a, std::shared_ptr<Emulator> b) { 
+    return (a->manufacturer < b->manufacturer); 
   });
 }


### PR DESCRIPTION
This updates emulators.cpp to use a more strict comparison operator with some additonal small improvements to make use of `std::ranges::sort` to make the code look a little prettier whilst retaining the original function, this should fully fix #2411. 