### PR TITLE
desktop-ui: prevent hotkey from firing when setting one

### DIFF
--- a/desktop-ui/input/hotkeys.cpp
+++ b/desktop-ui/input/hotkeys.cpp
@@ -179,6 +179,7 @@ auto InputManager::createHotkeys() -> void {
 
 auto InputManager::pollHotkeys() -> void {
   if(Application::modal()) return;
+  if(settingsWindow.focused()) return;
 
   if(settings.input.defocus != "Allow") {
     if (!presentation.focused() && !ruby::video.fullScreen()) return;


### PR DESCRIPTION
I was constantly getting trolled, with hotkeys triggering a ms after I set them up in the Hotkeys menu. This fixes it.