### PR TITLE
n64: implement eeprom write timing and status flags

### DIFF
--- a/ares/n64/cartridge/cartridge.hpp
+++ b/ares/n64/cartridge/cartridge.hpp
@@ -3,7 +3,6 @@ struct Cartridge {
   VFS::Pak pak;
   Memory::Readable16 rom;
   Memory::Writable16 ram;
-  Memory::Writable16 eeprom;
   struct Flash : Memory::Writable {
     template<u32 Size>
     auto read(u32 address) -> u64 {
@@ -87,6 +86,9 @@ struct Cartridge {
     } memory;
   } debugger;
 
+  Memory::Writable16 eeprom;
+  n1 eepromBusy;
+
   auto title() const -> string { return information.title; }
   auto region() const -> string { return information.region; }
   auto cic() const -> string { return information.cic; }
@@ -100,6 +102,7 @@ struct Cartridge {
 
   //joybus.cpp
   auto joybusComm(n8 send, n8 recv, n8 input[], n8 output[]) -> n2;
+  auto eepromFinish() -> void;
 
   //serialization.cpp
   auto serialize(serializer&) -> void;

--- a/ares/n64/cartridge/joybus.cpp
+++ b/ares/n64/cartridge/joybus.cpp
@@ -8,7 +8,7 @@ auto Cartridge::joybusComm(n8 send, n8 recv, n8 input[], n8 output[]) -> n2 {
     if(cartridge.eeprom.size == 512) {
       output[0] = 0x00;
       output[1] = 0x80;
-      output[2] = 0x00;
+      output[2] = eepromBusy ? 0x80 : 0x00;
       valid = 1;
     }
 
@@ -16,7 +16,7 @@ auto Cartridge::joybusComm(n8 send, n8 recv, n8 input[], n8 output[]) -> n2 {
     if(cartridge.eeprom.size == 2048) {
       output[0] = 0x00;
       output[1] = 0xc0;
-      output[2] = 0x00;
+      output[2] = eepromBusy ? 0x80 : 0x00;
       valid = 1;
     }
   }
@@ -25,19 +25,23 @@ auto Cartridge::joybusComm(n8 send, n8 recv, n8 input[], n8 output[]) -> n2 {
   if(input[0] == 0x04 && send >= 2) {
     u32 address = input[1] * 8;
     for(u32 index : range(recv)) {
-      output[index] = cartridge.eeprom.read<Byte>(address++);
+      output[index] = !eepromBusy ? cartridge.eeprom.read<Byte>(address++) : 0xff;
     }
     valid = 1;
   }
 
   //write EEPROM
   if(input[0] == 0x05 && send >= 2 && recv >= 1) {
-    u32 address = input[1] * 8;
-    for(u32 index : range(send - 2)) {
-      cartridge.eeprom.write<Byte>(address++, input[2 + index]);
-    }
-    output[0] = 0x00;
+    output[0] = eepromBusy ? 0x80 : 0x00;
     valid = 1;
+    if(!eepromBusy) {
+      u32 address = input[1] * 8;
+      for(u32 index : range(send - 2)) {
+        cartridge.eeprom.write<Byte>(address++, input[2 + index]);
+      }
+      eepromBusy = 1;
+      queue.insert(Queue::EEPROM_Write, 187'500 * 25); //25ms
+    }
   }
 
   //RTC status
@@ -72,4 +76,8 @@ auto Cartridge::joybusComm(n8 send, n8 recv, n8 input[], n8 output[]) -> n2 {
   status.bit(0) = valid;
   status.bit(1) = over;
   return status;
+}
+
+auto Cartridge::eepromFinish() -> void {
+  eepromBusy = 0;
 }

--- a/ares/n64/cartridge/serialization.cpp
+++ b/ares/n64/cartridge/serialization.cpp
@@ -1,6 +1,7 @@
 auto Cartridge::serialize(serializer& s) -> void {
   s(ram);
   s(eeprom);
+  s(eepromBusy);
   s(flash);
   s(rtc);
 }

--- a/ares/n64/cpu/cpu.cpp
+++ b/ares/n64/cpu/cpu.cpp
@@ -74,6 +74,7 @@ auto CPU::synchronize() -> void {
     case Queue::SI_DMA_Write:  return si.dmaWrite();
     case Queue::SI_BUS_Write:  return si.writeFinished();
     case Queue::RTC_Tick:      return cartridge.rtc.tick();
+    case Queue::EEPROM_Write:  return cartridge.eepromFinish();
     case Queue::DD_Clock_Tick:  return dd.rtc.tickClock();
     case Queue::DD_MECHA_Response:  return dd.mechaResponse();
     case Queue::DD_BM_Request:  return dd.bmRequest();

--- a/ares/n64/n64.hpp
+++ b/ares/n64/n64.hpp
@@ -83,6 +83,7 @@ namespace ares::Nintendo64 {
       SI_DMA_Write,
       SI_BUS_Write,
       RTC_Tick,
+      EEPROM_Write,
       DD_Clock_Tick,
       DD_MECHA_Response,
       DD_BM_Request,

--- a/ares/n64/system/serialization.cpp
+++ b/ares/n64/system/serialization.cpp
@@ -1,4 +1,4 @@
-static const string SerializerVersion = "v146";
+static const string SerializerVersion = "v147";
 
 auto System::serialize(bool synchronize) -> serializer {
   serializer s;


### PR DESCRIPTION
Currently Ares implements an infinitely fast EEPROM, but alas real EEPROMs can take even 20 ms to save a single block of 8 bytes.

This commit implement approximate timings and the related flag to notify the CPU that the EEPROM is busy writing data.