### PR TITLE
desktop-ui(cli): more settings parity between CLI and GUI

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ Usage: ./ares [options] game(s)
   --dump-settings        Print the current settings and exit
   --list-settings        Print all configurable setting keys and exit
   --list-setting-values  Print valid values for each setting key and exit
+  --list-sys-aliases     Print valid system aliases and exit
   --no-file-prompt       Do not prompt to load (optional) additional roms (eg: 64DD)
   --settings-file path   Specify a settings file override (settings.bml)
   --save-state slot      Specify a save state slot to load (1-9)

--- a/README.md
+++ b/README.md
@@ -46,7 +46,9 @@ Usage: ./ares [options] game(s)
   --system system        Specify the system name
   --shader shader        Specify a slang shader to load (requires OpenGL or Metal)
   --setting name=value   Specify a value for a setting
-  --dump-all-settings    Show a list of all existing settings and exit
+  --dump-settings        Print the current settings and exit
+  --list-settings        Print all configurable setting keys and exit
+  --list-setting-values  Print valid values for each setting key and exit
   --no-file-prompt       Do not prompt to load (optional) additional roms (eg: 64DD)
   --settings-file path   Specify a settings file override (settings.bml)
   --save-state slot      Specify a save state slot to load (1-9)

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Usage: ./ares [options] game(s)
   --fullscreen           Start in full screen mode
   --pseudofullscreen     Start in pseudo full screen mode
   --kiosk                Start in minimal UI mode (implies --no-file-prompt)
-  --system system        Specify the system name
+  --system system        Specify the system name (supports aliases, eg: fc, n64 etc.)
   --shader shader        Specify a slang shader to load (requires OpenGL or Metal)
   --setting name=value   Specify a value for a setting
   --dump-settings        Print the current settings and exit

--- a/desktop-ui/desktop-ui.cpp
+++ b/desktop-ui/desktop-ui.cpp
@@ -1,4 +1,5 @@
 #include "desktop-ui.hpp"
+#include <map>
 
 namespace ruby {
   Video video;
@@ -108,10 +109,82 @@ auto nall::main(Arguments arguments) -> void {
     }
   }
 
+  if(arguments.take("--dump-settings")) {
+    auto settingsFile = BML::unserialize(string::read(settings.filePath), " ");
+    std::function<void(const Markup::Node&, string)> dump;
+    dump = [&](const Markup::Node& node, string prefix) -> void {
+      for(const auto& setting : node) {
+        string path = prefix ? string{prefix, "/", setting.name()} : setting.name();
+        if(setting.size() == 0) {
+          string value = string{setting.string()}.strip();
+          //empty mappings like ";;" represent unset bindings and should be omitted
+          string mappingProbe = string{value}.replace(";", "").strip();
+          if(value && mappingProbe) print(path, "=", value, "\n");
+        }
+        dump(setting, path);
+      }
+    };
+    dump(settingsFile, {});
+    return;
+  }
+
   inputManager.create();
   Emulator::construct();
 
   settings.load();
