### PR TITLE
CI: Update FreeBSD runner to 15.0

### DIFF
--- a/.github/workflows/build-aux.yml
+++ b/.github/workflows/build-aux.yml
@@ -105,12 +105,12 @@ jobs:
         TARGET_PRESET: ${{ matrix.platform.target-cmake-preset }}
     - name: "Build: FreeBSD"
       if: matrix.platform.name == 'freebsd'
-      uses: cross-platform-actions/action@e8a7b572196ff79ded1979dc2bb9ee67d1ddb252
+      uses: cross-platform-actions/action@492b0c80085400348c599edace11141a4ee73524
       env:
         TARGET_PRESET: ${{ matrix.platform.target-cmake-preset }}
       with:
         operating_system: freebsd
-        version: 14.3
+        version: '15.0'
         environment_variables: TARGET_PRESET
         run: |
           sudo pkg install -y cmake pkgconf ccache ninja gtk3 libX11 libXext libXrandr libXrender libglvnd alsa-lib libao libudev-devd librashader openal-soft pulseaudio sdl3 vulkan-loader


### PR DESCRIPTION
Update `cross-platform-actions` to `v0.32.0` by using the explicit commit https://github.com/cross-platform-actions/action/commit/492b0c80085400348c599edace11141a4ee73524

The change from `14.3` to a string literal `'15.0'` is mandatory, otherwise the FreeBSD VM image cannot be fetched.