### PR TITLE
Linux Qt builds for Wayland + ignore global hotkeys when ares is not focused

### DIFF
--- a/desktop-ui/input/input.cpp
+++ b/desktop-ui/input/input.cpp
@@ -144,7 +144,7 @@ auto InputDigital::value() -> s16 {
     auto& groupID = binding.groupID;
     auto& inputID = binding.inputID;
     auto& qualifier = binding.qualifier;
-    if (device->isKeyboard() && program.keyboardCaptured) continue;
+    if (device->isKeyboard() && (program.keyboardCaptured || (!presentation.focused() && !ruby::video.fullScreen()))) continue;
     s16 value = device->group(groupID).input(inputID).value();
     s16 output = 0;
 
@@ -178,6 +178,7 @@ auto InputDigital::pressed() -> bool {
 
 
 auto InputHotkey::value() -> s16 {
+  if(!presentation.focused() && !ruby::video.fullScreen()) return 0;
   lock_guard<recursive_mutex> inputLock(program.inputMutex);
   s16 result = 0;
 
@@ -264,7 +265,7 @@ auto InputAnalog::value() -> s16 {
     auto& groupID = binding.groupID;
     auto& inputID = binding.inputID;
     auto& qualifier = binding.qualifier;
-    if (device->isKeyboard() && program.keyboardCaptured) continue;    
+    if (device->isKeyboard() && (program.keyboardCaptured || !presentation.focused())) continue;    
     s16 value = device->group(groupID).input(inputID).value();
 
     if(device->isKeyboard() && groupID == HID::Keyboard::GroupID::Button) {
@@ -333,7 +334,7 @@ auto InputAbsolute::value() -> s16 {
     auto& groupID = binding.groupID;
     auto& inputID = binding.inputID;
     auto& qualifier = binding.qualifier;
-    if (device->isKeyboard() && program.keyboardCaptured) continue;
+    if (device->isKeyboard() && (program.keyboardCaptured || (!presentation.focused() && !ruby::video.fullScreen()))) continue;
     s16 value = device->group(groupID).input(inputID).value();
 
     if(device->isMouse() && groupID == HID::Joypad::GroupID::Axis && ruby::input.acquired()) {
@@ -392,7 +393,7 @@ auto InputRelative::value() -> s16 {
     auto& groupID = binding.groupID;
     auto& inputID = binding.inputID;
     auto& qualifier = binding.qualifier;
-    if (device->isKeyboard() && program.keyboardCaptured) continue;
+    if (device->isKeyboard() && (program.keyboardCaptured || (!presentation.focused() && !ruby::video.fullScreen()))) continue;
     s16 value = device->group(groupID).input(inputID).value();
 
     if(device->isMouse() && groupID == HID::Joypad::GroupID::Axis && ruby::input.acquired()) {

--- a/hiro/qt/application.cpp
+++ b/hiro/qt/application.cpp
@@ -89,6 +89,20 @@ auto pApplication::initialize() -> void {
   setenv("QTCOMPOSE", "/usr/local/lib/X11/locale/", 0);
   #endif
 
+  #if (defined(PLATFORM_LINUX) || defined(PLATFORM_BSD))
+  // ruby's Linux video backend is GLX/X11-based, so default Qt to X11 under Wayland
+  // unless the user explicitly requested a Qt platform plugin.
+  if(!getenv("QT_QPA_PLATFORM")) {
+    if(getenv("WAYLAND_DISPLAY")) {
+      setenv("QT_QPA_PLATFORM", "xcb", 0);
+    } else if(auto sessionType = getenv("XDG_SESSION_TYPE")) {
+      if(string{sessionType}.iequals("wayland")) {
+        setenv("QT_QPA_PLATFORM", "xcb", 0);
+      }
+    }
+  }
+  #endif
+
   #if defined(DISPLAY_XORG)
   XInitThreads();
   state().display = XOpenDisplay(nullptr);


### PR DESCRIPTION
The first commit prevents ares hotkeys from being triggered when ares is on a different workspace (noticed on Hyprland).

Second one prevents ares' Qt build from crashing on startup on wayland (also noticed on Hyprland):
```
QWidget::paintEngine: Should no longer be called
QWidget::paintEngine: Should no longer be called
X Error of failed request:  BadWindow (invalid Window parameter)
  Major opcode of failed request:  3 (X_GetWindowAttributes)
  Resource id in failed request:  0x479bf890
  Serial number of failed request:  27
  Current serial number in output stream:  28
QThreadStorage: entry 1 destroyed before end of thread 0x5611475a0ba0
QThreadStorage: entry 0 destroyed before end of thread 0x5611475a0ba0
beginResetModel called; about to emit modelAboutToBeReset
endResetModel called; about to emit modelReset
beginResetModel called; about to emit modelAboutToBeReset
endResetModel called; about to emit modelReset
beginResetModel called; about to emit modelAboutToBeReset
endResetModel called; about to emit modelReset
QBasicTimer::start: QBasicTimer can only be used with threads started with QThread
beginResetModel called; about to emit modelAboutToBeReset
endResetModel called; about to emit modelReset
beginResetModel called; about to emit modelAboutToBeReset
endResetModel called; about to emit modelReset
fish: Job 1, './ares…' terminated by signal SIGSEGV (Address boundary error)
```