### PR TITLE
desktop-ui: add --batch minimal UI mode

### DIFF
--- a/desktop-ui/desktop-ui.cpp
+++ b/desktop-ui/desktop-ui.cpp
@@ -80,8 +80,8 @@ auto nall::main(Arguments arguments) -> void {
     program.startPseudoFullScreen = true;
   }
 
-  if(arguments.take("--batch")) {
-    program.batchMode = true;
+  if(arguments.take("--kiosk")) {
+    program.kioskMode = true;
     program.noFilePrompt = true;
   }
 
@@ -145,7 +145,7 @@ auto nall::main(Arguments arguments) -> void {
 #endif
     print("  --fullscreen          Start in full screen mode\n");
     print("  --pseudofullscreen    Start in psuedo full screen mode\n");
-    print("  --batch               Start in minimal UI mode (implies --no-file-prompt)\n");
+    print("  --kiosk               Start in minimal UI mode (implies --no-file-prompt)\n");
     print("  --system name         Specify the system name\n");
     print("  --shader name         Specify the name of the shader to use\n");
     print("  --setting name=value  Specify a value for a setting\n");
@@ -181,28 +181,28 @@ auto nall::main(Arguments arguments) -> void {
   }
 
   program.startGameLoad.clear();
-  std::vector<string> invalidBatchPaths;
+  std::vector<string> invalidKioskPaths;
   for(auto argument : arguments) {
     if(file::exists(argument) || directory::exists(argument)) {
       program.startGameLoad.push_back(argument);
-    } else if(program.batchMode) {
-      invalidBatchPaths.push_back(argument);
+    } else if(program.kioskMode) {
+      invalidKioskPaths.push_back(argument);
     }
   }
 
-  if(program.batchMode) {
-    if(!invalidBatchPaths.empty()) {
-      print("Batch mode error: path does not exist: ", invalidBatchPaths.front(), "\n");
+  if(program.kioskMode) {
+    if(!invalidKioskPaths.empty()) {
+      print("Kiosk mode error: path does not exist: ", invalidKioskPaths.front(), "\n");
       return;
     }
     if(program.startGameLoad.empty()) {
-      print("Batch mode error: provide a valid game file or directory.\n");
+      print("Kiosk mode error: provide a valid game file or directory.\n");
       return;
     }
   }
 
   Instances::presentation.construct();
-  if(!program.batchMode) {
+  if(!program.kioskMode) {
     Instances::settingsWindow.construct();
     program.settingsWindowConstructed = true;
     Instances::gameBrowserWindow.construct();

--- a/desktop-ui/desktop-ui.cpp
+++ b/desktop-ui/desktop-ui.cpp
@@ -80,6 +80,11 @@ auto nall::main(Arguments arguments) -> void {
     program.startPseudoFullScreen = true;
   }
 
+  if(arguments.take("--batch")) {
+    program.batchMode = true;
+    program.noFilePrompt = true;
+  }
+
   if(string system; arguments.take("--system", system)) {
     program.startSystem = system;
   }
@@ -128,6 +133,8 @@ auto nall::main(Arguments arguments) -> void {
     settings.process(true);
   }
 
+  if(program.noFilePrompt) settings.general.noFilePrompt = true;
+
   if(arguments.take("--help")) {
     print("\n Usage: ares [OPTIONS]... game(s)\n\n");
     print("Options:\n");
@@ -138,6 +145,7 @@ auto nall::main(Arguments arguments) -> void {
 #endif
     print("  --fullscreen          Start in full screen mode\n");
     print("  --pseudofullscreen    Start in psuedo full screen mode\n");
+    print("  --batch               Start in minimal UI mode (implies --no-file-prompt)\n");
     print("  --system name         Specify the system name\n");
     print("  --shader name         Specify the name of the shader to use\n");
     print("  --setting name=value  Specify a value for a setting\n");
@@ -173,14 +181,35 @@ auto nall::main(Arguments arguments) -> void {
   }
 
   program.startGameLoad.clear();
+  std::vector<string> invalidBatchPaths;
   for(auto argument : arguments) {
-    if(file::exists(argument) || directory::exists(argument)) program.startGameLoad.push_back(argument);
+    if(file::exists(argument) || directory::exists(argument)) {
+      program.startGameLoad.push_back(argument);
+    } else if(program.batchMode) {
+      invalidBatchPaths.push_back(argument);
+    }
+  }
+
+  if(program.batchMode) {
+    if(!invalidBatchPaths.empty()) {
+      print("Batch mode error: path does not exist: ", invalidBatchPaths.front(), "\n");
+      return;
+    }
+    if(program.startGameLoad.empty()) {
+      print("Batch mode error: provide a valid game file or directory.\n");
+      return;
+    }
   }
 
   Instances::presentation.construct();
-  Instances::settingsWindow.construct();
-  Instances::gameBrowserWindow.construct();
-  Instances::toolsWindow.construct();
+  if(!program.batchMode) {
+    Instances::settingsWindow.construct();
+    program.settingsWindowConstructed = true;
+    Instances::gameBrowserWindow.construct();
+    program.gameBrowserWindowConstructed = true;
+    Instances::toolsWindow.construct();
+    program.toolsWindowConstructed = true;
+  }
 
   program.create();
   Application::onMain(std::bind_front(&Program::main, &program));
@@ -189,9 +218,9 @@ auto nall::main(Arguments arguments) -> void {
   settings.save();
 
   Instances::presentation.destruct();
-  Instances::settingsWindow.destruct();
-  Instances::toolsWindow.destruct();
-  Instances::gameBrowserWindow.destruct();
+  if(program.settingsWindowConstructed) Instances::settingsWindow.destruct();
+  if(program.toolsWindowConstructed) Instances::toolsWindow.destruct();
+  if(program.gameBrowserWindowConstructed) Instances::gameBrowserWindow.destruct();
 }
 
 #if defined(PLATFORM_WINDOWS) && defined(ARCHITECTURE_AMD64) && !defined(BUILD_LOCAL)

--- a/desktop-ui/emulator/emulator.cpp
+++ b/desktop-ui/emulator/emulator.cpp
@@ -254,7 +254,7 @@ auto Emulator::setColorBleed(bool value) -> bool {
 
 auto Emulator::error(const string& text) -> void {
   MessageDialog().setTitle("Error").setText(text).setAlignment(presentation).error();
-  if(program.batchMode) program.pendingBatchExit = true;
+  if(program.kioskMode) program.pendingKioskExit = true;
 }
 
 auto Emulator::input(ares::Node::Input::Input input) -> void {

--- a/desktop-ui/emulator/emulator.cpp
+++ b/desktop-ui/emulator/emulator.cpp
@@ -254,6 +254,7 @@ auto Emulator::setColorBleed(bool value) -> bool {
 
 auto Emulator::error(const string& text) -> void {
   MessageDialog().setTitle("Error").setText(text).setAlignment(presentation).error();
+  if(program.batchMode) program.pendingBatchExit = true;
 }
 
 auto Emulator::input(ares::Node::Input::Input input) -> void {
@@ -319,4 +320,3 @@ auto Emulator::inputKeyboard(string name) -> bool {
 
   return false;
 }
-

--- a/desktop-ui/presentation/presentation.cpp
+++ b/desktop-ui/presentation/presentation.cpp
@@ -5,6 +5,37 @@ Presentation& presentation = Instances::presentation();
 #define ELLIPSIS "\u2026"
 
 Presentation::Presentation() {
+  if(program.batchMode) {
+    viewport.setDroppable().onDrop([&](std::vector<string> filenames) {
+      Program::Guard guard;
+      if(filenames.size() != 1) return;
+      if(auto emulator = program.identify(filenames.front())) {
+        program.load(emulator, filenames.front());
+      }
+    });
+
+    Application::onOpenFile([&](auto filename) {
+      Program::Guard guard;
+      if(auto emulator = program.identify(filename)) {
+        program.load(emulator, filename);
+      }
+    });
+
+    onClose([&] {
+      program.quit();
+    });
+
+    menuBar.setVisible(false);
+    layout.remove(statusLayout);
+    resizeWindow();
+    setTitle({ares::Name, " ", ares::Version});
+    setAssociatedFile();
+    setBackgroundColor({0, 0, 0});
+    setAlignment(Alignment::Center);
+    setVisible();
+    return;
+  }
+
   loadMenu.setText("Load");
 
   systemMenu.setVisible(false);
@@ -329,7 +360,7 @@ auto Presentation::resizeWindow() -> void {
     viewportHeight = videoHeight * multiplier;
   }
 
-  u32 statusHeight = showStatusBarSetting.checked() ? StatusHeight : 0;
+  u32 statusHeight = (!program.batchMode && showStatusBarSetting.checked()) ? StatusHeight : 0;
 
   // Prevent the window frame from going out of bounds
   u32 monitorHeight = 1;
@@ -358,6 +389,7 @@ auto Presentation::resizeWindow() -> void {
 }
 
 auto Presentation::loadEmulators() -> void {
+  if(program.batchMode) return;
   loadMenu.reset();
 
   //clean up the recent games history first
@@ -500,6 +532,13 @@ auto Presentation::loadEmulators() -> void {
 }
 
 auto Presentation::loadEmulator() -> void {
+  if(program.batchMode) {
+    setTitle(emulator->root->game());
+    setAssociatedFile(emulator->game->location);
+    setFocused();
+    viewport.setFocused();
+    return;
+  }
   setTitle(emulator->root->game());
   setAssociatedFile(emulator->game->location);
   systemMenu.setText(emulator->name);
@@ -515,6 +554,7 @@ auto Presentation::loadEmulator() -> void {
 }
 
 auto Presentation::refreshSystemMenu() -> void {
+  if(program.batchMode) return;
   systemMenu.reset();
 
   //allow each emulator core to create any specialized menus necessary:
@@ -635,6 +675,7 @@ auto Presentation::refreshSystemMenu() -> void {
 auto Presentation::unloadEmulator(bool reloading) -> void {
   setTitle({ares::Name, " ", ares::Version});
   setAssociatedFile();
+  if(program.batchMode) return;
   systemMenu.setVisible(false);
   systemMenu.reset();
 
@@ -650,6 +691,7 @@ auto Presentation::showIcon(bool visible) -> void {
 }
 
 auto Presentation::loadShaders() -> void {
+  if(program.batchMode) return;
   videoShaderMenu.reset();
   videoShaderMenu.setEnabled(ruby::video.hasShader());
   if(!ruby::video.hasShader()) return;

--- a/desktop-ui/presentation/presentation.cpp
+++ b/desktop-ui/presentation/presentation.cpp
@@ -5,7 +5,7 @@ Presentation& presentation = Instances::presentation();
 #define ELLIPSIS "\u2026"
 
 Presentation::Presentation() {
-  if(program.batchMode) {
+  if(program.kioskMode) {
     viewport.setDroppable().onDrop([&](std::vector<string> filenames) {
       Program::Guard guard;
       if(filenames.size() != 1) return;
@@ -360,7 +360,7 @@ auto Presentation::resizeWindow() -> void {
     viewportHeight = videoHeight * multiplier;
   }
 
-  u32 statusHeight = (!program.batchMode && showStatusBarSetting.checked()) ? StatusHeight : 0;
+  u32 statusHeight = (!program.kioskMode && showStatusBarSetting.checked()) ? StatusHeight : 0;
 
   // Prevent the window frame from going out of bounds
   u32 monitorHeight = 1;
@@ -389,7 +389,7 @@ auto Presentation::resizeWindow() -> void {
 }
 
 auto Presentation::loadEmulators() -> void {
-  if(program.batchMode) return;
+  if(program.kioskMode) return;
   loadMenu.reset();
 
   //clean up the recent games history first
@@ -532,7 +532,7 @@ auto Presentation::loadEmulators() -> void {
 }
 
 auto Presentation::loadEmulator() -> void {
-  if(program.batchMode) {
+  if(program.kioskMode) {
     setTitle(emulator->root->game());
     setAssociatedFile(emulator->game->location);
     setFocused();
@@ -554,7 +554,7 @@ auto Presentation::loadEmulator() -> void {
 }
 
 auto Presentation::refreshSystemMenu() -> void {
-  if(program.batchMode) return;
+  if(program.kioskMode) return;
   systemMenu.reset();
 
   //allow each emulator core to create any specialized menus necessary:
@@ -675,7 +675,7 @@ auto Presentation::refreshSystemMenu() -> void {
 auto Presentation::unloadEmulator(bool reloading) -> void {
   setTitle({ares::Name, " ", ares::Version});
   setAssociatedFile();
-  if(program.batchMode) return;
+  if(program.kioskMode) return;
   systemMenu.setVisible(false);
   systemMenu.reset();
 
@@ -691,7 +691,7 @@ auto Presentation::showIcon(bool visible) -> void {
 }
 
 auto Presentation::loadShaders() -> void {
-  if(program.batchMode) return;
+  if(program.kioskMode) return;
   videoShaderMenu.reset();
   videoShaderMenu.setEnabled(ruby::video.hasShader());
   if(!ruby::video.hasShader()) return;

--- a/desktop-ui/program/drivers.cpp
+++ b/desktop-ui/program/drivers.cpp
@@ -14,8 +14,44 @@ auto Program::videoDriverUpdate() -> void {
 
   if(!ruby::video.ready()) {
     MessageDialog().setText({"Failed to initialize ", settings.video.driver, " video driver."}).setAlignment(presentation).error();
+    if(batchMode) pendingBatchExit = true;
     settings.video.driver = "None";
-    driverSettings.videoDriverUpdate();
+    if(settingsWindowConstructed) driverSettings.videoDriverUpdate();
+    return;
+  }
+
+  if(startShader && !Presentation::shaderArgApplied) {
+    Presentation::shaderArgApplied = true;
+    string location = locate("Shaders/");
+    #if defined(PLATFORM_LINUX) || defined(PLATFORM_BSD)
+    if(!inode::exists(location)) location = locate("../libretro/shaders/shaders_slang/");
+    #endif
+
+    string existingShader = settings.video.shader;
+    startShader.transform("\\", "/");
+    if(!startShader.imatch("None")) {
+      settings.video.shader = {startShader, ".slangp"};
+    } else {
+      settings.video.shader = startShader;
+    }
+
+    if(inode::exists({location, settings.video.shader})) {
+      ruby::video.setShader({location, settings.video.shader});
+    } else if(settings.video.shader.imatch("None")) {
+      ruby::video.setShader("None");
+    } else {
+      if(batchMode) {
+        showMessage({"Requested shader not found: ", location, settings.video.shader, ". Using existing shader."});
+      } else {
+        hiro::MessageDialog()
+          .setTitle("Warning")
+          .setAlignment(hiro::Alignment::Center)
+          .setText({"Requested shader not found: ", location, settings.video.shader,
+            "\nUsing existing defined shader: ", location, existingShader})
+          .warning();
+      }
+      settings.video.shader = existingShader;
+    }
   }
 
   presentation.loadShaders();
@@ -94,8 +130,9 @@ auto Program::audioDriverUpdate() -> void {
 
   if(!ruby::audio.ready()) {
     MessageDialog().setText({"Failed to initialize ", settings.audio.driver, " audio driver."}).setAlignment(presentation).error();
+    if(batchMode) pendingBatchExit = true;
     settings.audio.driver = "None";
-    driverSettings.audioDriverUpdate();
+    if(settingsWindowConstructed) driverSettings.audioDriverUpdate();
   }
 }
 
@@ -137,8 +174,9 @@ auto Program::inputDriverUpdate() -> void {
 
   if(!ruby::input.ready()) {
     MessageDialog().setText({"Failed to initialize ", settings.input.driver, " input driver."}).setAlignment(presentation).error();
+    if(batchMode) pendingBatchExit = true;
     settings.input.driver = "None";
-    driverSettings.inputDriverUpdate();
+    if(settingsWindowConstructed) driverSettings.inputDriverUpdate();
   }
 
   inputManager.poll(true);

--- a/desktop-ui/program/drivers.cpp
+++ b/desktop-ui/program/drivers.cpp
@@ -14,7 +14,7 @@ auto Program::videoDriverUpdate() -> void {
 
   if(!ruby::video.ready()) {
     MessageDialog().setText({"Failed to initialize ", settings.video.driver, " video driver."}).setAlignment(presentation).error();
-    if(batchMode) pendingBatchExit = true;
+    if(kioskMode) pendingKioskExit = true;
     settings.video.driver = "None";
     if(settingsWindowConstructed) driverSettings.videoDriverUpdate();
     return;
@@ -40,7 +40,7 @@ auto Program::videoDriverUpdate() -> void {
     } else if(settings.video.shader.imatch("None")) {
       ruby::video.setShader("None");
     } else {
-      if(batchMode) {
+      if(kioskMode) {
         showMessage({"Requested shader not found: ", location, settings.video.shader, ". Using existing shader."});
       } else {
         hiro::MessageDialog()
@@ -130,7 +130,7 @@ auto Program::audioDriverUpdate() -> void {
 
   if(!ruby::audio.ready()) {
     MessageDialog().setText({"Failed to initialize ", settings.audio.driver, " audio driver."}).setAlignment(presentation).error();
-    if(batchMode) pendingBatchExit = true;
+    if(kioskMode) pendingKioskExit = true;
     settings.audio.driver = "None";
     if(settingsWindowConstructed) driverSettings.audioDriverUpdate();
   }
@@ -174,7 +174,7 @@ auto Program::inputDriverUpdate() -> void {
 
   if(!ruby::input.ready()) {
     MessageDialog().setText({"Failed to initialize ", settings.input.driver, " input driver."}).setAlignment(presentation).error();
-    if(batchMode) pendingBatchExit = true;
+    if(kioskMode) pendingKioskExit = true;
     settings.input.driver = "None";
     if(settingsWindowConstructed) driverSettings.inputDriverUpdate();
   }

--- a/desktop-ui/program/load.cpp
+++ b/desktop-ui/program/load.cpp
@@ -11,6 +11,7 @@ auto Program::identify(const string& filename) -> std::shared_ptr<Emulator> {
     "Unable to determine what type of game this file is.\n"
     "Please use the load menu to choose the appropriate game system instead."
   }).setAlignment(presentation).error();
+  if(batchMode) pendingBatchExit = true;
   return {};
 }
 
@@ -23,6 +24,13 @@ auto Program::load(std::shared_ptr<Emulator> emulator, string location) -> bool 
 
   // For arcade systems, show the game browser dialog as we're using MAME-compatible roms
   if(emulator->arcade() && !location) {
+    if(!gameBrowserWindowConstructed) {
+      if(batchMode) {
+        showMessage("Batch mode does not support the arcade game browser. Specify a game path.");
+      }
+      ::emulator.reset();
+      return false;
+    }
     gameBrowserWindow.show(emulator);
     
     // Temporarily pretend that the load failed to prevent crash
@@ -53,11 +61,17 @@ auto Program::load(string location) -> bool {
   string savesPath = settings.paths.saves;
   if(!savesPath) savesPath = Location::path(location);
   if(!directory::writable(savesPath)) {
-    MessageDialog().setTitle(ares::Name).setText({
-      "The current save path is read-only; please choose a writable save path now.\n"
-      "Otherwise, any in-game progress will be lost once this game is unloaded!\n\n"
-      "Current save location: ", savesPath
-    }).warning();
+    if(batchMode) {
+      showMessage({
+        "Current save path is read-only; progress may be lost. Save location: ", savesPath
+      });
+    } else {
+      MessageDialog().setTitle(ares::Name).setText({
+        "The current save path is read-only; please choose a writable save path now.\n"
+        "Otherwise, any in-game progress will be lost once this game is unloaded!\n\n"
+        "Current save location: ", savesPath
+      }).warning();
+    }
   }
 
   paletteUpdate();
@@ -65,18 +79,20 @@ auto Program::load(string location) -> bool {
   presentation.loadEmulator();
   presentation.showIcon(false);
   if(settings.video.adaptiveSizing  && !startPseudoFullScreen) presentation.resizeWindow();
-  manifestViewer.reload();
-  cheatEditor.reload();
-  memoryEditor.reload();
-  graphicsViewer.reload();
-  streamManager.reload();
-  propertiesViewer.reload();
-  traceLogger.reload();
-  tapeViewer.reload();
+  if(toolsWindowConstructed) {
+    manifestViewer.reload();
+    cheatEditor.reload();
+    memoryEditor.reload();
+    graphicsViewer.reload();
+    streamManager.reload();
+    propertiesViewer.reload();
+    traceLogger.reload();
+    tapeViewer.reload();
+  }
   state = {};  //reset hotkey state slot to 1
   if(settings.boot.debugger) {
     pause(true);
-    toolsWindow.show("Tracer");
+    if(toolsWindowConstructed) toolsWindow.show("Tracer");
     presentation.setFocused();
   } else if (settings.boot.awaitGDBClient) {
     pause(true);
@@ -128,16 +144,18 @@ auto Program::unload() -> void {
   emulator.reset();
   rewindReset();
   presentation.unloadEmulator();
-  toolsWindow.setVisible(false);
-  gameBrowserWindow.setVisible(false);
-  manifestViewer.unload();
-  cheatEditor.unload();
-  memoryEditor.unload();
-  graphicsViewer.unload();
-  streamManager.unload();
-  propertiesViewer.unload();
-  traceLogger.unload();
-  tapeViewer.unload();
+  if(toolsWindowConstructed) {
+    toolsWindow.setVisible(false);
+    manifestViewer.unload();
+    cheatEditor.unload();
+    memoryEditor.unload();
+    graphicsViewer.unload();
+    streamManager.unload();
+    propertiesViewer.unload();
+    traceLogger.unload();
+    tapeViewer.unload();
+  }
+  if(gameBrowserWindowConstructed) gameBrowserWindow.setVisible(false);
   message.text = "";
   configuration = "";
   ruby::video.clear();

--- a/desktop-ui/program/load.cpp
+++ b/desktop-ui/program/load.cpp
@@ -11,7 +11,7 @@ auto Program::identify(const string& filename) -> std::shared_ptr<Emulator> {
     "Unable to determine what type of game this file is.\n"
     "Please use the load menu to choose the appropriate game system instead."
   }).setAlignment(presentation).error();
-  if(batchMode) pendingBatchExit = true;
+  if(kioskMode) pendingKioskExit = true;
   return {};
 }
 
@@ -25,8 +25,8 @@ auto Program::load(std::shared_ptr<Emulator> emulator, string location) -> bool 
   // For arcade systems, show the game browser dialog as we're using MAME-compatible roms
   if(emulator->arcade() && !location) {
     if(!gameBrowserWindowConstructed) {
-      if(batchMode) {
-        showMessage("Batch mode does not support the arcade game browser. Specify a game path.");
+      if(kioskMode) {
+        showMessage("Kiosk mode does not support the arcade game browser. Specify a game path.");
       }
       ::emulator.reset();
       return false;
@@ -61,7 +61,7 @@ auto Program::load(string location) -> bool {
   string savesPath = settings.paths.saves;
   if(!savesPath) savesPath = Location::path(location);
   if(!directory::writable(savesPath)) {
-    if(batchMode) {
+    if(kioskMode) {
       showMessage({
         "Current save path is read-only; progress may be lost. Save location: ", savesPath
       });

--- a/desktop-ui/program/platform.cpp
+++ b/desktop-ui/program/platform.cpp
@@ -169,7 +169,7 @@ auto Program::audio(ares::Node::Audio::Stream node) -> void {
 }
 
 auto Program::input(ares::Node::Input::Input node) -> void {
-  if(!driverSettings.inputDefocusAllow.checked()) {
+  if(settings.input.defocus != "Allow") {
     if(!ruby::video.fullScreen() && !presentation.focused()) {
       //treat the input as not being active
       if(auto button = node->cast<ares::Node::Input::Button>()) button->setValue(0);

--- a/desktop-ui/program/program.cpp
+++ b/desktop-ui/program/program.cpp
@@ -17,6 +17,11 @@ auto Program::create() -> void {
   audioDriverUpdate();
   inputDriverUpdate();
 
+  if(batchMode) {
+    if(startFullScreen) videoFullScreenToggle();
+    if(startPseudoFullScreen) videoPseudoFullScreenToggle();
+  }
+
   _isRunning = true;
   worker = thread::create(std::bind_front(&Program::emulatorRunLoop, this));
   program.rewindReset();
@@ -29,8 +34,10 @@ auto Program::create() -> void {
       for(auto &emulator: emulators) {
         if(emulator->name == startSystem) {
           if(load(emulator, gameToLoad)) {
-            if(startFullScreen) videoFullScreenToggle();
-            if(startPseudoFullScreen) videoPseudoFullScreenToggle();
+            if(!batchMode) {
+              if(startFullScreen) videoFullScreenToggle();
+              if(startPseudoFullScreen) videoPseudoFullScreenToggle();
+            }
           }
           return;
         }
@@ -39,8 +46,10 @@ auto Program::create() -> void {
 
     if(auto emulator = identify(gameToLoad)) {
       if(load(emulator, gameToLoad)) {
-        if(startFullScreen) videoFullScreenToggle();
-        if(startPseudoFullScreen) videoPseudoFullScreenToggle();
+        if(!batchMode) {
+          if(startFullScreen) videoFullScreenToggle();
+          if(startPseudoFullScreen) videoPseudoFullScreenToggle();
+        }
       }
     }
   }
@@ -73,7 +82,7 @@ auto Program::emulatorRunLoop(uintptr_t) -> void {
       continue;
     }
 
-    bool defocused = driverSettings.inputDefocusPause.checked() && !ruby::video.fullScreen() && !presentation.focused();
+    bool defocused = settings.input.defocus == "Pause" && !ruby::video.fullScreen() && !presentation.focused();
 
     if(!emulator || (paused && !program.requestFrameAdvance) || defocused) {
       ruby::audio.clear();
@@ -122,6 +131,12 @@ auto Program::main() -> void {
     ruby::audio.clear();
     return;
   }
+
+  if(pendingBatchExit) {
+    pendingBatchExit = false;
+    quit();
+    return;
+  }
   
   inputManager.poll();
   inputManager.pollHotkeys();
@@ -136,10 +151,12 @@ auto Program::main() -> void {
     _needsResize = false;
   }
 
-  memoryEditor.liveRefresh();
-  graphicsViewer.liveRefresh();
-  propertiesViewer.liveRefresh();
-  tapeViewer.liveRefresh();
+  if(toolsWindowConstructed) {
+    memoryEditor.liveRefresh();
+    graphicsViewer.liveRefresh();
+    propertiesViewer.liveRefresh();
+    tapeViewer.liveRefresh();
+  }
 }
 
 auto Program::quit() -> void {

--- a/desktop-ui/program/program.cpp
+++ b/desktop-ui/program/program.cpp
@@ -17,7 +17,7 @@ auto Program::create() -> void {
   audioDriverUpdate();
   inputDriverUpdate();
 
-  if(batchMode) {
+  if(kioskMode) {
     if(startFullScreen) videoFullScreenToggle();
     if(startPseudoFullScreen) videoPseudoFullScreenToggle();
   }
@@ -34,7 +34,7 @@ auto Program::create() -> void {
       for(auto &emulator: emulators) {
         if(emulator->name == startSystem) {
           if(load(emulator, gameToLoad)) {
-            if(!batchMode) {
+            if(!kioskMode) {
               if(startFullScreen) videoFullScreenToggle();
               if(startPseudoFullScreen) videoPseudoFullScreenToggle();
             }
@@ -46,7 +46,7 @@ auto Program::create() -> void {
 
     if(auto emulator = identify(gameToLoad)) {
       if(load(emulator, gameToLoad)) {
-        if(!batchMode) {
+        if(!kioskMode) {
           if(startFullScreen) videoFullScreenToggle();
           if(startPseudoFullScreen) videoPseudoFullScreenToggle();
         }
@@ -132,8 +132,8 @@ auto Program::main() -> void {
     return;
   }
 
-  if(pendingBatchExit) {
-    pendingBatchExit = false;
+  if(pendingKioskExit) {
+    pendingKioskExit = false;
     quit();
     return;
   }

--- a/desktop-ui/program/program.hpp
+++ b/desktop-ui/program/program.hpp
@@ -59,8 +59,12 @@ struct Program : ares::Platform {
 
   bool startFullScreen = false;
   bool startPseudoFullScreen = false;
+  bool batchMode = false;
   std::vector<string> startGameLoad;
   bool noFilePrompt = false;
+  bool settingsWindowConstructed = false;
+  bool gameBrowserWindowConstructed = false;
+  bool toolsWindowConstructed = false;
 
   string startSystem;
   string startShader;
@@ -76,6 +80,7 @@ struct Program : ares::Platform {
   bool requestFrameAdvance = false;
   bool requestScreenshot = false;
   bool keyboardCaptured = false;
+  atomic<bool> pendingBatchExit = false;
 
   struct State {
     u32 slot = 1;

--- a/desktop-ui/program/program.hpp
+++ b/desktop-ui/program/program.hpp
@@ -59,7 +59,7 @@ struct Program : ares::Platform {
 
   bool startFullScreen = false;
   bool startPseudoFullScreen = false;
-  bool batchMode = false;
+  bool kioskMode = false;
   std::vector<string> startGameLoad;
   bool noFilePrompt = false;
   bool settingsWindowConstructed = false;
@@ -80,7 +80,7 @@ struct Program : ares::Platform {
   bool requestFrameAdvance = false;
   bool requestScreenshot = false;
   bool keyboardCaptured = false;
-  atomic<bool> pendingBatchExit = false;
+  atomic<bool> pendingKioskExit = false;
 
   struct State {
     u32 slot = 1;


### PR DESCRIPTION
Introduce a `--batch` command-line option to run with a minimal presentation for frontend-driven launches (eg EmulationStation, arcade cabinets etc).

Behavior
- `--batch` implies `--no-file-prompt`
- Requires at least one valid game path (otherwise exits with a clear error)
- Uses a minimal presentation:
  - hides menu bar
  - removes status bar
  - black background / centered viewport
  - keeps file-open and drag/drop support
- Skips constructing settings/tools/game-browser windows in batch

Runtime safety
- Batch mode avoids UI-only flows where possible (logs messages instead)
- Driver and load/identify failures trigger a clean batch exit path
- Runtime defocus checks now use `settings.input.defocus` instead of `driverSettings.*.checked()`:
  - avoids dereferencing non-constructed UI widgets in batch
  - fixes batch crash from UI-state reads on non-UI code paths