### PR TITLE
fix: focus handling for alt-tabbing when fullscreen'd on Windows and X11

### DIFF
--- a/desktop-ui/input/hotkeys.cpp
+++ b/desktop-ui/input/hotkeys.cpp
@@ -181,7 +181,7 @@ auto InputManager::pollHotkeys() -> void {
   if(Application::modal()) return;
 
   if(settings.input.defocus != "Allow") {
-    if (!presentation.focused() && !ruby::video.fullScreen()) return;
+    if (!presentation.focused()) return;
   }
 
   for(auto& hotkey : hotkeys) {

--- a/desktop-ui/program/platform.cpp
+++ b/desktop-ui/program/platform.cpp
@@ -169,8 +169,8 @@ auto Program::audio(ares::Node::Audio::Stream node) -> void {
 }
 
 auto Program::input(ares::Node::Input::Input node) -> void {
-  if(settings.input.defocus != "Allow") {
-    if(!ruby::video.fullScreen() && !presentation.focused()) {
+  if(!driverSettings.inputDefocusAllow.checked()) {
+    if(!presentation.focused()) {
       //treat the input as not being active
       if(auto button = node->cast<ares::Node::Input::Button>()) button->setValue(0);
       if(auto axis = node->cast<ares::Node::Input::Axis>()) axis->setValue(0);

--- a/desktop-ui/program/platform.cpp
+++ b/desktop-ui/program/platform.cpp
@@ -169,7 +169,7 @@ auto Program::audio(ares::Node::Audio::Stream node) -> void {
 }
 
 auto Program::input(ares::Node::Input::Input node) -> void {
-  if(!driverSettings.inputDefocusAllow.checked()) {
+  if(settings.input.defocus != "Allow") {
     if(!presentation.focused()) {
       //treat the input as not being active
       if(auto button = node->cast<ares::Node::Input::Button>()) button->setValue(0);

--- a/desktop-ui/program/program.cpp
+++ b/desktop-ui/program/program.cpp
@@ -83,7 +83,7 @@ auto Program::emulatorRunLoop(uintptr_t) -> void {
       continue;
     }
 
-    bool defocused = driverSettings.inputDefocusPause.checked() && !presentation.focused();
+    bool defocused = settings.input.defocus == "Pause" && !presentation.focused();
 
     if(!emulator || (paused && !program.requestFrameAdvance) || defocused) {
       ruby::audio.clear();

--- a/desktop-ui/program/program.cpp
+++ b/desktop-ui/program/program.cpp
@@ -83,7 +83,7 @@ auto Program::emulatorRunLoop(uintptr_t) -> void {
       continue;
     }
 
-    bool defocused = settings.input.defocus == "Pause" && !ruby::video.fullScreen() && !presentation.focused();
+    bool defocused = driverSettings.inputDefocusPause.checked() && !presentation.focused();
 
     if(!emulator || (paused && !program.requestFrameAdvance) || defocused) {
       ruby::audio.clear();

--- a/ruby/input/keyboard/xlib.cpp
+++ b/ruby/input/keyboard/xlib.cpp
@@ -7,6 +7,11 @@ struct InputKeyboardXlib {
   std::shared_ptr<HID::Keyboard> hid = std::make_shared<HID::Keyboard>();
 
   Display* display = nullptr;
+  // Focus gate: only process key state when the active X11 window belongs to this PID.
+  Window rootWindow = 0;
+  Atom netActiveWindow = 0;
+  Atom netWmPid = 0;
+  u32 selfPid = 0;
 
   struct Key {
     string name;
@@ -14,6 +19,16 @@ struct InputKeyboardXlib {
     u32 keycode = 0;
   };
   std::vector<Key> keys;
+
+  // Return _NET_WM_PID for an X11 window (0 if missing/invalid).
+  auto getNetWmPid(Window window) -> u32 {
+    Atom actualType; int actualFormat; unsigned long nItems, bytesAfter; unsigned char* propValue = nullptr; u32 pid = 0;
+    if(XGetWindowProperty(display, window, netWmPid, 0, 1, False, XA_CARDINAL, &actualType, &actualFormat, &nItems, &bytesAfter, &propValue) == Success && propValue) {
+      pid = *(u32*)propValue;
+      XFree(propValue);
+    }
+    return pid;
+  }
 
   auto assign(u32 inputID, bool value) -> void {
     auto& group = hid->buttons();
@@ -23,6 +38,20 @@ struct InputKeyboardXlib {
   }
 
   auto poll(std::vector<std::shared_ptr<HID::Device>>& devices) -> void {
+    Atom actualType; int actualFormat; unsigned long nItems, bytesAfter; unsigned char* propValue = nullptr; Window activeWindow = None;
+      // XQueryKeymap reports global key state; ignore it unless the active window belongs to this PID.
+      if(XGetWindowProperty(display, rootWindow, netActiveWindow, 0, 1, False, XA_WINDOW, &actualType, &actualFormat, &nItems, &bytesAfter, &propValue) == Success && propValue) {
+      activeWindow = *(Window*)propValue;
+      XFree(propValue);
+    }
+
+    bool processInput = false;
+    if(activeWindow == None) processInput = false;
+    else if(getNetWmPid(activeWindow) == selfPid) processInput = true;
+
+    // Not focused: keep device enumerated, but don't update state.
+    if(!processInput) return devices.push_back(hid);
+
     char state[32];
     XQueryKeymap(display, state);
 
@@ -37,6 +66,11 @@ struct InputKeyboardXlib {
 
   auto initialize() -> bool {
     display = XOpenDisplay(0);
+    rootWindow = DefaultRootWindow(display);
+    // Cache atoms + PID for focus gating
+    netActiveWindow = XInternAtom(display, "_NET_ACTIVE_WINDOW", False);
+    netWmPid = XInternAtom(display, "_NET_WM_PID", False);
+    selfPid = (u32)getpid();
 
     keys.push_back({"Escape", XK_Escape});
 

--- a/ruby/input/mouse/xlib.cpp
+++ b/ruby/input/mouse/xlib.cpp
@@ -13,6 +13,10 @@ struct InputMouseXlib {
   Cursor invisibleCursor = 0;
   u32 screenWidth = 0;
   u32 screenHeight = 0;
+  // Focus gate: drop pointer grab when the active X11 window is not ours
+  Atom netActiveWindow = 0;
+  Atom netWmPid = 0;
+  u32 selfPid = 0;
 
   struct Mouse {
     bool acquired = false;
@@ -26,6 +30,16 @@ struct InputMouseXlib {
 
   auto acquired() -> bool {
     return ms.acquired;
+  }
+
+  // Return _NET_WM_PID for an X11 window (0 if missing/invalid)
+  auto getNetWmPid(Window window) -> u32 {
+    Atom actualType; int actualFormat; unsigned long nItems, bytesAfter; unsigned char* propValue = nullptr; u32 pid = 0;
+    if(XGetWindowProperty(display, window, netWmPid, 0, 1, False, XA_CARDINAL, &actualType, &actualFormat, &nItems, &bytesAfter, &propValue) == Success && propValue) {
+      pid = *(u32*)propValue;
+      XFree(propValue);
+    }
+    return pid;
   }
 
   auto acquire() -> bool {
@@ -65,6 +79,25 @@ struct InputMouseXlib {
   }
 
   auto poll(std::vector<std::shared_ptr<HID::Device>>& devices) -> void {
+    // If the mouse is grabbed (relative mode), only keep the grab while this window
+    // (or another window owned by this process) is the active/focused window.
+    // Prevents stuck mouse capture after alt-tabbing out of fullscreen
+    if(acquired()) {
+      Atom actualType; int actualFormat; unsigned long nItems, bytesAfter; unsigned char* propValue = nullptr; Window activeWindow = None;
+      if(XGetWindowProperty(display, rootWindow, netActiveWindow, 0, 1, False, XA_WINDOW, &actualType, &actualFormat, &nItems, &bytesAfter, &propValue) == Success && propValue) {
+        activeWindow = *(Window*)propValue;
+        XFree(propValue);
+      }
+
+      // keep grab if our GLX child window is active, or if the active window belongs to our PID.
+      bool processInput = false;
+      if(activeWindow == handle) processInput = true;
+      else if(activeWindow != None && getNetWmPid(activeWindow) == selfPid) processInput = true;
+
+      // focus left ares' process: drop the grab so the user regains the cursor
+      if(!processInput && activeWindow != None) release();
+    }
+
     Window rootReturn;
     Window childReturn;
     s32 rootXReturn = 0;
@@ -124,6 +157,9 @@ struct InputMouseXlib {
     this->handle = handle;
     display = XOpenDisplay(0);
     rootWindow = DefaultRootWindow(display);
+    netActiveWindow = XInternAtom(display, "_NET_ACTIVE_WINDOW", False);
+    netWmPid = XInternAtom(display, "_NET_WM_PID", False);
+    selfPid = (u32)getpid();
 
     XWindowAttributes attributes;
     XGetWindowAttributes(display, rootWindow, &attributes);

--- a/ruby/video/direct3d9.cpp
+++ b/ruby/video/direct3d9.cpp
@@ -256,9 +256,9 @@ private:
     }
 
     if(self.fullScreen) {
-      _context = _window = CreateWindowEx(WS_EX_TOPMOST, L"VideoDirect3D9_Window", L"", WS_VISIBLE | WS_POPUP,
+      _context = _window = CreateWindowEx(WS_EX_NOACTIVATE, L"VideoDirect3D9_Window", L"", WS_VISIBLE | WS_POPUP | WS_DISABLED,
         _monitorX, _monitorY, _monitorWidth, _monitorHeight,
-        nullptr, nullptr, GetModuleHandle(0), nullptr);
+        (HWND)self.context, nullptr, GetModuleHandle(0), nullptr);
     } else {
       _context = (HWND)self.context;
     }

--- a/ruby/video/glx.cpp
+++ b/ruby/video/glx.cpp
@@ -233,6 +233,12 @@ private:
       CWBorderPixel | CWColormap | CWOverrideRedirect, &attributes);
     XSelectInput(_display, _window, ExposureMask);
     XSetWindowBackground(_display, _window, 0);
+    // Set _NET_WM_PID on the GLX window so input backends can attribute focus to this process.
+    {
+      auto pid = (uint32_t)getpid();
+      Atom netWmPid = XInternAtom(_display, "_NET_WM_PID", False);
+      XChangeProperty(_display, _window, netWmPid, XA_CARDINAL, 32, PropModeReplace, (unsigned char*)&pid, 1);
+    }
     XMapWindow(_display, _window);
     XFlush(_display);
 

--- a/ruby/video/wgl.cpp
+++ b/ruby/video/wgl.cpp
@@ -159,9 +159,9 @@ private:
     _monitorHeight = monitor.height;
 
     if(self.fullScreen) {
-      _context = _window = CreateWindowEx(WS_EX_TOPMOST, L"VideoOpenGL32_Window", L"", WS_VISIBLE | WS_POPUP,
+      _context = _window = CreateWindowEx(WS_EX_NOACTIVATE, L"VideoOpenGL32_Window", L"", WS_VISIBLE | WS_POPUP | WS_DISABLED,
         _monitorX, _monitorY, _monitorWidth, _monitorHeight,
-        nullptr, nullptr, GetModuleHandle(0), nullptr);
+        (HWND)self.context, nullptr, GetModuleHandle(0), nullptr);
     } else {
       _context = (HWND)self.context;
     }


### PR DESCRIPTION
Combines Linux & Windows fixes for focus lost when alt-tabbing on fullscreen:

#1426
```
Using WS_EX_TOPMOST on a fullscreen window prevents Alt+Tab from switching to any different window. This is a bit of an annoyance as it ruins the point of Alt+Tab, especially in the case of a non-exclusive mode being set. It however is very very bad in any case ares hangs, and thus prevents being able to switch to Task Manager to actually kill ares. This means the average user could potentially run into a situation requiring them sign out or shutdown their PC, and thus potentially lose data in other apps.

It also happens to be the case that if the user attempts to Alt+Tab while in exclusive fullscreen, ares will hang for whatever reason. This commit doesn't fix that hang, but it does at least allow the user to Alt+Tab out of the situation.

Note that the windows are being set with WS_DISABLED more to avoid what I believe is a Windows bug. Normally WS_EX_NOACTIVATE should prevent clicking on the window from actually activating the window. However, if you were to Alt+Tab to some other window, then have that other window being shunk so ares ends up shown, you can proceed to click on the ares window, and it will actually activate that window. This thus takes focus away from ares' presentation window with generally no way to give it focus (assuming inputs get blocked). WS_DISABLED prevents mouse input from working on the fullscreen window (which it normally doesn't do anything due to WS_EX_NOACTIVATE, only in the weird case I laid out does it do something)

Also this commit likely breaks macOS/Linux (haven't tested / can't test those), probably need to check for focus differently depending on platform defines?
```

#2434
```
Prevent keyboard state updates and mouse pointer grab from remaining active when the focused X11 window does not belong to this process.

- Keyboard: ignore XQueryKeymap results unless the active _NET_ACTIVE_WINDOW resolves to our PID.
- Mouse: automatically release pointer grab when focus leaves our window/process to avoid stuck cursor after alt-tab.
- GLX: explicitly set _NET_WM_PID on the GLX child window so focus attribution works reliably.

This ensures input is only processed while ares owns focus and avoids global key state leakage or cursor capture issues under X11 and Xwayland. The fix does not impact the Drivers->Input setting "When focus is lost" behavior; controller will still be able to trigger keys if set as "Allow input".

This commit replaces the whole workaround I previously attempted with https://github.com/ares-emulator/ares/pull/2431, to let the X server handling the windows as usual, instead of messing around with the desktop-ui/ logic.
```