### PR TITLE
desktop-ui: scaffold prefs system

### DIFF
--- a/desktop-ui/desktop-ui.cpp
+++ b/desktop-ui/desktop-ui.cpp
@@ -190,6 +190,11 @@ auto nall::main(Arguments arguments) -> void {
     }
   }
 
+  if(settings.prefs.implicitKiosk && !program.kiosk && !program.startGameLoad.empty()) {
+    program.kiosk = true;
+    program.noFilePrompt = true;
+  }
+
   if(program.kiosk) {
     if(!invalidKioskPaths.empty()) {
       program.error({"path does not exist: ", invalidKioskPaths.front()});

--- a/desktop-ui/input/input.cpp
+++ b/desktop-ui/input/input.cpp
@@ -525,6 +525,19 @@ auto InputManager::poll(bool force) -> void {
 
 auto InputManager::eventInput(std::shared_ptr<HID::Device> device, u32 groupID, u32 inputID, s16 oldValue, s16 newValue) -> void {
   lock_guard<recursive_mutex> inputLock(program.inputMutex);
+
+  if(settings.prefs.doubleClickFullScreen && ruby::video.fullScreen() && device->isMouse() && groupID == HID::Mouse::GroupID::Button && inputID == 0) {
+    if(oldValue == 0 && newValue != 0) {
+      auto current = chrono::millisecond();
+      if(current - presentation.lastViewportLeftClick <= 500) {
+        program.pendingVideoFullScreenToggle = true;
+        presentation.lastViewportLeftClick = 0;
+      } else {
+        presentation.lastViewportLeftClick = current;
+      }
+    }
+  }
+
   inputSettings.eventInput(device, groupID, inputID, oldValue, newValue);
   hotkeySettings.eventInput(device, groupID, inputID, oldValue, newValue);
 }

--- a/desktop-ui/presentation/presentation.cpp
+++ b/desktop-ui/presentation/presentation.cpp
@@ -170,6 +170,9 @@ Presentation::Presentation() {
   optionSettingsAction.setText("Options" ELLIPSIS).setIcon(Icon::Action::Settings).onActivate([&] {
     settingsWindow.show("Options");
   });
+  preferenceSettingsAction.setText("Preferences" ELLIPSIS).setIcon(Icon::Place::Settings).onActivate([&] {
+    settingsWindow.show("Preferences");
+  });
   firmwareSettingsAction.setText("Firmware" ELLIPSIS).setIcon(Icon::Emblem::Binary).onActivate([&] {
     settingsWindow.show("Firmware");
   });
@@ -395,7 +398,7 @@ auto Presentation::loadEmulators() -> void {
 
   //clean up the recent games history first
   std::vector<string> recentGames;
-  for(u32 index : range(9)) {
+  for(u32 index : range(Settings::Prefs::maxRecentGames)) {
     auto entry = settings.recent.game[index];
     auto parts = nall::split(entry, ";", 1L);
     parts.resize(2);
@@ -411,7 +414,9 @@ auto Presentation::loadEmulators() -> void {
 
   //build recent games list
   u32 count = 0;
+  auto recentGamesLimit = max(1u, min(Settings::Prefs::maxRecentGames, settings.prefs.recentGamesLimit));
   for(auto& game : recentGames) {
+    if(count >= recentGamesLimit) break;
     settings.recent.game[count++] = game;
   }
   { Menu recentGames{&loadMenu};
@@ -458,7 +463,7 @@ auto Presentation::loadEmulators() -> void {
       clearHistory.setText("Clear Menu");
       #endif
       clearHistory.onActivate([&] {
-        for(u32 index : range(9)) settings.recent.game[index] = {};
+        for(u32 index : range(Settings::Prefs::maxRecentGames)) settings.recent.game[index] = {};
         loadEmulators();
       });
     } else {

--- a/desktop-ui/presentation/presentation.cpp
+++ b/desktop-ui/presentation/presentation.cpp
@@ -21,6 +21,17 @@ Presentation::Presentation() {
         program.load(emulator, filename);
       }
     });
+    viewport.onMousePress([&](auto button) {
+      if(button != Mouse::Button::Left || !settings.prefs.doubleClickFullScreen) return;
+      auto current = chrono::millisecond();
+      if(current - lastViewportLeftClick <= 500) {
+        if(ruby::video.hasFullScreen()) program.videoFullScreenToggle();
+        else program.videoPseudoFullScreenToggle();
+        lastViewportLeftClick = 0;
+      } else {
+        lastViewportLeftClick = current;
+      }
+    });
 
     onClose([&] {
       program.quit();
@@ -322,26 +333,67 @@ Presentation::Presentation() {
 
   statusLeft .setAlignment(0.0).setFont(Font().setBold());
   statusRight.setAlignment(1.0).setFont(Font().setBold());
+  viewport.onMousePress([&](auto button) {
+    if(button != Mouse::Button::Left || !settings.prefs.doubleClickFullScreen) return;
+    auto current = chrono::millisecond();
+    if(current - lastViewportLeftClick <= 500) {
+      if(ruby::video.hasFullScreen()) program.videoFullScreenToggle();
+      else program.videoPseudoFullScreenToggle();
+      lastViewportLeftClick = 0;
+    } else {
+      lastViewportLeftClick = current;
+    }
+  });
 
   onClose([&] {
+    saveWindowState();
     program.quit();
   });
+  onMove([&] { saveWindowState(); });
+  onSize([&] { saveWindowState(); });
 
   loadEmulators();
 
-  resizeWindow();
+  if(settings.prefs.restoreWindowState && settings.prefs.window.width > 0 && settings.prefs.window.height > 0) {
+    setGeometry({
+      settings.prefs.window.x,
+      settings.prefs.window.y,
+      settings.prefs.window.width,
+      settings.prefs.window.height
+    });
+    if(settings.prefs.window.maximized) {
+      setMaximized(true);
+    }
+  } else {
+    resizeWindow();
+  }
   setTitle({ares::Name, " ", ares::Version});
   setAssociatedFile();
   setBackgroundColor({0, 0, 0});
-  setAlignment(Alignment::Center);
+  if(!settings.prefs.restoreWindowState || settings.prefs.window.width <= 0 || settings.prefs.window.height <= 0) {
+    setAlignment(Alignment::Center);
+  }
   setVisible();
 
   #if defined(PLATFORM_MACOS)
   Application::Cocoa::onAbout([&] { aboutAction.doActivate(); });
   Application::Cocoa::onActivate([&] { setFocused(); });
-  Application::Cocoa::onPreferences([&] { settingsWindow.show("Video"); });
+  Application::Cocoa::onPreferences([&] { settingsWindow.show("Preferences"); });
   Application::Cocoa::onQuit([&] { doClose(); });
   #endif
+}
+
+auto Presentation::saveWindowState() -> void {
+  if(program.kiosk) return;
+
+  settings.prefs.window.maximized = maximized();
+  if(maximized()) return;
+
+  auto geometry = this->geometry();
+  settings.prefs.window.x = geometry.x();
+  settings.prefs.window.y = geometry.y();
+  settings.prefs.window.width = geometry.width();
+  settings.prefs.window.height = geometry.height();
 }
 
 auto Presentation::resizeWindow() -> void {
@@ -473,11 +525,11 @@ auto Presentation::loadEmulators() -> void {
   loadMenu.append(MenuSeparator());
 
   //build emulator load list
-  u32 enabled = 0;
+  u32 shown = 0;
 
   //first pass; make sure "Arcade" is start of list
   for(auto& emulator : emulators) {
-    if(!emulator->configuration.visible) continue;
+    if(!settings.prefs.showDisabledEmulators && !emulator->configuration.visible) continue;
     if(emulator->group() == "Arcade") {
       Menu menu;
       menu.setIcon(Icon::Emblem::Folder);
@@ -488,12 +540,11 @@ auto Presentation::loadEmulators() -> void {
   }
 
   for(auto& emulator : emulators) {
-    if (!emulator->configuration.visible) continue;
-    enabled++;
+    if(!settings.prefs.showDisabledEmulators && !emulator->configuration.visible) continue;
+    shown++;
     MenuItem item;
     item.setIcon(Icon::Place::Server);
     item.setText({emulator->name, ELLIPSIS});
-    item.setVisible(emulator->configuration.visible);
     item.onActivate([=] {
       program.load(emulator);
     });
@@ -514,7 +565,7 @@ auto Presentation::loadEmulators() -> void {
     }
     menu.append(item);
   }
-  if(enabled == 0) {
+  if(shown == 0) {
     //if the user disables every system, give an indication for how to re-add systems to the load menu
     MenuItem item{&loadMenu};
     item.setIcon(Icon::Action::Add);

--- a/desktop-ui/presentation/presentation.hpp
+++ b/desktop-ui/presentation/presentation.hpp
@@ -57,6 +57,7 @@ struct Presentation : Window {
       MenuItem hotkeySettingsAction{&settingsMenu};
       MenuItem emulatorSettingsAction{&settingsMenu};
       MenuItem optionSettingsAction{&settingsMenu};
+      MenuItem preferenceSettingsAction{&settingsMenu};
       MenuItem firmwareSettingsAction{&settingsMenu};
       MenuItem pathSettingsAction{&settingsMenu};
       MenuItem driverSettingsAction{&settingsMenu};

--- a/desktop-ui/presentation/presentation.hpp
+++ b/desktop-ui/presentation/presentation.hpp
@@ -9,9 +9,11 @@ struct Presentation : Window {
   auto showIcon(bool visible) -> void;
   auto loadShaders() -> void;
   auto refreshSystemMenu() -> void;
+  auto saveWindowState() -> void;
 
   std::vector<string> shaderDirectories;
   static inline bool shaderArgApplied = false;
+  u64 lastViewportLeftClick = 0;
 
   MenuBar menuBar{this};
     Menu loadMenu{&menuBar};

--- a/desktop-ui/program/drivers.cpp
+++ b/desktop-ui/program/drivers.cpp
@@ -77,6 +77,8 @@ auto Program::videoFullScreenToggle() -> void {
   ruby::video.clear();
   if(!ruby::video.fullScreen()) {
     ruby::video.setFullScreen(true);
+    startFullScreen = true;
+    startPseudoFullScreen = false;
     if(!ruby::input.acquired()) {
       if(ruby::video.exclusive() || ruby::video.hasMonitors().size() == 1) {
         ruby::input.acquire();
@@ -87,6 +89,7 @@ auto Program::videoFullScreenToggle() -> void {
       ruby::input.release();
     }
     ruby::video.setFullScreen(false);
+    startFullScreen = false;
     presentation.viewport.setFocused();
   }
 }
@@ -102,6 +105,7 @@ auto Program::videoPseudoFullScreenToggle() -> void {
     if(!ruby::input.acquired() && ruby::video.hasMonitors().size() == 1) {
       ruby::input.acquire();
     }
+    startFullScreen = false;
     startPseudoFullScreen = true;
   } else {
     if(ruby::input.acquired()) {

--- a/desktop-ui/program/load.cpp
+++ b/desktop-ui/program/load.cpp
@@ -111,6 +111,7 @@ auto Program::load(string location) -> bool {
     settings.recent.game[index + 1] = settings.recent.game[index];
   }
   settings.recent.game[0] = {emulator->name, ";", location};
+  settings.prefs.lastGame = settings.recent.game[0];
   presentation.loadEmulators();
 
   configuration = emulator->root->attribute("configuration");

--- a/desktop-ui/program/load.cpp
+++ b/desktop-ui/program/load.cpp
@@ -120,6 +120,12 @@ auto Program::load(string location) -> bool {
     if(stateLoad(program.startSaveStateSlot.integer())) {
       state.slot = program.startSaveStateSlot.integer();
     }
+  } else if(settings.prefs.loadMostRecentState) {
+    if(auto slot = mostRecentStateSlot()) {
+      if(stateLoad(*slot)) {
+        state.slot = *slot;
+      }
+    }
   }
 
   return true;

--- a/desktop-ui/program/load.cpp
+++ b/desktop-ui/program/load.cpp
@@ -107,7 +107,7 @@ auto Program::load(string location) -> bool {
   }
 
   //update recent games list
-  for(s32 index = 7; index >= 0; index--) {
+  for(s32 index = Settings::Prefs::maxRecentGames - 2; index >= 0; index--) {
     settings.recent.game[index + 1] = settings.recent.game[index];
   }
   settings.recent.game[0] = {emulator->name, ";", location};

--- a/desktop-ui/program/program.cpp
+++ b/desktop-ui/program/program.cpp
@@ -13,18 +13,70 @@ thread worker;
 auto Program::create() -> void {
   ares::platform = this;
 
+  auto applyGameStartupWindowPreference = [&] {
+    if(settings.prefs.startGameFullScreen) {
+      startFullScreen = true;
+      startPseudoFullScreen = false;
+      return;
+    }
+
+    if(settings.prefs.startGamePseudoFullScreen) {
+      startFullScreen = false;
+      startPseudoFullScreen = true;
+    }
+  };
+
   videoDriverUpdate();
   audioDriverUpdate();
   inputDriverUpdate();
 
-  if(kiosk) {
-    if(startFullScreen) videoFullScreenToggle();
-    if(startPseudoFullScreen) videoPseudoFullScreenToggle();
-  }
+  auto restoreStartWindowMode = [&] {
+    if(startFullScreen && !ruby::video.fullScreen()) {
+      videoFullScreenToggle();
+    }
+    if(startPseudoFullScreen && !presentation.fullScreen()) {
+      videoPseudoFullScreenToggle();
+    }
+  };
+
+  restoreStartWindowMode();
 
   _isRunning = true;
   worker = thread::create(std::bind_front(&Program::emulatorRunLoop, this));
   program.rewindReset();
+
+  auto resumeLastGame = [&] {
+    if(startSystem || !startGameLoad.empty() || !settings.prefs.resumeLastGame || !settings.prefs.lastGame) {
+      return false;
+    }
+
+    auto parts = nall::split(settings.prefs.lastGame, ";", 1L);
+    parts.resize(2);
+    auto system = parts[0];
+    auto location = parts[1];
+    if(!system || !location || !inode::exists(location)) {
+      return false;
+    }
+
+    for(auto& emulator : emulators) {
+      if(emulator->name != system) continue;
+      if(load(emulator, location)) {
+        if(settings.prefs.resumeLastGamePaused) {
+          pause(true);
+        }
+        applyGameStartupWindowPreference();
+        restoreStartWindowMode();
+        return true;
+      }
+      break;
+    }
+
+    return false;
+  };
+
+  if(resumeLastGame()) {
+    return;
+  }
 
   if(!startGameLoad.empty()) {
     Program::Guard guard;
@@ -34,10 +86,8 @@ auto Program::create() -> void {
       for(auto &emulator: emulators) {
         if(emulator->name == startSystem) {
           if(load(emulator, gameToLoad)) {
-            if(!kiosk) {
-              if(startFullScreen) videoFullScreenToggle();
-              if(startPseudoFullScreen) videoPseudoFullScreenToggle();
-            }
+            applyGameStartupWindowPreference();
+            restoreStartWindowMode();
           }
           return;
         }
@@ -47,10 +97,8 @@ auto Program::create() -> void {
 
     if(auto emulator = identify(gameToLoad)) {
       if(load(emulator, gameToLoad)) {
-        if(!kiosk) {
-          if(startFullScreen) videoFullScreenToggle();
-          if(startPseudoFullScreen) videoPseudoFullScreenToggle();
-        }
+        applyGameStartupWindowPreference();
+        restoreStartWindowMode();
       }
     }
   }
@@ -142,6 +190,10 @@ auto Program::main() -> void {
   inputManager.poll();
   inputManager.pollHotkeys();
 
+  if(pendingVideoFullScreenToggle.exchange(false)) {
+    videoFullScreenToggle();
+  }
+
   updateMessage();
 
   //If Platform::video() changed the screen resolution, resize the presentation window here.
@@ -161,6 +213,7 @@ auto Program::main() -> void {
 }
 
 auto Program::quit() -> void {
+  presentation.saveWindowState();
   Program::Guard guard;
   _quitting = true;
   if(lock.owns_lock()) {

--- a/desktop-ui/program/program.hpp
+++ b/desktop-ui/program/program.hpp
@@ -25,6 +25,7 @@ struct Program : ares::Platform {
   //states.cpp
   auto stateSave(u32 slot) -> bool;
   auto stateLoad(u32 slot) -> bool;
+  auto mostRecentStateSlot() -> maybe<u32>;
   auto undoStateSave() -> bool;
   auto undoStateLoad() -> bool;
   auto clearUndoStates() -> void;

--- a/desktop-ui/program/program.hpp
+++ b/desktop-ui/program/program.hpp
@@ -84,6 +84,7 @@ struct Program : ares::Platform {
   bool requestScreenshot = false;
   bool keyboardCaptured = false;
   atomic<bool> pendingKioskExit = false;
+  std::atomic<bool> pendingVideoFullScreenToggle = false;
 
   struct State {
     u32 slot = 1;

--- a/desktop-ui/program/states.cpp
+++ b/desktop-ui/program/states.cpp
@@ -34,6 +34,14 @@ auto Program::stateLoad(u32 slot) -> bool {
   if(!memory.empty()) {
     serializer state{memory.data(), (u32)memory.size()};
     if(emulator->root->unserialize(state)) {
+      if(emulator->name == "WonderSwan" || emulator->name == "WonderSwan Color") {
+        if(auto orientation = emulator->root->find<ares::Node::Setting::String>("PPU/Screen/Orientation")) {
+          auto value = orientation->value();
+          orientation->setValue(value);
+          orientation->modify(value);
+        }
+      }
+
       showMessage({"Loaded state from slot ", slot});
       return true;
     }

--- a/desktop-ui/program/states.cpp
+++ b/desktop-ui/program/states.cpp
@@ -43,6 +43,27 @@ auto Program::stateLoad(u32 slot) -> bool {
   return false;
 }
 
+auto Program::mostRecentStateSlot() -> maybe<u32> {
+  Program::Guard guard;
+  if(!emulator) return {};
+
+  maybe<u32> newestSlot;
+  u64 newestTimestamp = 0;
+
+  for(u32 slot : range(1, 10)) {
+    auto location = emulator->locate(emulator->game->location, {".bs", slot}, settings.paths.saves);
+    if(!inode::exists(location)) continue;
+
+    auto timestamp = inode::timestamp(location);
+    if(!newestSlot || timestamp > newestTimestamp) {
+      newestSlot = slot;
+      newestTimestamp = timestamp;
+    }
+  }
+
+  return newestSlot;
+}
+
 auto Program::undoStateSave() -> bool {
   Program::Guard guard;
   if(!emulator) return false;

--- a/desktop-ui/settings/importexport.cpp
+++ b/desktop-ui/settings/importexport.cpp
@@ -22,6 +22,7 @@ auto ImportExportSettings::construct() -> void {
       hotkeySettings.construct();
       emulatorSettings.construct();
       optionSettings.construct();
+      preferenceSettings.construct();
       firmwareSettings.construct();
       pathSettings.construct();
       driverSettings.construct();

--- a/desktop-ui/settings/preferences.cpp
+++ b/desktop-ui/settings/preferences.cpp
@@ -16,6 +16,88 @@ auto PreferenceSettings::construct() -> void {
   recentGamesHintLayout.setAlignment(1).setPadding(12_sx, 0);
     recentGamesHint.setText("Maximum stored and shown entries (1-30)").setFont(Font().setSize(7.0)).setForegroundColor(SystemColor::Sublabel);
 
+  startupLabel.setText("Startup").setFont(Font().setBold());
+
+  restoreWindowStateLayout.setAlignment(1).setPadding(12_sx, 0);
+    restoreWindowStateOption.setText("Restore window size and position").setChecked(settings.prefs.restoreWindowState).onToggle([&] {
+      settings.prefs.restoreWindowState = restoreWindowStateOption.checked();
+    });
+    restoreWindowStateHint.setText("Reuse the previous window location and size on startup").setFont(Font().setSize(7.0)).setForegroundColor(SystemColor::Sublabel);
+
+  implicitKioskLayout.setAlignment(1).setPadding(12_sx, 0);
+    implicitKioskOption.setText("Imply --kiosk when opening a game").setChecked(settings.prefs.implicitKiosk).onToggle([&] {
+      if(!implicitKioskOption.checked()) {
+        settings.prefs.implicitKiosk = false;
+        return;
+      }
+
+      auto response = MessageDialog()
+        .setTitle("Warning")
+        .setAlignment(settingsWindow)
+        .setText("Launching ares with a game path will imply --kiosk.\n"
+                 "Kiosk mode has no GUI, so you may have to manually edit ares' configfile to undo this.\n\n"
+                 "Enable this option?")
+        .warning({"Enable", "Cancel"});
+
+      if(response == "Enable") {
+        settings.prefs.implicitKiosk = true;
+      } else {
+        implicitKioskOption.setChecked(false);
+        settings.prefs.implicitKiosk = false;
+      }
+
+      refresh();
+    });
+    implicitKioskHint.setText("Launch with --kiosk automatically when a game path is passed to ares").setFont(Font().setSize(7.0)).setForegroundColor(SystemColor::Sublabel);
+
+  startGameFullScreenLayout.setAlignment(1).setPadding(12_sx, 0);
+    startGameFullScreenOption.setText("Always start games in fullscreen").setChecked(settings.prefs.startGameFullScreen).onToggle([&] {
+      settings.prefs.startGameFullScreen = startGameFullScreenOption.checked();
+      if(settings.prefs.startGameFullScreen) {
+        settings.prefs.startGamePseudoFullScreen = false;
+      }
+      refresh();
+    });
+    startGameFullScreenHint.setText("Apply native fullscreen after launching or reopening a game").setFont(Font().setSize(7.0)).setForegroundColor(SystemColor::Sublabel);
+
+  startGamePseudoFullScreenLayout.setAlignment(1).setPadding(12_sx, 0);
+    startGamePseudoFullScreenOption.setText("Always start games in pseudo-fullscreen").setChecked(settings.prefs.startGamePseudoFullScreen).onToggle([&] {
+      settings.prefs.startGamePseudoFullScreen = startGamePseudoFullScreenOption.checked();
+      if(settings.prefs.startGamePseudoFullScreen) {
+        settings.prefs.startGameFullScreen = false;
+      }
+      refresh();
+    });
+    startGamePseudoFullScreenHint.setText("Apply pseudo-fullscreen after launching or reopening a game").setFont(Font().setSize(7.0)).setForegroundColor(SystemColor::Sublabel);
+
+  resumeLastGameLayout.setAlignment(1).setPadding(12_sx, 0);
+    resumeLastGameOption.setText("Reopen last loaded game on startup").setChecked(settings.prefs.resumeLastGame).onToggle([&] {
+      settings.prefs.resumeLastGame = resumeLastGameOption.checked();
+      updateResumeLastGamePausedState();
+    });
+    resumeLastGameHint.setText("Automatically reload the last opened game when ares starts").setFont(Font().setSize(7.0)).setForegroundColor(SystemColor::Sublabel);
+
+  resumeLastGamePausedLayout.setAlignment(1).setPadding(12_sx, 0);
+    resumeLastGamePausedOption.setText("Start reopened game paused").setChecked(settings.prefs.resumeLastGamePaused).onToggle([&] {
+      settings.prefs.resumeLastGamePaused = resumeLastGamePausedOption.checked();
+    });
+    resumeLastGamePausedHint.setText("Only applies when reopening the last loaded game").setFont(Font().setSize(7.0)).setForegroundColor(SystemColor::Sublabel);
+
+  menuLabel.setText("Menus").setFont(Font().setBold());
+
+  showDisabledEmulatorsLayout.setAlignment(1).setPadding(12_sx, 0);
+    showDisabledEmulatorsOption.setText("Show disabled emulators in Load menu").setChecked(settings.prefs.showDisabledEmulators).onToggle([&] {
+      settings.prefs.showDisabledEmulators = showDisabledEmulatorsOption.checked();
+      presentation.loadEmulators();
+    });
+    showDisabledEmulatorsHint.setText("Keep hidden systems visible in the Load menu").setFont(Font().setSize(7.0)).setForegroundColor(SystemColor::Sublabel);
+
+  doubleClickFullScreenLayout.setAlignment(1).setPadding(12_sx, 0);
+    doubleClickFullScreenOption.setText("Double-click viewport to toggle fullscreen").setChecked(settings.prefs.doubleClickFullScreen).onToggle([&] {
+      settings.prefs.doubleClickFullScreen = doubleClickFullScreenOption.checked();
+    });
+    doubleClickFullScreenHint.setText("Toggle fullscreen by double-clicking on the game image").setFont(Font().setSize(7.0)).setForegroundColor(SystemColor::Sublabel);
+
   refresh();
 }
 
@@ -47,8 +129,27 @@ auto PreferenceSettings::applyRecentGamesLimit(bool normalizeField) -> void {
   }
 }
 
+auto PreferenceSettings::updateResumeLastGamePausedState() -> void {
+  auto enabled = settings.prefs.resumeLastGame;
+  if(!enabled) {
+    settings.prefs.resumeLastGamePaused = false;
+  }
+  resumeLastGamePausedOption.setEnabled(enabled);
+  resumeLastGamePausedHint.setEnabled(enabled);
+  resumeLastGamePausedOption.setChecked(enabled && settings.prefs.resumeLastGamePaused);
+}
+
 auto PreferenceSettings::refresh() -> void {
   auto value = max(1u, min(Settings::Prefs::maxRecentGames, settings.prefs.recentGamesLimit));
   settings.prefs.recentGamesLimit = value;
   recentGamesValue.setText(integer(value));
+  restoreWindowStateOption.setChecked(settings.prefs.restoreWindowState);
+  implicitKioskOption.setChecked(settings.prefs.implicitKiosk);
+  startGameFullScreenOption.setChecked(settings.prefs.startGameFullScreen);
+  startGamePseudoFullScreenOption.setChecked(settings.prefs.startGamePseudoFullScreen);
+  implicitKioskHint.setEnabled(true);
+  resumeLastGameOption.setChecked(settings.prefs.resumeLastGame);
+  showDisabledEmulatorsOption.setChecked(settings.prefs.showDisabledEmulators);
+  doubleClickFullScreenOption.setChecked(settings.prefs.doubleClickFullScreen);
+  updateResumeLastGamePausedState();
 }

--- a/desktop-ui/settings/preferences.cpp
+++ b/desktop-ui/settings/preferences.cpp
@@ -70,6 +70,12 @@ auto PreferenceSettings::construct() -> void {
     });
     startGamePseudoFullScreenHint.setText("Apply pseudo-fullscreen after launching or reopening a game").setFont(Font().setSize(7.0)).setForegroundColor(SystemColor::Sublabel);
 
+  loadMostRecentStateLayout.setAlignment(1).setPadding(12_sx, 0);
+    loadMostRecentStateOption.setText("Load most recent save state on game launch").setChecked(settings.prefs.loadMostRecentState).onToggle([&] {
+      settings.prefs.loadMostRecentState = loadMostRecentStateOption.checked();
+    });
+    loadMostRecentStateHint.setText("When a game opens, restore the newest existing save state slot for that game").setFont(Font().setSize(7.0)).setForegroundColor(SystemColor::Sublabel);
+
   resumeLastGameLayout.setAlignment(1).setPadding(12_sx, 0);
     resumeLastGameOption.setText("Reopen last loaded game on startup").setChecked(settings.prefs.resumeLastGame).onToggle([&] {
       settings.prefs.resumeLastGame = resumeLastGameOption.checked();
@@ -147,6 +153,7 @@ auto PreferenceSettings::refresh() -> void {
   implicitKioskOption.setChecked(settings.prefs.implicitKiosk);
   startGameFullScreenOption.setChecked(settings.prefs.startGameFullScreen);
   startGamePseudoFullScreenOption.setChecked(settings.prefs.startGamePseudoFullScreen);
+  loadMostRecentStateOption.setChecked(settings.prefs.loadMostRecentState);
   implicitKioskHint.setEnabled(true);
   resumeLastGameOption.setChecked(settings.prefs.resumeLastGame);
   showDisabledEmulatorsOption.setChecked(settings.prefs.showDisabledEmulators);

--- a/desktop-ui/settings/preferences.cpp
+++ b/desktop-ui/settings/preferences.cpp
@@ -1,0 +1,54 @@
+auto PreferenceSettings::construct() -> void {
+  setCollapsible();
+  setVisible(false);
+
+  historyLabel.setText("History").setFont(Font().setBold());
+
+  recentGamesLayout.setAlignment(1).setPadding(12_sx, 0);
+    recentGamesLabel.setText("Recent Games");
+    recentGamesValue.setEditable(true);
+    recentGamesValue.onChange([&] {
+      if(!recentGamesValue.text().strip()) return;
+      this->applyRecentGamesLimit(false);
+    }).onActivate([&] {
+      this->applyRecentGamesLimit(true);
+    });
+  recentGamesHintLayout.setAlignment(1).setPadding(12_sx, 0);
+    recentGamesHint.setText("Maximum stored and shown entries (1-30)").setFont(Font().setSize(7.0)).setForegroundColor(SystemColor::Sublabel);
+
+  refresh();
+}
+
+auto PreferenceSettings::readRecentGamesLimit() const -> maybe<u32> {
+  auto text = recentGamesValue.text().strip();
+  if(!text) {
+    return {};
+  }
+
+  for(auto character : text) {
+    if(character < '0' || character > '9') return {};
+  }
+
+  auto value = text.natural();
+  value = max(1u, min(Settings::Prefs::maxRecentGames, value));
+  return value;
+}
+
+auto PreferenceSettings::applyRecentGamesLimit(bool normalizeField) -> void {
+  auto value = readRecentGamesLimit();
+  if(!value) {
+    if(normalizeField) refresh();
+    return;
+  }
+
+  settings.prefs.recentGamesLimit = *value;
+  if(normalizeField) {
+    recentGamesValue.setText(integer(*value));
+  }
+}
+
+auto PreferenceSettings::refresh() -> void {
+  auto value = max(1u, min(Settings::Prefs::maxRecentGames, settings.prefs.recentGamesLimit));
+  settings.prefs.recentGamesLimit = value;
+  recentGamesValue.setText(integer(value));
+}

--- a/desktop-ui/settings/settings.cpp
+++ b/desktop-ui/settings/settings.cpp
@@ -121,6 +121,7 @@ auto Settings::process(bool load) -> void {
   bind(boolean, "Prefs/ImplicitKiosk", prefs.implicitKiosk);
   bind(boolean, "Prefs/StartGameFullScreen", prefs.startGameFullScreen);
   bind(boolean, "Prefs/StartGamePseudoFullScreen", prefs.startGamePseudoFullScreen);
+  bind(boolean, "Prefs/LoadMostRecentState", prefs.loadMostRecentState);
   bind(boolean, "Prefs/ResumeLastGame", prefs.resumeLastGame);
   bind(boolean, "Prefs/ResumeLastGamePaused", prefs.resumeLastGamePaused);
   bind(boolean, "Prefs/DoubleClickFullScreen", prefs.doubleClickFullScreen);

--- a/desktop-ui/settings/settings.cpp
+++ b/desktop-ui/settings/settings.cpp
@@ -116,6 +116,20 @@ auto Settings::process(bool load) -> void {
   bind(natural, "Rewind/Frequency", rewind.frequency);
 
   bind(natural, "Prefs/RecentGamesLimit", prefs.recentGamesLimit);
+  bind(boolean, "Prefs/ShowDisabledEmulators", prefs.showDisabledEmulators);
+  bind(boolean, "Prefs/RestoreWindowState", prefs.restoreWindowState);
+  bind(boolean, "Prefs/ImplicitKiosk", prefs.implicitKiosk);
+  bind(boolean, "Prefs/StartGameFullScreen", prefs.startGameFullScreen);
+  bind(boolean, "Prefs/StartGamePseudoFullScreen", prefs.startGamePseudoFullScreen);
+  bind(boolean, "Prefs/ResumeLastGame", prefs.resumeLastGame);
+  bind(boolean, "Prefs/ResumeLastGamePaused", prefs.resumeLastGamePaused);
+  bind(boolean, "Prefs/DoubleClickFullScreen", prefs.doubleClickFullScreen);
+  bind(string,  "Prefs/LastGame", prefs.lastGame);
+  bind(integer, "Prefs/Window/X", prefs.window.x);
+  bind(integer, "Prefs/Window/Y", prefs.window.y);
+  bind(integer, "Prefs/Window/Width", prefs.window.width);
+  bind(integer, "Prefs/Window/Height", prefs.window.height);
+  bind(boolean, "Prefs/Window/Maximized", prefs.window.maximized);
 
   bind(string,  "Paths/Home", paths.home);
   bind(string,  "Paths/Firmware", paths.firmware);
@@ -139,6 +153,10 @@ auto Settings::process(bool load) -> void {
   bind(boolean, "MegaDrive/TMSS", megadrive.tmss);
 
   prefs.recentGamesLimit = max(1u, min(Prefs::maxRecentGames, prefs.recentGamesLimit));
+  if(!prefs.resumeLastGame) prefs.resumeLastGamePaused = false;
+  prefs.window.width = max(0, prefs.window.width);
+  prefs.window.height = max(0, prefs.window.height);
+  if(prefs.startGameFullScreen) prefs.startGamePseudoFullScreen = false;
 
   for(u32 index : range(Prefs::maxRecentGames)) {
     string name = {"Recent/Game-", 1 + index};

--- a/desktop-ui/settings/settings.cpp
+++ b/desktop-ui/settings/settings.cpp
@@ -6,6 +6,7 @@
 #include "hotkeys.cpp"
 #include "emulators.cpp"
 #include "options.cpp"
+#include "preferences.cpp"
 #include "firmware.cpp"
 #include "paths.cpp"
 #include "drivers.cpp"
@@ -22,6 +23,7 @@ InputSettings& inputSettings = settingsWindow.inputSettings;
 HotkeySettings& hotkeySettings = settingsWindow.hotkeySettings;
 EmulatorSettings& emulatorSettings = settingsWindow.emulatorSettings;
 OptionSettings& optionSettings = settingsWindow.optionSettings;
+PreferenceSettings& preferenceSettings = settingsWindow.preferenceSettings;
 FirmwareSettings& firmwareSettings = settingsWindow.firmwareSettings;
 PathSettings& pathSettings = settingsWindow.pathSettings;
 DebugSettings& debugSettings = settingsWindow.debugSettings;
@@ -113,6 +115,8 @@ auto Settings::process(bool load) -> void {
   bind(natural, "Rewind/Length", rewind.length);
   bind(natural, "Rewind/Frequency", rewind.frequency);
 
+  bind(natural, "Prefs/RecentGamesLimit", prefs.recentGamesLimit);
+
   bind(string,  "Paths/Home", paths.home);
   bind(string,  "Paths/Firmware", paths.firmware);
   bind(string,  "Paths/Saves", paths.saves);
@@ -134,7 +138,9 @@ auto Settings::process(bool load) -> void {
 
   bind(boolean, "MegaDrive/TMSS", megadrive.tmss);
 
-  for(u32 index : range(9)) {
+  prefs.recentGamesLimit = max(1u, min(Prefs::maxRecentGames, prefs.recentGamesLimit));
+
+  for(u32 index : range(Prefs::maxRecentGames)) {
     string name = {"Recent/Game-", 1 + index};
     bind(string, name, recent.game[index]);
   }
@@ -199,6 +205,7 @@ auto Settings::process(bool load) -> void {
 auto SettingsWindow::initialize() -> void {
   onClose([&] {
     settings.save();
+    presentation.loadEmulators();
     setVisible(false);
     //cancel any pending input assignment requests, if any
     inputSettings.setVisible(false);
@@ -213,6 +220,7 @@ auto SettingsWindow::initialize() -> void {
   panelList.append(ListViewItem().setText("Hotkeys").setIcon(Icon::Device::Keyboard));
   panelList.append(ListViewItem().setText("Emulators").setIcon(Icon::Place::Server));
   panelList.append(ListViewItem().setText("Options").setIcon(Icon::Action::Settings));
+  panelList.append(ListViewItem().setText("Preferences").setIcon(Icon::Place::Settings));
   panelList.append(ListViewItem().setText("Firmware").setIcon(Icon::Emblem::Binary));
   panelList.append(ListViewItem().setText("Paths").setIcon(Icon::Emblem::Folder));
   panelList.append(ListViewItem().setText("Drivers").setIcon(Icon::Place::Settings));
@@ -227,6 +235,7 @@ auto SettingsWindow::initialize() -> void {
   panelContainer.append(hotkeySettings, Size{~0, ~0});
   panelContainer.append(emulatorSettings, Size{~0, ~0});
   panelContainer.append(optionSettings, Size{~0, ~0});
+  panelContainer.append(preferenceSettings, Size{~0, ~0});
   panelContainer.append(firmwareSettings, Size{~0, ~0});
   panelContainer.append(pathSettings, Size{~0, ~0});
   panelContainer.append(driverSettings, Size{~0, ~0});
@@ -240,6 +249,7 @@ auto SettingsWindow::initialize() -> void {
   hotkeySettings.construct();
   emulatorSettings.construct();
   optionSettings.construct();
+  preferenceSettings.construct();
   firmwareSettings.construct();
   pathSettings.construct();
   driverSettings.construct();
@@ -280,6 +290,7 @@ auto SettingsWindow::eventChange() -> void {
   hotkeySettings.setVisible(false);
   emulatorSettings.setVisible(false);
   optionSettings.setVisible(false);
+  preferenceSettings.setVisible(false);
   firmwareSettings.setVisible(false);
   pathSettings.setVisible(false);
   driverSettings.setVisible(false);
@@ -295,6 +306,7 @@ auto SettingsWindow::eventChange() -> void {
     if(item.text() == "Hotkeys"  ) found = true, hotkeySettings.setVisible();
     if(item.text() == "Emulators") found = true, emulatorSettings.setVisible();
     if(item.text() == "Options"  ) found = true, optionSettings.setVisible();
+    if(item.text() == "Preferences") found = true, preferenceSettings.refresh(), preferenceSettings.setVisible();
     if(item.text() == "Firmware" ) found = true, firmwareSettings.setVisible();
     if(item.text() == "Paths"    ) found = true, pathSettings.setVisible();
     if(item.text() == "Drivers"  ) found = true, driverSettings.setVisible();

--- a/desktop-ui/settings/settings.hpp
+++ b/desktop-ui/settings/settings.hpp
@@ -90,6 +90,24 @@ struct Settings : Markup::Node {
   struct Prefs {
     static constexpr u32 maxRecentGames = 30;
     u32 recentGamesLimit = 9;
+    bool showDisabledEmulators = false;
+    bool restoreWindowState = false;
+    bool implicitKiosk = false;
+    bool startGameFullScreen = false;
+    bool startGamePseudoFullScreen = false;
+    bool resumeLastGame = false;
+    bool resumeLastGamePaused = false;
+    bool doubleClickFullScreen = false;
+    string lastGame;
+    struct Window {
+      s32 x = 0;
+      s32 y = 0;
+      s32 width = 0;
+      s32 height = 0;
+      bool maximized = false;
+      bool fullScreen = false;
+      bool pseudoFullScreen = false;
+    } window;
   } prefs;
 
   struct Paths {
@@ -307,6 +325,7 @@ struct PreferenceSettings : VerticalLayout {
   auto refresh() -> void;
   auto readRecentGamesLimit() const -> maybe<u32>;
   auto applyRecentGamesLimit(bool normalizeField) -> void;
+  auto updateResumeLastGamePausedState() -> void;
 
   Label historyLabel{this, Size{~0, 0}, 5};
   HorizontalLayout recentGamesLayout{this, Size{~0, 0}, 5};
@@ -316,6 +335,32 @@ struct PreferenceSettings : VerticalLayout {
   HorizontalLayout recentGamesHintLayout{this, Size{~0, 0}, 5};
     Canvas recentGamesHintIndent{&recentGamesHintLayout, Size{12_sx, 0}};
     Label recentGamesHint{&recentGamesHintLayout, Size{~0, layoutVertSize}};
+  Label startupLabel{this, Size{~0, 0}, 5};
+  HorizontalLayout restoreWindowStateLayout{this, Size{~0, 0}, 5};
+    CheckLabel restoreWindowStateOption{&restoreWindowStateLayout, Size{0, 0}, 5};
+    Label restoreWindowStateHint{&restoreWindowStateLayout, Size{~0, layoutVertSize}};
+  HorizontalLayout implicitKioskLayout{this, Size{~0, 0}, 5};
+    CheckLabel implicitKioskOption{&implicitKioskLayout, Size{0, 0}, 5};
+    Label implicitKioskHint{&implicitKioskLayout, Size{~0, layoutVertSize}};
+  HorizontalLayout startGameFullScreenLayout{this, Size{~0, 0}, 5};
+    CheckLabel startGameFullScreenOption{&startGameFullScreenLayout, Size{0, 0}, 5};
+    Label startGameFullScreenHint{&startGameFullScreenLayout, Size{~0, layoutVertSize}};
+  HorizontalLayout startGamePseudoFullScreenLayout{this, Size{~0, 0}, 5};
+    CheckLabel startGamePseudoFullScreenOption{&startGamePseudoFullScreenLayout, Size{0, 0}, 5};
+    Label startGamePseudoFullScreenHint{&startGamePseudoFullScreenLayout, Size{~0, layoutVertSize}};
+  HorizontalLayout resumeLastGameLayout{this, Size{~0, 0}, 5};
+    CheckLabel resumeLastGameOption{&resumeLastGameLayout, Size{0, 0}, 5};
+    Label resumeLastGameHint{&resumeLastGameLayout, Size{~0, layoutVertSize}};
+  HorizontalLayout resumeLastGamePausedLayout{this, Size{~0, 0}, 5};
+    CheckLabel resumeLastGamePausedOption{&resumeLastGamePausedLayout, Size{0, 0}, 5};
+    Label resumeLastGamePausedHint{&resumeLastGamePausedLayout, Size{~0, layoutVertSize}};
+  Label menuLabel{this, Size{~0, 0}, 5};
+  HorizontalLayout showDisabledEmulatorsLayout{this, Size{~0, 0}, 5};
+    CheckLabel showDisabledEmulatorsOption{&showDisabledEmulatorsLayout, Size{0, 0}, 5};
+    Label showDisabledEmulatorsHint{&showDisabledEmulatorsLayout, Size{~0, layoutVertSize}};
+  HorizontalLayout doubleClickFullScreenLayout{this, Size{~0, 0}, 5};
+    CheckLabel doubleClickFullScreenOption{&doubleClickFullScreenLayout, Size{0, 0}, 5};
+    Label doubleClickFullScreenHint{&doubleClickFullScreenLayout, Size{~0, layoutVertSize}};
 };
 
 struct FirmwareSettings : VerticalLayout {

--- a/desktop-ui/settings/settings.hpp
+++ b/desktop-ui/settings/settings.hpp
@@ -87,6 +87,11 @@ struct Settings : Markup::Node {
     u32 frequency = 10;
   } rewind;
 
+  struct Prefs {
+    static constexpr u32 maxRecentGames = 30;
+    u32 recentGamesLimit = 9;
+  } prefs;
+
   struct Paths {
     string home;
     string firmware;
@@ -102,7 +107,7 @@ struct Settings : Markup::Node {
   } paths;
 
   struct Recent {
-    string game[9];
+    string game[Prefs::maxRecentGames];
   } recent;
 
   struct DebugServer {
@@ -297,6 +302,22 @@ struct OptionSettings : VerticalLayout {
       Label megaDriveTmssHint{&megaDriveTmssLayout, Size{0, layoutVertSize}};
 };
 
+struct PreferenceSettings : VerticalLayout {
+  auto construct() -> void;
+  auto refresh() -> void;
+  auto readRecentGamesLimit() const -> maybe<u32>;
+  auto applyRecentGamesLimit(bool normalizeField) -> void;
+
+  Label historyLabel{this, Size{~0, 0}, 5};
+  HorizontalLayout recentGamesLayout{this, Size{~0, 0}, 5};
+    Label recentGamesLabel{&recentGamesLayout, Size{0, layoutVertSize}};
+    LineEdit recentGamesValue{&recentGamesLayout, Size{36_sx, 0}};
+    Canvas recentGamesSpacer{&recentGamesLayout, Size{~0, 0}};
+  HorizontalLayout recentGamesHintLayout{this, Size{~0, 0}, 5};
+    Canvas recentGamesHintIndent{&recentGamesHintLayout, Size{12_sx, 0}};
+    Label recentGamesHint{&recentGamesHintLayout, Size{~0, layoutVertSize}};
+};
+
 struct FirmwareSettings : VerticalLayout {
   auto construct() -> void;
   auto refresh() -> void;
@@ -472,6 +493,7 @@ struct SettingsWindow : Window {
       HotkeySettings hotkeySettings;
       EmulatorSettings emulatorSettings;
       OptionSettings optionSettings;
+      PreferenceSettings preferenceSettings;
       FirmwareSettings firmwareSettings;
       PathSettings pathSettings;
       DriverSettings driverSettings;
@@ -494,6 +516,7 @@ extern InputSettings& inputSettings;
 extern HotkeySettings& hotkeySettings;
 extern EmulatorSettings& emulatorSettings;
 extern OptionSettings& optionSettings;
+extern PreferenceSettings& preferenceSettings;
 extern FirmwareSettings& firmwareSettings;
 extern PathSettings& pathSettings;
 extern DriverSettings& driverSettings;

--- a/desktop-ui/settings/settings.hpp
+++ b/desktop-ui/settings/settings.hpp
@@ -95,6 +95,7 @@ struct Settings : Markup::Node {
     bool implicitKiosk = false;
     bool startGameFullScreen = false;
     bool startGamePseudoFullScreen = false;
+    bool loadMostRecentState = false;
     bool resumeLastGame = false;
     bool resumeLastGamePaused = false;
     bool doubleClickFullScreen = false;
@@ -348,6 +349,9 @@ struct PreferenceSettings : VerticalLayout {
   HorizontalLayout startGamePseudoFullScreenLayout{this, Size{~0, 0}, 5};
     CheckLabel startGamePseudoFullScreenOption{&startGamePseudoFullScreenLayout, Size{0, 0}, 5};
     Label startGamePseudoFullScreenHint{&startGamePseudoFullScreenLayout, Size{~0, layoutVertSize}};
+  HorizontalLayout loadMostRecentStateLayout{this, Size{~0, 0}, 5};
+    CheckLabel loadMostRecentStateOption{&loadMostRecentStateLayout, Size{0, 0}, 5};
+    Label loadMostRecentStateHint{&loadMostRecentStateLayout, Size{~0, layoutVertSize}};
   HorizontalLayout resumeLastGameLayout{this, Size{~0, 0}, 5};
     CheckLabel resumeLastGameOption{&resumeLastGameLayout, Size{0, 0}, 5};
     Label resumeLastGameHint{&resumeLastGameLayout, Size{~0, layoutVertSize}};


### PR DESCRIPTION
Introduce a Preferences panel for configuring global ares behavior not tied to a specific emulator/core.

This commit adds the initial scaffolding for a preferences system, with an option to control how many recent games are stored in settings.bml/displayed in the Recent Games menu.