### PR TITLE
gba: improve handling of background mosaic toggle

### DIFF
--- a/ares/gba/ppu/background.cpp
+++ b/ares/gba/ppu/background.cpp
@@ -13,12 +13,19 @@ auto PPU::Background::scanline(u32 y) -> void {
   mosaicOffset = 0;
   for(auto& pixel : output) pixel = {};
   latch.active = false;
+  if(!io.mosaic || (y % (1 + io.mosaicHeight)) == 0) {
+    vmosaic = y;
+    affine.hmosaic = io.lx;
+    affine.vmosaic = io.ly;
+  }
 }
 
 auto PPU::Background::outputPixel(u32 x, u32 y) -> void {
   //horizontal mosaic
-  if(!io.mosaic || !mosaicOffset) {
+  if(!mosaicOffset) {
     mosaicOffset = 1 + io.mosaicWidth;
+    mosaic = output[x];
+  } else if(!io.mosaic) {
     mosaic = output[x];
   }
   mosaicOffset--;
@@ -49,12 +56,6 @@ auto PPU::Background::run(s32 x, u32 y) -> void {
 
 auto PPU::Background::linearFetchTileMap(s32 x, u32 y) -> void {
   if(ppu.blank() || !io.enable[0]) return;
-
-  if(x == -7) {
-    if(!io.mosaic || (y % (1 + io.mosaicHeight)) == 0) {
-      vmosaic = y;
-    }
-  }
 
   fx = x + io.hoffset;
   fy = vmosaic + io.voffset;
@@ -128,12 +129,8 @@ auto PPU::Background::affineFetchTileMap(u32 x, u32 y) -> void {
   if(ppu.blank() || !io.enable[0]) return;
 
   if(x == 0) {
-    if(!io.mosaic || (y % (1 + io.mosaicHeight)) == 0) {
-      hmosaic = io.lx;
-      vmosaic = io.ly;
-    }
-    fx = hmosaic;
-    fy = vmosaic;
+    fx = affine.hmosaic;
+    fy = affine.vmosaic;
   }
 
   affine.screenSize = 16 << io.screenSize;
@@ -178,12 +175,8 @@ auto PPU::Background::bitmap(u32 x, u32 y) -> void {
   if(ppu.blank() || !io.enable[0]) return;
 
   if(x == 0) {
-    if(!io.mosaic || (y % (1 + io.mosaicHeight)) == 0) {
-      hmosaic = io.lx;
-      vmosaic = io.ly;
-    }
-    fx = hmosaic;
-    fy = vmosaic;
+    fx = affine.hmosaic;
+    fy = affine.vmosaic;
   }
 
   n1  depth = io.mode != 4;  //0 = 8-bit (mode 4); 1 = 15-bit (mode 3, mode 5)
@@ -224,10 +217,10 @@ auto PPU::Background::power(u32 id) -> void {
 
   io = {};
   latch = {};
+  affine = {};
   for(auto& pixel : output) pixel = {};
   mosaic = {};
   mosaicOffset = 0;
-  hmosaic = 0;
   vmosaic = 0;
   fx = 0;
   fy = 0;

--- a/ares/gba/ppu/ppu.cpp
+++ b/ares/gba/ppu/ppu.cpp
@@ -144,8 +144,6 @@ auto PPU::main() -> void {
     bg3.io.ly = bg3.io.y;
   }
 
-  step(3);
-
   u32 y = display.io.vcounter;
   memory::move(io.forceBlank, io.forceBlank + 1, sizeof(io.forceBlank) - 1);
   memory::move(bg0.io.enable, bg0.io.enable + 1, sizeof(bg0.io.enable) - 1);
@@ -159,6 +157,8 @@ auto PPU::main() -> void {
   bg3.scanline(y);
   objects.scanline((y + 1) % 228);
   dac.scanline(y);
+
+  step(4);
 
   if(y < 160) {
     if(accurate) {
@@ -230,7 +230,7 @@ auto PPU::main() -> void {
     step(1035);
   }
 
-  step(194);
+  step(193);
 }
 
 auto PPU::frame() -> void {
@@ -264,7 +264,7 @@ auto PPU::power() -> void {
   window3.power(OUT);
   dac.power();
 
-  renderingCycle = 43;  //by default, render at first cycle of pixel output
+  renderingCycle = 42;  //by default, render at first cycle of pixel output
   string gameID;
   for(u32 index : range(4)) {
     n32 address = 0xac + index;

--- a/ares/gba/ppu/ppu.hpp
+++ b/ares/gba/ppu/ppu.hpp
@@ -169,6 +169,8 @@ private:
     struct Affine {
       u32 screenSize;
       u32 screenWrap;
+      u32 hmosaic;
+      u32 vmosaic;
       u32 cx;
       u32 cy;
       u32 tx;
@@ -179,8 +181,6 @@ private:
     Pixel output[240];
     Pixel mosaic;
     u32 mosaicOffset;
-
-    u32 hmosaic;
     u32 vmosaic;
 
     i28 fx;

--- a/ares/gba/ppu/serialization.cpp
+++ b/ares/gba/ppu/serialization.cpp
@@ -53,7 +53,6 @@ auto PPU::Background::serialize(serializer& s) -> void {
   s(io.ly);
 
   s(mosaicOffset);
-  s(hmosaic);
   s(vmosaic);
   s(fx);
   s(fy);

--- a/ares/gba/system/serialization.cpp
+++ b/ares/gba/system/serialization.cpp
@@ -1,4 +1,4 @@
-static const string SerializerVersion = "v148.2";
+static const string SerializerVersion = "v148.3";
 
 auto System::serialize(bool synchronize) -> serializer {
   if(synchronize) scheduler.enter(Scheduler::Mode::Synchronize);


### PR DESCRIPTION
The horizontal mosaic counter should run regardless of whether background mosaic is enabled or not. Also significantly improves timings for vertical component of background mosaic.