### PR TITLE
x11: gate keyboard input and mouse grab on active window PID

### DIFF
--- a/ruby/input/keyboard/xlib.cpp
+++ b/ruby/input/keyboard/xlib.cpp
@@ -7,6 +7,11 @@ struct InputKeyboardXlib {
   std::shared_ptr<HID::Keyboard> hid = std::make_shared<HID::Keyboard>();
 
   Display* display = nullptr;
+  // Focus gate: only process key state when the active X11 window belongs to this PID.
+  Window rootWindow = 0;
+  Atom netActiveWindow = 0;
+  Atom netWmPid = 0;
+  u32 selfPid = 0;
 
   struct Key {
     string name;
@@ -14,6 +19,16 @@ struct InputKeyboardXlib {
     u32 keycode = 0;
   };
   std::vector<Key> keys;
+
+  // Return _NET_WM_PID for an X11 window (0 if missing/invalid).
+  auto getNetWmPid(Window window) -> u32 {
+    Atom actualType; int actualFormat; unsigned long nItems, bytesAfter; unsigned char* propValue = nullptr; u32 pid = 0;
+    if(XGetWindowProperty(display, window, netWmPid, 0, 1, False, XA_CARDINAL, &actualType, &actualFormat, &nItems, &bytesAfter, &propValue) == Success && propValue) {
+      pid = *(u32*)propValue;
+      XFree(propValue);
+    }
+    return pid;
+  }
 
   auto assign(u32 inputID, bool value) -> void {
     auto& group = hid->buttons();
@@ -23,6 +38,20 @@ struct InputKeyboardXlib {
   }
 
   auto poll(std::vector<std::shared_ptr<HID::Device>>& devices) -> void {
+    Atom actualType; int actualFormat; unsigned long nItems, bytesAfter; unsigned char* propValue = nullptr; Window activeWindow = None;
+      // XQueryKeymap reports global key state; ignore it unless the active window belongs to this PID.
+      if(XGetWindowProperty(display, rootWindow, netActiveWindow, 0, 1, False, XA_WINDOW, &actualType, &actualFormat, &nItems, &bytesAfter, &propValue) == Success && propValue) {
+      activeWindow = *(Window*)propValue;
+      XFree(propValue);
+    }
+
+    bool processInput = false;
+    if(activeWindow == None) processInput = false;
+    else if(getNetWmPid(activeWindow) == selfPid) processInput = true;
+
+    // Not focused: keep device enumerated, but don't update state.
+    if(!processInput) return devices.push_back(hid);
+
     char state[32];
     XQueryKeymap(display, state);
 
@@ -37,6 +66,11 @@ struct InputKeyboardXlib {
 
   auto initialize() -> bool {
     display = XOpenDisplay(0);
+    rootWindow = DefaultRootWindow(display);
+    // Cache atoms + PID for focus gating
+    netActiveWindow = XInternAtom(display, "_NET_ACTIVE_WINDOW", False);
+    netWmPid = XInternAtom(display, "_NET_WM_PID", False);
+    selfPid = (u32)getpid();
 
     keys.push_back({"Escape", XK_Escape});
 

--- a/ruby/input/mouse/xlib.cpp
+++ b/ruby/input/mouse/xlib.cpp
@@ -13,6 +13,10 @@ struct InputMouseXlib {
   Cursor invisibleCursor = 0;
   u32 screenWidth = 0;
   u32 screenHeight = 0;
+  // Focus gate: drop pointer grab when the active X11 window is not ours
+  Atom netActiveWindow = 0;
+  Atom netWmPid = 0;
+  u32 selfPid = 0;
 
   struct Mouse {
     bool acquired = false;
@@ -26,6 +30,16 @@ struct InputMouseXlib {
 
   auto acquired() -> bool {
     return ms.acquired;
+  }
+
+  // Return _NET_WM_PID for an X11 window (0 if missing/invalid)
+  auto getNetWmPid(Window window) -> u32 {
+    Atom actualType; int actualFormat; unsigned long nItems, bytesAfter; unsigned char* propValue = nullptr; u32 pid = 0;
+    if(XGetWindowProperty(display, window, netWmPid, 0, 1, False, XA_CARDINAL, &actualType, &actualFormat, &nItems, &bytesAfter, &propValue) == Success && propValue) {
+      pid = *(u32*)propValue;
+      XFree(propValue);
+    }
+    return pid;
   }
 
   auto acquire() -> bool {
@@ -65,6 +79,25 @@ struct InputMouseXlib {
   }
 
   auto poll(std::vector<std::shared_ptr<HID::Device>>& devices) -> void {
+    // If the mouse is grabbed (relative mode), only keep the grab while this window
+    // (or another window owned by this process) is the active/focused window.
+    // Prevents stuck mouse capture after alt-tabbing out of fullscreen
+    if(acquired()) {
+      Atom actualType; int actualFormat; unsigned long nItems, bytesAfter; unsigned char* propValue = nullptr; Window activeWindow = None;
+      if(XGetWindowProperty(display, rootWindow, netActiveWindow, 0, 1, False, XA_WINDOW, &actualType, &actualFormat, &nItems, &bytesAfter, &propValue) == Success && propValue) {
+        activeWindow = *(Window*)propValue;
+        XFree(propValue);
+      }
+
+      // keep grab if our GLX child window is active, or if the active window belongs to our PID.
+      bool processInput = false;
+      if(activeWindow == handle) processInput = true;
+      else if(activeWindow != None && getNetWmPid(activeWindow) == selfPid) processInput = true;
+
+      // focus left ares' process: drop the grab so the user regains the cursor
+      if(!processInput && activeWindow != None) release();
+    }
+
     Window rootReturn;
     Window childReturn;
     s32 rootXReturn = 0;
@@ -124,6 +157,9 @@ struct InputMouseXlib {
     this->handle = handle;
     display = XOpenDisplay(0);
     rootWindow = DefaultRootWindow(display);
+    netActiveWindow = XInternAtom(display, "_NET_ACTIVE_WINDOW", False);
+    netWmPid = XInternAtom(display, "_NET_WM_PID", False);
+    selfPid = (u32)getpid();
 
     XWindowAttributes attributes;
     XGetWindowAttributes(display, rootWindow, &attributes);

--- a/ruby/video/glx.cpp
+++ b/ruby/video/glx.cpp
@@ -233,6 +233,12 @@ private:
       CWBorderPixel | CWColormap | CWOverrideRedirect, &attributes);
     XSelectInput(_display, _window, ExposureMask);
     XSetWindowBackground(_display, _window, 0);
+    // Set _NET_WM_PID on the GLX window so input backends can attribute focus to this process.
+    {
+      auto pid = (uint32_t)getpid();
+      Atom netWmPid = XInternAtom(_display, "_NET_WM_PID", False);
+      XChangeProperty(_display, _window, netWmPid, XA_CARDINAL, 32, PropModeReplace, (unsigned char*)&pid, 1);
+    }
     XMapWindow(_display, _window);
     XFlush(_display);
 


### PR DESCRIPTION
Prevent keyboard state updates and mouse pointer grab from remaining active when the focused X11 window does not belong to this process.

- Keyboard: ignore XQueryKeymap results unless the active _NET_ACTIVE_WINDOW resolves to our PID.
- Mouse: automatically release pointer grab when focus leaves our window/process to avoid stuck cursor after alt-tab.
- GLX: explicitly set _NET_WM_PID on the GLX child window so focus attribution works reliably.

This ensures input is only processed while ares owns focus and avoids global key state leakage or cursor capture issues under X11 and Xwayland. The fix does not impact the Drivers->Input setting "When focus is lost" behavior; controller will still be able to trigger keys if set as "Allow input".

This commit replaces the whole workaround I previously attempted with https://github.com/ares-emulator/ares/pull/2431, to let the X server handling the windows as usual, instead of messing around with the desktop-ui/ logic.

edit: on hold, will try to get the [windows fix](https://github.com/ares-emulator/ares/pull/1426) merged as well. we're still waiting for testing feedback on macOS