### PR TITLE
ruby: enable SDL_HINT_NO_SIGNAL_HANDLERS to avoid ctrl+C hijacks

### DIFF
--- a/ruby/input/sdl.cpp
+++ b/ruby/input/sdl.cpp
@@ -22,6 +22,7 @@ struct InputSDL : InputDriver {
   ~InputSDL() { terminate(); }
 
   auto create() -> bool override {
+    SDL_SetHint(SDL_HINT_NO_SIGNAL_HANDLERS, "1");
     return initialize();
   }
 


### PR DESCRIPTION
As of SDL 3.2.0, "SDL will install a SIGINT and SIGTERM handler, and when it catches a signal, convert it into an SDL_EVENT_QUIT event." by default, thus preventing Ctrl+C from terminating an ares process after it intercepts `SIGINT` if using the SDL input driver.
Enabling `SDL_HINT_NO_SIGNAL_HANDLERS` disables this behavior.