### PR TITLE
Fix Linux shader install path: copy contents instead of directory

### DIFF
--- a/desktop-ui/cmake/os-linux.cmake
+++ b/desktop-ui/cmake/os-linux.cmake
@@ -18,7 +18,7 @@ if(ARES_ENABLE_LIBRASHADER)
       add_dependencies(desktop-ui bundled_shaders)
       set_target_properties(bundled_shaders PROPERTIES FOLDER "generated" PREFIX "")
       install(
-        DIRECTORY "${slang_shaders_LOCATION}"
+        DIRECTORY "${slang_shaders_LOCATION}/"
         DESTINATION "${ARES_INSTALL_DATA_DESTINATION}/Shaders"
         USE_SOURCE_PERMISSIONS
         COMPONENT desktop-ui


### PR DESCRIPTION
## Summary

Fix slang-shaders being installed in an extra subdirectory on Linux.

`install(DIRECTORY "${slang_shaders_LOCATION}" ...)` without a trailing slash copies the **directory itself**, creating `Shaders/shaders_slang/` instead of putting the shader files directly in `Shaders/`.

Adding a trailing slash (`"${slang_shaders_LOCATION}/"`) makes CMake copy the **contents**, which is consistent with macOS and Windows:

| Platform | Command | Behavior |
|---|---|---|
| macOS | `ditto "${slang_shaders_LOCATION}" ".../Shaders/"` | Copies contents |
| Windows | `copy_directory "${slang_shaders_LOCATION}" ".../Shaders/"` | Copies contents |
| Linux (before) | `install(DIRECTORY "${slang_shaders_LOCATION}" ...)` | Copies directory itself |
| Linux (after) | `install(DIRECTORY "${slang_shaders_LOCATION}/" ...)` | Copies contents |

## Change

One character added: a trailing `/` in `desktop-ui/cmake/os-linux.cmake` line 21.

## Test plan

- [x] Verified shaders end up directly in `Shaders/` instead of `Shaders/shaders_slang/`
- [x] Tested via Snap package build and runtime shader selection in ares UI