### PR TITLE
fix abort on exit caused by invalid mutex unlock

### DIFF
--- a/desktop-ui/program/program.cpp
+++ b/desktop-ui/program/program.cpp
@@ -145,7 +145,9 @@ auto Program::main() -> void {
 auto Program::quit() -> void {
   Program::Guard guard;
   _quitting = true;
-  lock.unlock();
+  if(lock.owns_lock()) {
+    lock.unlock();
+  }
   _programConditionVariable.notify_all();
   worker.join();
   program._isRunning = false;


### PR DESCRIPTION
`Program::quit()` could call `unlock()` on a `unique_lock` that did not own the mutex, triggering `std::system_error` ("Operation not permitted") and terminating the process on exit.

Guard the `unlock()` call with `owns_lock()`.

This fixes the error I got on Alt+F4ing ares, or clicking `Load` -> `Quit`:
```
⋊> ares/build/rundir/bin on fix-shutdown-crash  ares
OpenGL Version: 4.6 (Core Profile) Mesa 25.3.5-arch1.1, GLSL: 4.60
terminate called after throwing an instance of 'std::system_error'
  what():  Operation not permitted
fish: Job 1, 'ares' terminated by signal SIGABRT (Abort)
⏎
⋊> ares/build/rundir/bin on fix-shutdown-crash    
```