+
+  //normalize for the setting key. "LaserActive (NEC PAC)" => "LaserActiveNECPAC"
+  auto settingKey = [](string text) -> string {
+    return string{text}.replace(" ", "").replace("(", "").replace(")", "").replace("/", "").replace("\\", "");
+  };
+
+  std::vector<string> portSettings;
+  std::vector<string> peripheralSettings;
+  for(auto& emulator : emulators) {
+    string core = settingKey(emulator->name);
+    for(auto& port : emulator->ports) {
+      if(port.devices.size() <= 1) continue;
+      portSettings.push_back({"Ports/", core, "/", settingKey(port.name)});
+    }
+
+    if(core == "Nintendo64" || core == "Nintendo64DD") {
+      for(auto& port : emulator->ports) {
+        string portKey = settingKey(port.name);
+        if(!portKey.beginsWith("ControllerPort")) continue;
+        peripheralSettings.push_back({"Peripherals/", core, "/", portKey});
+      }
+    }
+  }
+
+  //for settings that don't persist in settings.bml because they are dynamically generated
+  //based on the loaded core
+  auto isDynamicSetting = [&](const string& path) -> bool {
+    if(std::ranges::find(portSettings, path) != portSettings.end()) return true;
+    if(std::ranges::find(peripheralSettings, path) != peripheralSettings.end()) return true;
+    return false;
+  };
+
+  auto enumerateDumpableSettings = [&]() -> std::vector<string> {
+    std::vector<string> dumpableSettings;
+    std::function<void(const Markup::Node&, string)> dump;
+    dump = [&](const Markup::Node& node, string prefix) -> void {
+      for(const auto& setting : node) {
+        string path = prefix ? string{prefix, "/", setting.name()} : setting.name();
+        bool isLeaf = setting.size() == 0;
+        if(isLeaf) {
+          auto parts = nall::split(path, "/");
+          if(!parts.empty() && parts[0] != "Ports" && parts[0] != "Peripherals") {
+            dumpableSettings.push_back(path);
+          }
+        }
+        dump(setting, path);
+      }
+    };
+    dump(settings, {});
+    for(auto& path : portSettings) dumpableSettings.push_back(path);
+    for(auto& path : peripheralSettings) dumpableSettings.push_back(path);
+    return dumpableSettings;
+  };
 
   if(arguments.find("--setting")) {
     string settingValue;
@@ -121,6 +194,8 @@ auto nall::main(Arguments arguments) -> void {
         auto node = settings[kv[0]];
         if(node) {
           node.setValue(kv[1]);
+        } else if(isDynamicSetting(kv[0])) {
+          settings(kv[0]).setValue(kv[1]);
         } else {
           print("Invalid setting: ", settingValue, "\n");
           return;
@@ -149,7 +224,9 @@ auto nall::main(Arguments arguments) -> void {
     print("  --system name         Specify the system name\n");
     print("  --shader name         Specify the name of the shader to use\n");
     print("  --setting name=value  Specify a value for a setting\n");
-    print("  --dump-all-settings   Show a list of all existing settings and exit\n");
+    print("  --dump-settings       Print the current settings and exit\n");
+    print("  --list-settings       Print all configurable setting keys and exit\n");
+    print("  --list-setting-values Print valid values for each setting key and exit\n");
     print("  --no-file-prompt      Do not prompt to load (optional) additional roms (eg: 64DD)\n");
     print("  --settings-file path  Specify a settings file override (settings.bml)\n");
     print("  --save-state slot     Specify a save state slot to load (1-9)\n");
@@ -168,15 +245,92 @@ auto nall::main(Arguments arguments) -> void {
     return;
   }
 
-  if(arguments.take("--dump-all-settings")) {
-    std::function<void(const Markup::Node&, string)> dump;
-    dump = [&](const Markup::Node& node, string prefix) -> void {
-      for(const auto& setting : node) {
-        print(prefix, setting.name(), "\n");
-        dump(setting, string(prefix, setting.name(), "/"));
+  if(arguments.take("--list-settings")) {
+    for(const auto& path : enumerateDumpableSettings()) {
+      print(path, "\n");
+    }
+    return;
+  }
+
+  if(arguments.take("--list-setting-values")) {
+    auto joinChoices = [](const std::vector<string>& values) -> string {
+      string output;
+      for(size_t index = 0; index < values.size(); ++index) {
+        if(index) output.append("|");
+        output.append(values[index]);
       }
+      return output;
     };
-    dump(settings, "");
+
+    std::map<string, std::vector<string>> choiceMap;
+    auto appendChoice = [&](const string& path, const string& value) -> void {
+      auto& choices = choiceMap[path];
+      if(std::ranges::find(choices, value) == choices.end()) choices.push_back(value);
+    };
+    auto appendChoices = [&](const string& path, const std::vector<string>& values) -> void {
+      for(const auto& value : values) appendChoice(path, value);
+    };
+
+    appendChoices("Video/Driver", ruby::video.hasDrivers());
+    appendChoice("Video/Monitor", "Primary");
+    if(settings.video.monitor && settings.video.monitor != "Primary") appendChoice("Video/Monitor", settings.video.monitor);
+    appendChoices("Video/Format", ruby::video.hasFormats());
+    appendChoices("Audio/Driver", ruby::audio.hasDrivers());
+    appendChoices("Audio/Device", ruby::audio.hasDevices());
+    for(auto frequency : ruby::audio.hasFrequencies()) appendChoice("Audio/Frequency", frequency);
+    for(auto latency : ruby::audio.hasLatencies()) appendChoice("Audio/Latency", latency);
+    appendChoices("Input/Driver", ruby::input.hasDrivers());
+    appendChoices("Input/Defocus", {"Pause", "Block", "Allow"});
+    appendChoices("Video/Quality", {"SD", "HD", "UHD"});
+    appendChoices("Video/Output", {"Scale", "Integer", "Stretch"});
+    appendChoices("Video/AspectCorrectionMode", {"None", "Standard", "Anamorphic"});
+    appendChoices("Boot/Prefer", {
+      "NTSC-U,NTSC-J,PAL",
+      "NTSC-U,PAL,NTSC-J",
+      "NTSC-J,NTSC-U,PAL",
+      "NTSC-J,PAL,NTSC-U",
+      "PAL,NTSC-U,NTSC-J",
+      "PAL,NTSC-J,NTSC-U"
+    });
+    appendChoices("Nintendo64/ControllerPakBankString", {
+      "32KiB (Default)",
+      "128KiB (Datel 1Meg)",
+      "512KiB (Datel 4Meg)",
+      "1984KiB (Maximum)"
+    });
+
+    for(auto& emulator : emulators) {
+      string core = settingKey(emulator->name);
+      for(auto& port : emulator->ports) {
+        if(port.devices.size() <= 1) continue;
+        string path = {"Ports/", core, "/", settingKey(port.name)};
+        for(auto& device : port.devices) appendChoice(path, device.name);
+      }
+
+      if(core == "Nintendo64" || core == "Nintendo64DD") {
+        for(auto& port : emulator->ports) {
+          string portKey = settingKey(port.name);
+          if(!portKey.beginsWith("ControllerPort")) continue;
+          string path = {"Peripherals/", core, "/", portKey};
+          appendChoices(path, {"Rumble Pak", "Controller Pak", "Transfer Pak", "Bio Sensor", "None"});
+        }
+      }
+    }
+
+    for(const auto& path : enumerateDumpableSettings()) {
+      std::vector<string> choices;
+      if(choiceMap.contains(path)) {
+        choices = choiceMap[path];
+      } else {
+        auto value = settings[path].string();
+        if(value == "true" || value == "false") {
+          choices = {"true", "false"};
+        } else {
+          choices = {"<value>"};
+        }
+      }
+      print(path, "=", joinChoices(choices), "\n");
+    }
     return;
   }
 

--- a/desktop-ui/desktop-ui.cpp
+++ b/desktop-ui/desktop-ui.cpp
@@ -131,6 +131,65 @@ auto nall::main(Arguments arguments) -> void {
   inputManager.create();
   Emulator::construct();
 
+  auto resolveSystemName = [&](const string& name) -> string {
+    auto alias = string{name}.downcase();
+
+    static const std::map<string, string> aliases = {
+      {"a2600", "Atari 2600"},
+      {"aes", "Neo Geo AES"},
+      {"arc", "Arcade"},
+      {"cv", "ColecoVision"},
+      {"fc", "Famicom"},
+      {"fds", "Famicom Disk System"},
+      {"gb", "Game Boy"},
+      {"gba", "Game Boy Advance"},
+      {"gbc", "Game Boy Color"},
+      {"gcv", "ColecoVision"},
+      {"gg", "Game Gear"},
+      {"gen", "Mega Drive"},
+      {"genesis", "Mega Drive"},
+      {"m32x", "Mega 32X"},
+      {"mcd", "Mega CD"},
+      {"md", "Mega Drive"},
+      {"ms", "Master System"},
+      {"mvs", "Neo Geo MVS"},
+      {"nes", "Famicom"},
+      {"ngaes", "Neo Geo AES"},
+      {"ngmvs", "Neo Geo MVS"},
+      {"ngp", "Neo Geo Pocket"},
+      {"ngpc", "Neo Geo Pocket Color"},
+      {"n64", "Nintendo 64"},
+      {"n64dd", "Nintendo 64DD"},
+      {"pce", "PC Engine"},
+      {"pcecd", "PC Engine CD"},
+      {"pcv2", "Pocket Challenge V2"},
+      {"ps", "PlayStation"},
+      {"ps1", "PlayStation"},
+      {"psx", "PlayStation"},
+      {"sc3000", "SC-3000"},
+      {"sfc", "Super Famicom"},
+      {"sg", "SG-1000"},
+      {"sg1000", "SG-1000"},
+      {"sms", "Master System"},
+      {"snes", "Super Famicom"},
+      {"sufami", "Super Famicom"},
+      {"ws", "WonderSwan"},
+      {"wsc", "WonderSwan Color"},
+      {"zx", "ZX Spectrum"},
+      {"zx128", "ZX Spectrum 128"},
+    };
+
+    if(auto match = aliases.find(alias); match != aliases.end()) {
+      return match->second;
+    }
+
+    return name;
+  };
+
+  if(program.startSystem) {
+    program.startSystem = resolveSystemName(program.startSystem);
+  }
+
   settings.load();
 
   //normalize for the setting key. "LaserActive (NEC PAC)" => "LaserActiveNECPAC"
@@ -221,7 +280,7 @@ auto nall::main(Arguments arguments) -> void {
     print("  --fullscreen          Start in full screen mode\n");
     print("  --pseudofullscreen    Start in psuedo full screen mode\n");
     print("  --kiosk               Start in minimal UI mode (implies --no-file-prompt)\n");
-    print("  --system name         Specify the system name\n");
+    print("  --system name         Specify the system name (supports aliases, eg: fc, n64 etc.)\n");
     print("  --shader name         Specify the name of the shader to use\n");
     print("  --setting name=value  Specify a value for a setting\n");
     print("  --dump-settings       Print the current settings and exit\n");

--- a/desktop-ui/desktop-ui.cpp
+++ b/desktop-ui/desktop-ui.cpp
@@ -131,56 +131,52 @@ auto nall::main(Arguments arguments) -> void {
   inputManager.create();
   Emulator::construct();
 
+  static const std::vector<std::pair<string, std::vector<string>>> systemAliases = {
+    {"Arcade", {"arc"}},
+    {"Atari 2600", {"a2600"}},
+    {"ColecoVision", {"cv"}},
+    {"Famicom", {"fc", "nes"}},
+    {"Famicom Disk System", {"fds"}},
+    {"Game Boy", {"dmg", "gb"}},
+    {"Game Boy Advance", {"agb", "gba"}},
+    {"Game Boy Color", {"cgb", "gbc"}},
+    {"Game Gear", {"gg"}},
+    {"LaserActive (NEC PAC)", {"lnec", "pacn1", "pacn10"}},
+    {"LaserActive (SEGA PAC)", {"lsega", "pacs1", "pacs10"}},
+    {"MSX", {"msx"}},
+    {"MSX2", {"msx2"}},
+    {"Master System", {"ms", "sms"}},
+    {"Mega 32X", {"32x"}},
+    {"Mega CD", {"mcd"}},
+    {"Mega CD 32X", {"mcd32x"}},
+    {"Mega Drive", {"gen", "genesis", "md", "sg"}},
+    {"MyVision", {"mv"}},
+    {"Neo Geo AES", {"aes", "ngaes"}},
+    {"Neo Geo MVS", {"mvs", "ngmvs"}},
+    {"Neo Geo Pocket", {"ngp"}},
+    {"Neo Geo Pocket Color", {"ngpc"}},
+    {"Nintendo 64", {"n64"}},
+    {"Nintendo 64DD", {"n64dd"}},
+    {"PC Engine", {"pce"}},
+    {"PC Engine CD", {"pcecd"}},
+    {"PlayStation", {"ps", "ps1", "psx"}},
+    {"Pocket Challenge V2", {"pcv2"}},
+    {"SC-3000", {"sc3000"}},
+    {"SG-1000", {"sg1000"}},
+    {"Saturn", {"sat", "ss"}},
+    {"Super Famicom", {"sfc", "snes"}},
+    {"SuperGrafx", {"sgx"}},
+    {"SuperGrafx CD", {"sgxcd"}},
+    {"WonderSwan", {"ws"}},
+    {"WonderSwan Color", {"wsc"}},
+    {"ZX Spectrum", {"zx"}},
+    {"ZX Spectrum 128", {"zx128"}},
+  };
+
   auto resolveSystemName = [&](const string& name) -> string {
     auto alias = string{name}.downcase();
-
-    static const std::map<string, string> aliases = {
-      {"a2600", "Atari 2600"},
-      {"aes", "Neo Geo AES"},
-      {"arc", "Arcade"},
-      {"cv", "ColecoVision"},
-      {"fc", "Famicom"},
-      {"fds", "Famicom Disk System"},
-      {"gb", "Game Boy"},
-      {"gba", "Game Boy Advance"},
-      {"gbc", "Game Boy Color"},
-      {"gcv", "ColecoVision"},
-      {"gg", "Game Gear"},
-      {"gen", "Mega Drive"},
-      {"genesis", "Mega Drive"},
-      {"m32x", "Mega 32X"},
-      {"mcd", "Mega CD"},
-      {"md", "Mega Drive"},
-      {"ms", "Master System"},
-      {"mvs", "Neo Geo MVS"},
-      {"nes", "Famicom"},
-      {"ngaes", "Neo Geo AES"},
-      {"ngmvs", "Neo Geo MVS"},
-      {"ngp", "Neo Geo Pocket"},
-      {"ngpc", "Neo Geo Pocket Color"},
-      {"n64", "Nintendo 64"},
-      {"n64dd", "Nintendo 64DD"},
-      {"pce", "PC Engine"},
-      {"pcecd", "PC Engine CD"},
-      {"pcv2", "Pocket Challenge V2"},
-      {"ps", "PlayStation"},
-      {"ps1", "PlayStation"},
-      {"psx", "PlayStation"},
-      {"sc3000", "SC-3000"},
-      {"sfc", "Super Famicom"},
-      {"sg", "SG-1000"},
-      {"sg1000", "SG-1000"},
-      {"sms", "Master System"},
-      {"snes", "Super Famicom"},
-      {"sufami", "Super Famicom"},
-      {"ws", "WonderSwan"},
-      {"wsc", "WonderSwan Color"},
-      {"zx", "ZX Spectrum"},
-      {"zx128", "ZX Spectrum 128"},
-    };
-
-    if(auto match = aliases.find(alias); match != aliases.end()) {
-      return match->second;
+    for(const auto& [system, aliases] : systemAliases) {
+      if(std::ranges::find(aliases, alias) != aliases.end()) return system;
     }
 
     return name;
@@ -286,6 +282,7 @@ auto nall::main(Arguments arguments) -> void {
     print("  --dump-settings       Print the current settings and exit\n");
     print("  --list-settings       Print all configurable setting keys and exit\n");
     print("  --list-setting-values Print valid values for each setting key and exit\n");
+    print("  --list-sys-aliases    Print valid system aliases and exit\n");
     print("  --no-file-prompt      Do not prompt to load (optional) additional roms (eg: 64DD)\n");
     print("  --settings-file path  Specify a settings file override (settings.bml)\n");
     print("  --save-state slot     Specify a save state slot to load (1-9)\n");
@@ -307,6 +304,18 @@ auto nall::main(Arguments arguments) -> void {
   if(arguments.take("--list-settings")) {
     for(const auto& path : enumerateDumpableSettings()) {
       print(path, "\n");
+    }
+    return;
+  }
+
+  if(arguments.take("--list-sys-aliases")) {
+    for(const auto& [system, aliases] : systemAliases) {
+      print(system, ": ");
+      for(u32 index : range(aliases.size())) {
+        if(index) print(", ");
+        print(aliases[index]);
+      }
+      print("\n");
     }
     return;
   }

--- a/desktop-ui/emulator/emulator.cpp
+++ b/desktop-ui/emulator/emulator.cpp
@@ -4,6 +4,11 @@
 std::vector<std::shared_ptr<Emulator>> emulators;
 std::shared_ptr<Emulator> emulator;
 
+//normalize for the setting key. "LaserActive (NEC PAC)" => "LaserActiveNECPAC"
+static auto settingKey(string text) -> string {
+  return string{text}.replace(" ", "").replace("(", "").replace(")", "").replace("/", "").replace("\\", "");
+}
+
 auto Emulator::enumeratePorts(string name) -> std::vector<InputPort>& {
   for(auto& emulator : emulators) {
     if(emulator->name == name && !emulator->ports.empty()) return emulator->ports;
@@ -131,6 +136,9 @@ auto Emulator::load(const string& location) -> bool {
   if(result != successful) {
     return false;
   }
+
+  applyPortSettings();
+
   setBoolean("Color Emulation", settings.video.colorEmulation);
   setBoolean("Deep Black Boost", settings.video.deepBlackBoost);
   setBoolean("Interframe Blending", settings.video.interframeBlending);
@@ -140,6 +148,91 @@ auto Emulator::load(const string& location) -> bool {
   latch = {};
   root->power();
   return true;
+}
+
+auto Emulator::applyPortSettings() -> void {
+  auto core = settingKey(name);
+  auto resolveSupported = [&](const std::vector<string>& supported, string value) -> string {
+    value = value.strip();
+    if(!value) return {};
+    auto normalizedValue = settingKey(value);
+    for(auto& option : supported) {
+      if(option == value) return option;
+    }
+    for(auto& option : supported) {
+      auto normalizedOption = settingKey(option);
+      if(normalizedOption.imatch(normalizedValue)) return option;
+    }
+    return {};
+  };
+
+  for(auto port : ares::Node::enumerate<ares::Node::Port>(root)) {
+    if(!port->hotSwappable()) continue;
+    if(port->type() != "Controller" && port->type() != "Expansion") continue;
+
+    auto portKey = settingKey(port->name());
+    auto path = string{"Ports/", core, "/", portKey};
+
+    string device;
+    if(auto node = settings[path]) device = string{node.string()}.strip();
+    if(!device) continue;
+
+    auto supportedDevices = port->supported();
+    device = resolveSupported(supportedDevices, device);
+    bool supported = !!device;
+    bool blacklisted = std::ranges::find(inputBlacklist, device) != inputBlacklist.end();
+    if(!supported || blacklisted) continue;
+
+    port->disconnect();
+    if(port->allocate(device)) port->connect();
+  }
+
+  // apply Nintendo 64 controller pak/peripheral settings
+  if(core == "Nintendo64" || core == "Nintendo64DD") {
+    for(auto port : ares::Node::enumerate<ares::Node::Port>(root)) {
+      if(port->type() != "Controller") continue;
+
+      auto controller = port->connected();
+      if(!controller || controller->name() != "Gamepad") continue;
+
+      auto pakPort = controller->find<ares::Node::Port>("Pak");
+      if(!pakPort || !pakPort->hotSwappable()) continue;
+
+      auto peripheralKey = settingKey(port->name());
+      auto peripheralPath = string{"Peripherals/", core, "/", peripheralKey};
+
+      string peripheral;
+      if(auto node = settings[peripheralPath]) peripheral = string{node.string()}.strip();
+      if(!peripheral) continue;
+
+      if(settingKey(peripheral).imatch("None")) {
+        pakPort->disconnect();
+        continue;
+      }
+
+      auto supportedPeripherals = pakPort->supported();
+      peripheral = resolveSupported(supportedPeripherals, peripheral);
+      if(!peripheral) continue;
+
+      if(peripheral == "Controller Pak") {
+        if(auto n64 = dynamic_cast<Nintendo64*>(this)) {
+          n64->gamepad = mia::Pak::create("Nintendo 64");
+          n64->gamepad->pak->append("save.pak", 32_KiB);
+
+          string pakExt = ".pak";
+          auto portName = string{port->name()};
+          if(portName.size()) {
+            string portNum = portName[portName.size() - 1];
+            if(portNum != "1") pakExt = string{".", portNum, ".pak"};
+          }
+          if(n64->game) n64->gamepad->load("save.pak", pakExt, n64->game->location);
+        }
+      }
+
+      pakPort->disconnect();
+      if(pakPort->allocate(peripheral)) pakPort->connect();
+    }
+  }
 }
 
 auto Emulator::load(std::shared_ptr<mia::Pak> pak, string& path) -> string {

--- a/desktop-ui/emulator/emulator.hpp
+++ b/desktop-ui/emulator/emulator.hpp
@@ -13,6 +13,7 @@ struct Emulator {
   auto load(const string& location) -> bool;
   auto load(std::shared_ptr<mia::Pak> pak, string& path) -> string;
   auto loadFirmware(const Firmware&) -> std::shared_ptr<vfs::file>;
+  auto applyPortSettings() -> void;
   virtual auto unload() -> void;
   auto refresh() -> void;
   auto setBoolean(const string& name, bool value) -> bool;

--- a/mia/medium/famicom-disk-system.cpp
+++ b/mia/medium/famicom-disk-system.cpp
@@ -34,19 +34,23 @@ auto FamicomDiskSystem::load(string location) -> LoadResult {
     if(view.size() % 65500 == 16) view = view.subspan(16);  //skip iNES / fwNES header
     u32 index = 0;
 
-    auto output = transform(view);
-    do {
+    while(true) {
+      auto output = transform(view);
+      if(output.empty()) break;
+
       string name;
       name.append("disk", (char)('1' + index / 2), ".");
       name.append("side", (char)('A' + index % 2));
       pak->append(name, output);
+
+      if(view.size() <= 65500) break;
       view = view.subspan(65500);
       index++;
-      output = transform(view);
-    } while (!output.empty());
+    }
   }
 
   if(!pak) return romNotFound;
+  if(!pak->read("disk1.sideA")) return invalidROM;
 
   Pak::load("disk1.sideA", ".d1a");
   Pak::load("disk1.sideB", ".d1b");


### PR DESCRIPTION
Add new CLI options for inspecting and configuring settings currently exclusive in the GUI.

This replaces the old `--dump-all-settings` flag with a clearer split between:
- `--dump-settings` to print the current settings
- `--list-settings` to print all configurable setting keys
- `--list-setting-values` to print valid values for each setting key