### PR TITLE
ps1: enable scheduler synchronization

### DIFF
--- a/ares/ps1/system/serialization.cpp
+++ b/ares/ps1/system/serialization.cpp
@@ -1,4 +1,4 @@
-static const string SerializerVersion = "v146";
+static const string SerializerVersion = "v147";
 
 auto System::serialize(bool synchronize) -> serializer {
   serializer s;
@@ -37,6 +37,7 @@ auto System::unserialize(serializer& s) -> bool {
 }
 
 auto System::serialize(serializer& s, bool synchronize) -> void {
+  scheduler.setSynchronize(synchronize);
   s(memory);
   s(cpu);
   s(gpu);


### PR DESCRIPTION
Call scheduler.setSynchronize(synchronize) during PS1 serialization to match the behavior used by other cores.

Without synchronized serialization, coroutine/thread state may be captured inconsistently, which can lead to crashes or undefined behavior when loading savestates after relaunch.

Bump serializer version to v147 to invalidate incompatible v146 savestates created without scheduler synchronization.