### PR TITLE
Remove OpenGL macOS Video Driver

### DIFF
--- a/ruby/cmake/os-macos.cmake
+++ b/ruby/cmake/os-macos.cmake
@@ -7,7 +7,7 @@ endif()
 
 target_sources(
   ruby
-  PRIVATE video/cgl.cpp video/metal/metal.cpp video/metal/metal.hpp video/metal/Shaders.metal video/metal/ShaderTypes.h
+  PRIVATE video/metal/metal.cpp video/metal/metal.hpp video/metal/Shaders.metal video/metal/ShaderTypes.h
 )
 
 # todo address
@@ -35,7 +35,6 @@ target_link_libraries(
     "$<LINK_LIBRARY:FRAMEWORK,IOKit.framework>"
     "$<LINK_LIBRARY:FRAMEWORK,QuartzCore.framework>"
     "$<LINK_LIBRARY:FRAMEWORK,OpenAL.framework>"
-    "$<LINK_LIBRARY:FRAMEWORK,OpenGL.framework>"
     "$<LINK_LIBRARY:WEAK_FRAMEWORK,Metal.framework>"
     "$<LINK_LIBRARY:WEAK_FRAMEWORK,MetalKit.framework>"
 )
@@ -52,7 +51,6 @@ if(librashader_FOUND)
   )
 endif()
 
-target_enable_feature(ruby "OpenGL video driver" VIDEO_CGL)
 target_enable_feature(ruby "Metal video driver" VIDEO_METAL)
 target_enable_feature(ruby "OpenAL audio driver" AUDIO_OPENAL)
 if(SDL_FOUND)
@@ -60,10 +58,9 @@ if(SDL_FOUND)
   target_enable_feature(ruby "SDL audio driver" AUDIO_SDL)
 endif()
 if(librashader_FOUND AND ARES_ENABLE_LIBRASHADER)
-  target_enable_feature(ruby "librashader OpenGL runtime" LIBRA_RUNTIME_OPENGL)
   target_enable_feature(ruby "librashader Metal runtime" LIBRA_RUNTIME_METAL)
 else()
-  target_compile_definitions(ruby PRIVATE LIBRA_RUNTIME_OPENGL LIBRA_RUNTIME_METAL)
+  target_compile_definitions(ruby PRIVATE LIBRA_RUNTIME_METAL)
 endif()
 target_enable_feature(ruby "Quartz input driver" INPUT_QUARTZ)
 

--- a/ruby/video/video.cpp
+++ b/ruby/video/video.cpp
@@ -1,16 +1,3 @@
-#if defined(VIDEO_CGL)
-  #if defined(__APPLE__)
-    #pragma clang diagnostic push
-    #pragma clang diagnostic ignored "-Wdeprecated-declarations"
-  #endif
-
-  #include <ruby/video/cgl.cpp>
-
-  #if defined(__APPLE__)
-    #pragma clang diagnostic pop
-  #endif
-#endif
-
 #if defined(VIDEO_DIRECT3D9)
   #include <ruby/video/direct3d9.cpp>
 #endif
@@ -184,10 +171,6 @@ auto Video::create(string driver) -> bool {
   self.instance.reset();
   if(!driver) driver = optimalDriver();
 
-  #if defined(VIDEO_CGL)
-  if(driver == "OpenGL 3.2") self.instance = std::make_unique<VideoCGL>(*this);
-  #endif
-
   #if defined(VIDEO_DIRECT3D9)
   if(driver == "Direct3D 9.0") self.instance = std::make_unique<VideoDirect3D9>(*this);
   #endif
@@ -221,10 +204,6 @@ auto Video::hasDrivers() -> std::vector<string> {
   "Direct3D 9.0",
   #endif
 
-  #if defined(VIDEO_CGL)
-  "OpenGL 3.2",
-  #endif
-
   #if defined(VIDEO_GLX)
   "OpenGL 3.2",
   #endif
@@ -245,8 +224,6 @@ auto Video::optimalDriver() -> string {
   return "OpenGL 3.2";
   #elif defined(VIDEO_DIRECT3D9)
   return "Direct3D 9.0";
-  #elif defined(VIDEO_CGL)
-  return "OpenGL 3.2";
   #else
   return "None";
   #endif
@@ -258,8 +235,6 @@ auto Video::safestDriver() -> string {
   #elif defined(VIDEO_DIRECT3D9)
   return "Direct3D 9.0";
   #elif defined(VIDEO_WGL)
-  return "OpenGL 3.2";
-  #elif defined(VIDEO_CGL)
   return "OpenGL 3.2";
   #elif defined(VIDEO_GLX)
   return "OpenGL 3.2";


### PR DESCRIPTION
OpenGL has issues on macOS and has long been deprecated by Apple. This removes OpenGL as a video driver option. macOS users should be using the Metal driver.

This issue can be closed as a result: https://github.com/ares-emulator/ares/issues/2333