### PR TITLE
gba: refactor bus reads

### DIFF
--- a/ares/gba/apu/io.cpp
+++ b/ares/gba/apu/io.cpp
@@ -142,7 +142,7 @@ auto APU::readIO(n32 address) -> n8 {
 
   }
 
-  return cpu.openBus.get(Byte, address);
+  return cpu.mdr >> (8 * (address & 3));
 }
 
 auto APU::writeIO(n32 address, n8 data) -> void {

--- a/ares/gba/cpu/coprocessor.cpp
+++ b/ares/gba/cpu/coprocessor.cpp
@@ -12,5 +12,5 @@ auto CPU::Coprocessor::debugMCR() -> void {
 }
 
 auto CPU::Coprocessor::debugMRC() -> n32 {
-  return cpu.openBus.get(Word, 0);
+  return cpu.mdr;
 }

--- a/ares/gba/cpu/cpu.hpp
+++ b/ares/gba/cpu/cpu.hpp
@@ -255,13 +255,6 @@ struct CPU : ARM7TDMI, Thread, IO {
     n4 unknown2;
   } memory;
 
-  struct OpenBus {
-    auto get(u32 mode, n32 address) -> n32;
-    auto set(u32 mode, n32 address, n32 word) -> void;
-    n32 data;
-    n32 iwramData;
-  } openBus;
-
   struct {
     auto empty() const { return addr == load; }
     auto full() const { return load - addr == 16; }
@@ -292,6 +285,9 @@ struct CPU : ARM7TDMI, Thread, IO {
     n1  burstActive;
     n32 hcounter;
   } context;
+
+  n32 iwramBus;
+  n32 mdr;
 };
 
 extern CPU cpu;

--- a/ares/gba/cpu/dma.cpp
+++ b/ares/gba/cpu/dma.cpp
@@ -59,7 +59,10 @@ auto CPU::DMAC::Channel::read() -> void {
     if(mode & Word) addr &= ~3;
     if(mode & Half) addr &= ~1;
     latch.data = cpu.getDMA(mode, addr);
-    if(mode & Half) latch.data |= latch.data << 16;
+    if(mode & Half) {
+      latch.data &= 0xffff;
+      latch.data |= latch.data << 16;
+    }
   }
 
   switch(sourceMode) {

--- a/ares/gba/cpu/io.cpp
+++ b/ares/gba/cpu/io.cpp
@@ -245,7 +245,7 @@ auto CPU::readIO(n32 address) -> n8 {
 
   }
 
-  return cpu.openBus.get(Byte, address);
+  return mdr >> (8 * (address & 3));
 }
 
 auto CPU::writeIO(n32 address, n8 data) -> void {

--- a/ares/gba/cpu/memory.cpp
+++ b/ares/gba/cpu/memory.cpp
@@ -1,25 +1,33 @@
 template <bool UseDebugger>
 auto CPU::readIWRAM(u32 mode, n32 address) -> n32 {
-  if constexpr(!UseDebugger) prefetchStep(1);
-  n32 word;
+  if constexpr(UseDebugger) {
+    address &= 0x7ffc;
+    return iwram[address + 0] << 0 | iwram[address + 1] << 8 | iwram[address + 2] << 16 | iwram[address + 3] << 24;
+  }
+  prefetchStep(1);
   if(mode & Word) {
     address &= 0x7ffc;
-    word = iwram[address + 0] << 0 | iwram[address + 1] << 8 | iwram[address + 2] << 16 | iwram[address + 3] << 24;
+    iwramBus = iwram[address + 0] << 0 | iwram[address + 1] << 8 | iwram[address + 2] << 16 | iwram[address + 3] << 24;
   } else if(mode & Half) {
     address &= 0x7ffe;
-    word = iwram[address + 0] << 0 | iwram[address + 1] << 8;
+    n16 half = iwram[address + 0] << 0 | iwram[address + 1] << 8;
+    if(address & 2) {
+      iwramBus.bit(16,31) = half;
+    } else {
+      iwramBus.bit( 0,15) = half;
+    }
   } else {
     address &= 0x7fff;
-    word = iwram[address];
+    iwramBus.byte(address & 3) = iwram[address];
   }
-
-  return word;
+  return iwramBus;
 }
 
 auto CPU::writeIWRAM(u32 mode, n32 address, n32 word) -> void {
   prefetchStep(1);
   if(mode & Word) {
     address &= 0x7ffc;
+    iwramBus = word;
     iwram[address + 0] = word >>  0;
     iwram[address + 1] = word >>  8;
     iwram[address + 2] = word >> 16;
@@ -27,33 +35,31 @@ auto CPU::writeIWRAM(u32 mode, n32 address, n32 word) -> void {
     return;
   } else if(mode & Half) {
     address &= 0x7ffe;
+    if(address & 2) {
+      iwramBus.bit(16,31) = word;
+    } else {
+      iwramBus.bit( 0,15) = word;
+    }
     iwram[address + 0] = word >> 0;
     iwram[address + 1] = word >> 8;
   } else {
     address &= 0x7fff;
+    iwramBus.byte(address & 3) = word;
     iwram[address] = word;
   }
 }
 
 template <bool UseDebugger>
 auto CPU::readEWRAM(u32 mode, n32 address) -> n32 {
-  if(!memory.ewram) return readIWRAM<UseDebugger>(mode, address);
-  if(mode & Word) return readEWRAM<UseDebugger>(Half, address &~ 2) << 0 | readEWRAM<UseDebugger>(Half, address | 2) << 16;
+  if(mode & Word) return (n16)readEWRAM<UseDebugger>(Half, address & ~2) << 0 | (n16)readEWRAM<UseDebugger>(Half, address | 2) << 16;
 
   if constexpr(!UseDebugger) prefetchStep(16 - memory.ewramWait);
-  n16 half;
   address &= 0x3ffff;
-  if(mode & Half) {
-    half = ewram[address & ~1] << 0 | ewram[address | 1] << 8;
-  } else {
-    half = ewram[address];
-  }
-
-  return half;
+  n16 half = ewram[address & ~1] << 0 | ewram[address | 1] << 8;
+  return half << 0 | half << 16;
 }
 
 auto CPU::writeEWRAM(u32 mode, n32 address, n32 word) -> void {
-  if(!memory.ewram) return writeIWRAM(mode, address, word);
   if(mode & Word) {
     writeEWRAM(Half, address &~2, word >>  0);
     writeEWRAM(Half, address | 2, word >> 16);
@@ -72,7 +78,7 @@ auto CPU::writeEWRAM(u32 mode, n32 address, n32 word) -> void {
 
 template <bool UseDebugger>
 auto CPU::readPRAM(u32 mode, n32 address) -> n32 {
-  if(mode & Word) return readPRAM<UseDebugger>(Half, address & ~2) << 0 | readPRAM<UseDebugger>(Half, address | 2) << 16;
+  if(mode & Word) return (n16)readPRAM<UseDebugger>(Half, address & ~2) << 0 | (n16)readPRAM<UseDebugger>(Half, address | 2) << 16;
 
   //stall until PPU is no longer accessing PRAM (minimum 1 cycle)
   if constexpr(!UseDebugger) {
@@ -82,7 +88,8 @@ auto CPU::readPRAM(u32 mode, n32 address) -> n32 {
     } while(ppu.pramContention());
   }
 
-  return ppu.readPRAM(mode, address);
+  n16 half = ppu.readPRAM(mode, address);
+  return half << 0 | half << 16;
 }
 
 auto CPU::writePRAM(u32 mode, n32 address, n32 word) -> void {
@@ -103,7 +110,7 @@ auto CPU::writePRAM(u32 mode, n32 address, n32 word) -> void {
 
 template <bool UseDebugger>
 auto CPU::readVRAM(u32 mode, n32 address) -> n32 {
-  if(mode & Word) return readVRAM<UseDebugger>(Half, address & ~2) << 0 | readVRAM<UseDebugger>(Half, address | 2) << 16;
+  if(mode & Word) return (n16)readVRAM<UseDebugger>(Half, address & ~2) << 0 | (n16)readVRAM<UseDebugger>(Half, address | 2) << 16;
 
   //stall until PPU is no longer accessing VRAM (minimum 1 cycle)
   if constexpr(!UseDebugger) {
@@ -113,7 +120,8 @@ auto CPU::readVRAM(u32 mode, n32 address) -> n32 {
     } while(ppu.vramContention(address));
   }
 
-  return ppu.readVRAM(mode, address);
+  n16 half = ppu.readVRAM(mode, address);
+  return half << 0 | half << 16;
 }
 
 auto CPU::writeVRAM(u32 mode, n32 address, n32 word) -> void {
@@ -136,8 +144,8 @@ template<bool UseDebugger>
 auto CPU::readROM(u32 mode, n32 address) -> n32 {
   if(mode & Word) {
     n32 word = 0;
-    word |= readROM<UseDebugger>(Half, address & ~2) <<  0;
-    word |= readROM<UseDebugger>(Half, address |  2) << 16;
+    word |= (n16)readROM<UseDebugger>(Half, address & ~2) <<  0;
+    word |= (n16)readROM<UseDebugger>(Half, address |  2) << 16;
     return word;
   }
 
@@ -147,9 +155,7 @@ auto CPU::readROM(u32 mode, n32 address) -> n32 {
   }
   n16 half = cartridge.readRom<UseDebugger>(address);
   if constexpr(!UseDebugger) context.burstActive = true;
-
-  if(mode & Byte) return half.byte(address & 1);
-  return half;
+  return half << 0 | half << 16;
 }
 
 auto CPU::writeROM(u32 mode, n32 address, n32 word) -> void {

--- a/ares/gba/cpu/serialization.cpp
+++ b/ares/gba/cpu/serialization.cpp
@@ -107,9 +107,6 @@ auto CPU::serialize(serializer& s) -> void {
   s(memory.ewramWait);
   s(memory.unknown2);
 
-  s(openBus.data);
-  s(openBus.iwramData);
-
   for(auto& slot : prefetch.slot) s(slot);
   s(prefetch.addr);
   s(prefetch.load);
@@ -126,4 +123,7 @@ auto CPU::serialize(serializer& s) -> void {
   s(context.busLocked);
   s(context.burstActive);
   s(context.hcounter);
+
+  s(iwramBus);
+  s(mdr);
 }

--- a/ares/gba/display/io.cpp
+++ b/ares/gba/display/io.cpp
@@ -20,7 +20,7 @@ auto Display::readIO(n32 address) -> n8 {
 
   }
 
-  return cpu.openBus.get(Byte, address);
+  return cpu.mdr >> (8 * (address & 3));
 }
 
 auto Display::writeIO(n32 address, n8 data) -> void {

--- a/ares/gba/memory/memory.hpp
+++ b/ares/gba/memory/memory.hpp
@@ -6,8 +6,6 @@ struct IO {
 };
 
 struct Bus {
-  static auto mirror(n32 address, n32 size) -> n32;
-
   auto power() -> void;
 
   IO* io[0x400] = {nullptr};

--- a/ares/gba/ppu/io.cpp
+++ b/ares/gba/ppu/io.cpp
@@ -84,7 +84,7 @@ auto PPU::readIO(n32 address) -> n8 {
 
   }
 
-  return cpu.openBus.get(Byte, address);
+  return cpu.mdr >> (8 * (address & 3));
 }
 
 auto PPU::writeIO(n32 address, n8 data) -> void {

--- a/ares/gba/system/bios.cpp
+++ b/ares/gba/system/bios.cpp
@@ -16,9 +16,7 @@ auto BIOS::readROM(n25 address) -> n32 {
 
 auto BIOS::read(u32 mode, n25 address) -> n32 {
   //unmapped memory
-  if(address >= 0x0000'4000) {
-    return cpu.openBus.get(mode, address);  //0000'4000-01ff'ffff
-  }
+  if(address >= 0x0000'4000) return cpu.mdr;  //0000'4000-01ff'ffff
 
   //GBA BIOS is read-protected; only the BIOS itself can read its own memory
   //when accessed elsewhere; this should return the last value read by the BIOS program
@@ -27,10 +25,7 @@ auto BIOS::read(u32 mode, n25 address) -> n32 {
   } else {
     if(cpu.processor.r15 > 0x01ff'ffff && cpu.processor.r15 < 0x0200'4000) mdr = readROM(address);
   }
-
-  if(mode & Word) address &= ~3;
-  if(mode & Half) address &= ~1;
-  return mdr >> (8 * (address & 3));
+  return mdr;
 }
 
 auto BIOS::write(u32 mode, n25 address, n32 word) -> void {

--- a/ares/gba/system/serialization.cpp
+++ b/ares/gba/system/serialization.cpp
@@ -1,4 +1,4 @@
-static const string SerializerVersion = "v148.1";
+static const string SerializerVersion = "v148.2";
 
 auto System::serialize(bool synchronize) -> serializer {
   if(synchronize) scheduler.enter(Scheduler::Mode::Synchronize);


### PR DESCRIPTION
On read, all GBA memory regions will now return a 32-bit value, with 8-bit and 16-bit accesses being handled in bus.cpp by right-shifting the 32-bit value. This fixes some open bus edge cases while also simplifying how memory reads are handled.