### PR TITLE
md: fix screen in interlace mode 1

### DIFF
--- a/ares/md/vdp-performance/main.cpp
+++ b/ares/md/vdp-performance/main.cpp
@@ -81,7 +81,7 @@ auto VDP::main() -> void {
     vedge();
 
     if(vcounter() == 0) {
-      latch.interlace = io.interlaceMode == 3;
+      latch.interlace = io.interlaceMode.bit(0);
       latch.overscan  = io.overscan;
       frame();
       state.field ^= 1;

--- a/ares/md/vdp/main.cpp
+++ b/ares/md/vdp/main.cpp
@@ -168,7 +168,7 @@ auto VDP::main() -> void {
   if(h40()) mainH40();
   if(vcounter() == state.bottomline) {
     screen->setColorBleedWidth(latch.displayWidth ? 4 : 5);
-    latch.interlace = io.interlaceMode == 3;
+    latch.interlace = io.interlaceMode.bit(0);
     latch.overscan  = io.overscan;
     frame();
     state.field ^= 1;


### PR DESCRIPTION
It was pointed out by @kev4cards that interlace mode 1 (demonstrated by 240p Test Suite as "480i") wasn't being output at double height, meaning the screen was not actually set to interlaced mode. A simple fix.

In this mode, the render is normal (not 2x vertical resolution, as in interlace mode 2), but the resulting image output is interlaced.