### PR TITLE
ruby(audio): enable SDL_HINT_NO_SIGNAL_HANDLERS to avoid ctrl+C hijacks

### DIFF
--- a/ruby/audio/sdl.cpp
+++ b/ruby/audio/sdl.cpp
@@ -6,6 +6,7 @@ struct AudioSDL : AudioDriver {
   ~AudioSDL() { terminate(); }
 
   auto create() -> bool override {
+    SDL_SetHint(SDL_HINT_NO_SIGNAL_HANDLERS, "1");
     super.setChannels(2);
     super.setFrequency(48000);
     super.setLatency(20);


### PR DESCRIPTION
This completes https://github.com/ares-emulator/ares/pull/2445, if SDL is used as an audio driver, the SIGINT/SIGTERM are still hijacked.