### PR TITLE
n64: fix return GDB read result for RCP/PI bus path

### DIFF
--- a/ares/n64/system/system.cpp
+++ b/ares/n64/system/system.cpp
@@ -237,6 +237,7 @@ auto System::initDebugHooks() -> void {
         resPtr += 8;
         address += 4;
       }
+      return res;
     }
     return {};
   };


### PR DESCRIPTION
The multi-byte read handler for the RCP/PI address range
(0xA4000000-0xBFFFFFFF) correctly fills the result buffer via
bus.read<Word> but then falls through to `return {}` instead
of returning the result. This causes GDB memory reads from ROM
cartridge addresses to return empty responses.
