### PR TITLE
gba: prevent instruction tracing from modifying open bus

### DIFF
--- a/ares/gba/cpu/bus.cpp
+++ b/ares/gba/cpu/bus.cpp
@@ -74,7 +74,7 @@ inline auto CPU::getBus(u32 mode, n32 address) -> n32 {
 
   }
 
-  openBus.set(mode, address, word);
+  if constexpr(!UseDebugger) openBus.set(mode, address, word);
 
   if(auto result = platform->cheat(address)) return *result;
   return word;


### PR DESCRIPTION
Fixes a bug where instruction tracing would cause open bus values to be corrupted.