### PR TITLE
Adding StartupWMClass

### DIFF
--- a/desktop-ui/resource/ares.desktop
+++ b/desktop-ui/resource/ares.desktop
@@ -6,3 +6,4 @@ Icon=ares
 Terminal=false
 Type=Application
 Categories=Game;Emulator;
+StartupWMClass=Ares


### PR DESCRIPTION
I created a Snap version of Ares, but I noticed that KDE wasn't displaying the correct icon; this addition is to try and prevent that problem from happening.