### PR TITLE
XAudio2 latency adjustments

### DIFF
--- a/ruby/audio/xaudio2.cpp
+++ b/ruby/audio/xaudio2.cpp
@@ -16,7 +16,7 @@ struct AudioXAudio2 : AudioDriver, public IXAudio2VoiceCallback {
     if(!devices.empty()) super.setDevice(devices.front());
     super.setChannels(2);
     super.setFrequency(48000);
-    super.setLatency(40);
+    super.setLatency(20);
     return initialize();
   }
 
@@ -76,7 +76,7 @@ struct AudioXAudio2 : AudioDriver, public IXAudio2VoiceCallback {
   auto hasBlocking() -> bool override { return true; }
   auto hasDynamic() -> bool override { return true; }
   auto hasFrequencies() -> std::vector<u32> override { return {44100, 48000, 96000}; }
-  auto hasLatencies() -> std::vector<u32> override { return {10, 20, 40, 60, 80, 100}; }
+  auto hasLatencies() -> std::vector<u32> override { return {20, 40, 60, 80}; }
   auto setDevice(string device) -> bool override { return initialize(); }
   auto setBlocking(bool blocking) -> bool override { return true; }
   auto setFrequency(u32 frequency) -> bool override { return initialize(); }


### PR DESCRIPTION
XAudio2 fails to allow games to run at full speed at 10ms. Reported in Discord and I was able to verify as well. It isn't processor limited as running uncapped goes much higher. The audio driver itself doesn't like it, so I've removed 10ms latency and also removed 100ms as that is fairly high and is unnecessary. Finally the default was changed to 20 as it runs well and should be optimal (same as the SDL audio driver). 

FYI: setting latency to zero for the XAudio2 driver will crash ares. Didn't investigate further as 10 wasn't feasible and it isn't exposed as an option, but could be something like a divide by zero error or some other math not mathing. 