### PR TITLE
ui: disable empty load state slots in menu

### DIFF
--- a/desktop-ui/presentation/presentation.cpp
+++ b/desktop-ui/presentation/presentation.cpp
@@ -189,8 +189,8 @@ Presentation::Presentation() {
   toolsMenu.setVisible(false).setText("Tools");
   saveStateMenu.setText("Save State").setIcon(Icon::Media::Record);
   for(u32 slot : range(9)) {
-    MenuItem item{&saveStateMenu};
-    item.setText({"Slot ", 1 + slot}).onActivate([=, this] {
+    saveStateMenu.append(saveStateSlots[slot]);
+    saveStateSlots[slot].setText({"Slot ", 1 + slot}).onActivate([=, this] {
       Program::Guard guard;
       if(program.stateSave(1 + slot)) {
         undoSaveStateMenu.setEnabled(true);
@@ -199,8 +199,8 @@ Presentation::Presentation() {
   }
   loadStateMenu.setText("Load State").setIcon(Icon::Media::Rewind);
   for(u32 slot : range(9)) {
-    MenuItem item{&loadStateMenu};
-    item.setText({"Slot ", 1 + slot}).onActivate([=, this] {
+    loadStateMenu.append(loadStateSlots[slot]);
+    loadStateSlots[slot].setText({"Slot ", 1 + slot}).onActivate([=, this] {
       Program::Guard guard;
       if(program.stateLoad(1 + slot)) {
         undoLoadStateMenu.setEnabled(true);
@@ -541,6 +541,7 @@ auto Presentation::loadEmulator() -> void {
     systemMenu.setVisible();
 
     refreshSystemMenu();
+    refreshStateMenus();
 
     toolsMenu.setVisible(true);
     pauseEmulation.setChecked(false);
@@ -675,6 +676,7 @@ auto Presentation::unloadEmulator(bool reloading) -> void {
   if(program.kiosk) return;
   systemMenu.setVisible(false);
   systemMenu.reset();
+  refreshStateMenus();
 
   toolsMenu.setVisible(false);
 }
@@ -807,5 +809,21 @@ auto Presentation::loadShaders() -> void {
       settings.video.shader = item.attribute("file");
       ruby::video.setShader({location, settings.video.shader});
     }
+  }
+}
+
+auto Presentation::refreshStateMenus() -> void {
+  if(!emulator || !emulator->game) {
+    for(u32 slot : range(9)) {
+      saveStateSlots[slot].setEnabled(false);
+      loadStateSlots[slot].setEnabled(false);
+    }
+    return;
+  }
+
+  for(u32 slot : range(9)) {
+    saveStateSlots[slot].setEnabled(true);
+    auto location = emulator->locate(emulator->game->location, {".bs", 1 + slot}, settings.paths.saves);
+    loadStateSlots[slot].setEnabled(file::exists(location));
   }
 }

--- a/desktop-ui/presentation/presentation.cpp
+++ b/desktop-ui/presentation/presentation.cpp
@@ -192,9 +192,7 @@ Presentation::Presentation() {
     saveStateMenu.append(saveStateSlots[slot]);
     saveStateSlots[slot].setText({"Slot ", 1 + slot}).onActivate([=, this] {
       Program::Guard guard;
-      if(program.stateSave(1 + slot)) {
-        undoSaveStateMenu.setEnabled(true);
-      }
+      program.stateSave(1 + slot);
     });
   }
   loadStateMenu.setText("Load State").setIcon(Icon::Media::Rewind);
@@ -202,22 +200,18 @@ Presentation::Presentation() {
     loadStateMenu.append(loadStateSlots[slot]);
     loadStateSlots[slot].setText({"Slot ", 1 + slot}).onActivate([=, this] {
       Program::Guard guard;
-      if(program.stateLoad(1 + slot)) {
-        undoLoadStateMenu.setEnabled(true);
-      }
+      program.stateLoad(1 + slot);
     });
   }
-  undoSaveStateMenu.setText("Undo Last Save State").setIcon(Icon::Edit::Undo).setEnabled(false);
-  undoSaveStateMenu.onActivate([&] {
+  revertSaveStateMenu.setText("Revert Last Save State").setIcon(Icon::Edit::Undo).setEnabled(false);
+  revertSaveStateMenu.onActivate([&] {
     Program::Guard guard;
-    program.undoStateSave();
-    undoSaveStateMenu.setEnabled(false);
+    program.revertStateSave();
   });
   undoLoadStateMenu.setText("Undo Last Load State").setIcon(Icon::Edit::Undo).setEnabled(false);
   undoLoadStateMenu.onActivate([&] {
     Program::Guard guard;
     program.undoStateLoad();
-    undoLoadStateMenu.setEnabled(false);
   });
   captureScreenshot.setText("Capture Screenshot").setIcon(Icon::Emblem::Image).onActivate([&] {
     Program::Guard guard;

--- a/desktop-ui/presentation/presentation.hpp
+++ b/desktop-ui/presentation/presentation.hpp
@@ -68,7 +68,7 @@ struct Presentation : Window {
         MenuItem saveStateSlots[9];
       Menu loadStateMenu{&toolsMenu};
         MenuItem loadStateSlots[9];
-      MenuItem undoSaveStateMenu{&toolsMenu};
+      MenuItem revertSaveStateMenu{&toolsMenu};
       MenuItem undoLoadStateMenu{&toolsMenu};
       MenuItem captureScreenshot{&toolsMenu};
       MenuSeparator toolsMenuSeparatorA{&toolsMenu};

--- a/desktop-ui/presentation/presentation.hpp
+++ b/desktop-ui/presentation/presentation.hpp
@@ -9,6 +9,7 @@ struct Presentation : Window {
   auto showIcon(bool visible) -> void;
   auto loadShaders() -> void;
   auto refreshSystemMenu() -> void;
+  auto refreshStateMenus() -> void;
 
   std::vector<string> shaderDirectories;
   static inline bool shaderArgApplied = false;
@@ -64,7 +65,9 @@ struct Presentation : Window {
       MenuItem importExportAction{&settingsMenu};
     Menu toolsMenu{&menuBar};
       Menu saveStateMenu{&toolsMenu};
+        MenuItem saveStateSlots[9];
       Menu loadStateMenu{&toolsMenu};
+        MenuItem loadStateSlots[9];
       MenuItem undoSaveStateMenu{&toolsMenu};
       MenuItem undoLoadStateMenu{&toolsMenu};
       MenuItem captureScreenshot{&toolsMenu};

--- a/desktop-ui/program/program.hpp
+++ b/desktop-ui/program/program.hpp
@@ -25,7 +25,7 @@ struct Program : ares::Platform {
   //states.cpp
   auto stateSave(u32 slot) -> bool;
   auto stateLoad(u32 slot) -> bool;
-  auto undoStateSave() -> bool;
+  auto revertStateSave() -> bool;
   auto undoStateLoad() -> bool;
   auto clearUndoStates() -> void;
 

--- a/desktop-ui/program/states.cpp
+++ b/desktop-ui/program/states.cpp
@@ -3,9 +3,13 @@ auto Program::stateSave(u32 slot) -> bool {
   if(!emulator) return false;
 
   auto location = emulator->locate(emulator->game->location, {".bs", slot}, settings.paths.saves);
-  string undoLocation = {location.slice(0, (location.size() - 1)), "u"};
-  if(file::move(location, undoLocation)) {
-    state.undoSlot = slot;
+  if(file::exists(location)) {
+    auto undoLocation = emulator->locate(emulator->game->location, ".bsu", settings.paths.saves);
+    file::remove(undoLocation);
+    if(file::move(location, undoLocation)) {
+      state.undoSlot = slot;
+      presentation.revertSaveStateMenu.setEnabled(true);
+    }
   }
 
   if(auto state = emulator->root->serialize()) {
@@ -27,7 +31,9 @@ auto Program::stateLoad(u32 slot) -> bool {
   //Store current state for undo
   auto undoLocation = emulator->locate(emulator->game->location, {".blu"}, settings.paths.saves);
   if(auto state = emulator->root->serialize()) {
-    file::write(undoLocation, {state.data(), state.size()});
+    if(file::write(undoLocation, {state.data(), state.size()})) {
+      presentation.undoLoadStateMenu.setEnabled(true);
+    }
   }
 
   auto location = emulator->locate(emulator->game->location, {".bs", slot}, settings.paths.saves);
@@ -44,20 +50,21 @@ auto Program::stateLoad(u32 slot) -> bool {
   return false;
 }
 
-auto Program::undoStateSave() -> bool {
+auto Program::revertStateSave() -> bool {
   Program::Guard guard;
   if(!emulator) return false;
 
+  auto location = emulator->locate(emulator->game->location, {".bs", state.undoSlot}, settings.paths.saves);
   auto undoLocation = emulator->locate(emulator->game->location, ".bsu", settings.paths.saves);
-  string location = {undoLocation.slice(0, (undoLocation.size() - 1)), state.undoSlot};
   if(file::move(undoLocation, location)) {
     presentation.refreshStateMenus();
     showMessage({"Reverted to previous version in slot ", state.undoSlot, " of save file ", location});
-      return true;
-  } else {
-    showMessage({"Unable to revert to previous version of save file ", location});
-    return false;
+    presentation.revertSaveStateMenu.setEnabled(false);
+    return true;
   }
+
+  showMessage({"Unable to revert to previous version of save file ", location});
+  return false;
 }
 
 auto Program::undoStateLoad() -> bool {
@@ -71,6 +78,7 @@ auto Program::undoStateLoad() -> bool {
     if(emulator->root->unserialize(state)) {
       showMessage({"Loaded state from undo load file ", undoLocation});
       file::remove(undoLocation);
+      presentation.undoLoadStateMenu.setEnabled(false);
       return true;
     } else {
       showMessage({"Failed to unserialize state from undo load file ", undoLocation});
@@ -91,4 +99,7 @@ auto Program::clearUndoStates() -> void {
 
   location = emulator->locate(emulator->game->location, ".bsu", settings.paths.saves);
   file::remove(location);
+
+  presentation.revertSaveStateMenu.setEnabled(false);
+  presentation.undoLoadStateMenu.setEnabled(false);
 }

--- a/desktop-ui/program/states.cpp
+++ b/desktop-ui/program/states.cpp
@@ -10,6 +10,7 @@ auto Program::stateSave(u32 slot) -> bool {
 
   if(auto state = emulator->root->serialize()) {
     if(file::write(location, {state.data(), state.size()})) {
+      presentation.refreshStateMenus();
       showMessage({"Saved state to slot ", slot});
       return true;
     }
@@ -50,6 +51,7 @@ auto Program::undoStateSave() -> bool {
   auto undoLocation = emulator->locate(emulator->game->location, ".bsu", settings.paths.saves);
   string location = {undoLocation.slice(0, (undoLocation.size() - 1)), state.undoSlot};
   if(file::move(undoLocation, location)) {
+    presentation.refreshStateMenus();
     showMessage({"Reverted to previous version in slot ", state.undoSlot, " of save file ", location});
       return true;
   } else {


### PR DESCRIPTION
Implement `refreshStateMenus()` to dynamically enable/disable load slots based on the existence of .bs1-bs9 save files on disk.

- Track state slot MenuItems in Presentation class
- Refresh state menu status on emulator load, unload, and game reload
- Trigger menu refresh after save state and undo save state operations
- Ensure state slots are disabled when no game is loaded