### PR TITLE
cmake: add FindXAudio2 module and fix debug symbol detection on MinGW

### DIFF
--- a/cmake/finders/FindXAudio2.cmake
+++ b/cmake/finders/FindXAudio2.cmake
@@ -1,0 +1,60 @@
+# FindXAudio2
+# -----------
+# Detect whether XAudio2 is available and determine the correct library to link.
+#
+# Result variables:
+#   XAudio2_FOUND      - TRUE if a linkable XAudio2 was found
+#   XAudio2_LIBRARY    - Library name to pass to target_link_libraries
+#
+# Imported targets:
+#   XAudio2::XAudio2
+
+include(FindPackageHandleStandardArgs)
+
+if(MINGW)
+  include(CheckCXXSourceCompiles)
+  include(CMakePushCheckState)
+
+  # Minimal test program that creates an XAudio2 instance.
+  # XAudio2Create is the canonical entry point present in all supported versions.
+  set(_xaudio2_test_code "
+    #define WIN32_LEAN_AND_MEAN
+    #include <windows.h>
+    #include <xaudio2.h>
+    int main() {
+      IXAudio2* p = nullptr;
+      XAudio2Create(&p, 0, XAUDIO2_DEFAULT_PROCESSOR);
+      return 0;
+    }
+  ")
+
+  cmake_push_check_state(RESET)
+  # Suppress MSVC extension warnings that appear in MinGW XAudio2 headers
+  set(CMAKE_REQUIRED_FLAGS "-Wno-language-extension-token")
+
+  # Prefer the versioned import libraries shipped with newer MinGW sysroots.
+  # Fall back to the unversioned name if neither is available.
+  foreach(_lib IN ITEMS xaudio2_9 xaudio2_8)
+    set(CMAKE_REQUIRED_LIBRARIES "-l${_lib}")
+    check_cxx_source_compiles("${_xaudio2_test_code}" _HAVE_XAUDIO2_${_lib})
+    if(_HAVE_XAUDIO2_${_lib})
+      set(XAudio2_LIBRARY "${_lib}")
+      break()
+    endif()
+  endforeach()
+
+  cmake_pop_check_state()
+else()
+  # On MSVC and other non-MinGW toolchains the umbrella import library is
+  # provided by the Windows SDK and requires no extra detection.
+  set(XAudio2_LIBRARY "xaudio2")
+endif()
+
+find_package_handle_standard_args(XAudio2
+  REQUIRED_VARS XAudio2_LIBRARY
+)
+
+if(XAudio2_FOUND AND NOT TARGET XAudio2::XAudio2)
+  add_library(XAudio2::XAudio2 INTERFACE IMPORTED)
+  target_link_libraries(XAudio2::XAudio2 INTERFACE ${XAudio2_LIBRARY})
+endif()

--- a/cmake/finders/FindXAudio2.cmake
+++ b/cmake/finders/FindXAudio2.cmake
@@ -11,7 +11,12 @@
 
 include(FindPackageHandleStandardArgs)
 
-if(MINGW)
+if(MSVC)
+  # On MSVC toolchains the umbrella import library is
+  # provided by the Windows SDK and requires no extra detection.
+  set(XAudio2_LIBRARY "xaudio2")
+else()
+  # On other non-MSVC toolchain
   include(CheckCXXSourceCompiles)
   include(CMakePushCheckState)
 
@@ -44,10 +49,6 @@ if(MINGW)
   endforeach()
 
   cmake_pop_check_state()
-else()
-  # On MSVC and other non-MinGW toolchains the umbrella import library is
-  # provided by the Windows SDK and requires no extra detection.
-  set(XAudio2_LIBRARY "xaudio2")
 endif()
 
 find_package_handle_standard_args(XAudio2

--- a/cmake/windows/compilerconfig.cmake
+++ b/cmake/windows/compilerconfig.cmake
@@ -75,6 +75,19 @@ if(MSVC)
   string(REPLACE "/Ob1" "/Ob2" CMAKE_C_FLAGS_RELWITHDEBINFO ${CMAKE_C_FLAGS_RELWITHDEBINFO})
 endif()
 
+# Detect -gcodeview support at configure time.
+# This flag is supported by LLVM-based MinGW toolchains but not all g++ variants.
+# Result cached in ARES_COMPILER_SUPPORTS_GCODEVIEW.
+if(NOT MSVC)
+  include(CheckCXXCompilerFlag)
+  check_cxx_compiler_flag(-gcodeview ARES_COMPILER_SUPPORTS_GCODEVIEW)
+  if(ARES_COMPILER_SUPPORTS_GCODEVIEW)
+    message(STATUS "Checking for -gcodeview support: YES")
+  else()
+    message(STATUS "Checking for -gcodeview support: NO")
+  endif()
+endif()
+
 # add general compiler flags and optimizations
 if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
   # we are on either msys2/mingw clang, or clang-cl
@@ -88,19 +101,26 @@ if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
     # statically link libc++
     add_link_options(-static-libstdc++)
 
-    # msys2/mingw-specific invocations to make clang emit debug symbols
+    # msys2/mingw-specific invocations to make clang emit debug symbols.
+    # Default: use CodeView (-gcodeview) for better WinDbg/Visual Studio integration.
+    # Set ARES_MINGW_USE_DWARF_SYMBOLS=ON to use DWARF instead (e.g. for gdb/lldb workflows).
     if(NOT DEFINED ARES_MINGW_USE_DWARF_SYMBOLS)
       set(ARES_MINGW_USE_DWARF_SYMBOLS OFF)
     endif()
 
-    set(_ares_mingw_clang_debug_compile_options -g "$<IF:$<BOOL:${ARES_MINGW_USE_DWARF_SYMBOLS}>,-gdwarf,-gcodeview>")
-    set(
-      _ares_mingw_clang_debug_link_options
-      -g
-      "$<IF:$<BOOL:${ARES_MINGW_USE_DWARF_SYMBOLS}>,-gdwarf,-fuse-ld=lld;-Wl$<COMMA>--pdb=>"
-    )
-    add_compile_options("$<$<CONFIG:Debug,RelWithDebInfo>:${_ares_mingw_clang_debug_compile_options}>")
-    add_link_options("$<$<CONFIG:Debug,RelWithDebInfo>:${_ares_mingw_clang_debug_link_options}>")
+    if(NOT ARES_MINGW_USE_DWARF_SYMBOLS AND ARES_COMPILER_SUPPORTS_GCODEVIEW)
+      set(_ares_mingw_clang_debug_compile_options -gcodeview)
+    elseif(NOT ARES_COMPILER_SUPPORTS_GCODEVIEW AND NOT ARES_MINGW_USE_DWARF_SYMBOLS)
+      # CodeView requested but compiler does not support it; fall back silently to DWARF
+      message(STATUS "-gcodeview not supported by this toolchain; falling back to DWARF debug symbols")
+      set(_ares_mingw_clang_debug_compile_options "")
+    else()
+      set(_ares_mingw_clang_debug_compile_options "")
+    endif()
+
+    if(_ares_mingw_clang_debug_compile_options)
+      add_compile_options("$<$<CONFIG:Debug,RelWithDebInfo>:${_ares_mingw_clang_debug_compile_options}>")
+    endif()
 
     add_compile_options(-fwrapv)
   else()
@@ -132,14 +152,26 @@ elseif(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
     add_link_options(/WX)
   endif()
 elseif(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+  # msys2/mingw GCC — default to DWARF since most GCC versions don't support -gcodeview.
   if(NOT DEFINED ARES_MINGW_USE_DWARF_SYMBOLS)
     set(ARES_MINGW_USE_DWARF_SYMBOLS ON)
   endif()
 
-  set(_ares_mingw_gcc_debug_compile_options -g "$<IF:$<BOOL:${ARES_MINGW_USE_DWARF_SYMBOLS}>,-gdwarf,-gcodeview>")
-  set(_ares_mingw_gcc_debug_link_options -g "$<IF:$<BOOL:${ARES_MINGW_USE_DWARF_SYMBOLS}>,-gdwarf,-Wl$<COMMA>--pdb=>")
-  add_compile_options("$<$<CONFIG:Debug,RelWithDebInfo>:${_ares_mingw_gcc_debug_compile_options}>")
-  add_link_options("$<$<CONFIG:Debug,RelWithDebInfo>:${_ares_mingw_gcc_debug_link_options}>")
+  if(NOT ARES_MINGW_USE_DWARF_SYMBOLS)
+    # User explicitly disabled DWARF; try CodeView.
+    if(ARES_COMPILER_SUPPORTS_GCODEVIEW)
+      set(_ares_mingw_gcc_debug_compile_options -gcodeview)
+    else()
+      message(STATUS "-gcodeview not supported by this GCC toolchain; using default DWARF debug symbols")
+      set(_ares_mingw_gcc_debug_compile_options "")
+    endif()
+  else()
+    set(_ares_mingw_gcc_debug_compile_options "")
+  endif()
+
+  if(_ares_mingw_gcc_debug_compile_options)
+    add_compile_options("$<$<CONFIG:Debug,RelWithDebInfo>:${_ares_mingw_gcc_debug_compile_options}>")
+  endif()
 
   add_compile_options(${_ares_gcc_common_options})
   add_link_options(-static-libstdc++)

--- a/ruby/cmake/os-windows.cmake
+++ b/ruby/cmake/os-windows.cmake
@@ -23,11 +23,11 @@ target_sources(
 
 find_package(SDL)
 find_package(librashader)
+find_package(XAudio2)
 
 target_enable_feature(ruby "Direct3D 9 video driver" VIDEO_DIRECT3D9)
 target_enable_feature(ruby "OpenGL video driver" VIDEO_WGL)
 target_enable_feature(ruby "WASAPI audio driver" AUDIO_WASAPI)
-target_enable_feature(ruby "XAudio2 audio driver" AUDIO_XAUDIO2)
 target_enable_feature(ruby "DirectSound audio driver" AUDIO_DIRECTSOUND)
 target_enable_feature(ruby "waveOut audio driver" AUDIO_WAVEOUT)
 target_enable_feature(ruby "Windows input driver (XInput/DirectInput)" INPUT_WINDOWS)
@@ -43,11 +43,16 @@ else()
   target_compile_definitions(ruby PRIVATE LIBRA_RUNTIME_OPENGL)
 endif()
 
+if(XAudio2_FOUND)
+  target_enable_feature(ruby "XAudio2 audio driver" AUDIO_XAUDIO2)
+endif()
+
 target_link_libraries(
   ruby
   PRIVATE
     $<$<BOOL:TRUE>:librashader::librashader>
     $<$<BOOL:${SDL_FOUND}>:SDL::SDL>
+    $<$<BOOL:${XAudio2_FOUND}>:XAudio2::XAudio2>
     d3d9
     opengl32
     dsound
@@ -59,17 +64,3 @@ target_link_libraries(
     dxguid
 	ksuser
 )
-
-if(MSVC) 
-  target_link_libraries(
-    ruby
-	PRIVATE
-	  xaudio2
-  )
-else()
-  target_link_libraries(
-    ruby
-	PRIVATE
-	  xaudio2_9
-  )
-endif()


### PR DESCRIPTION
Add cmake/finders/FindXAudio2.cmake to replace the ad-hoc XAudio2 link logic in os-windows.cmake. On MSVC the Windows SDK umbrella library is used directly; on other toolchains (MinGW etc.) the module uses check_cxx_source_compiles to probe for xaudio2_9 and xaudio2_8 in the sysroot. An imported target XAudio2::XAudio2 is exported so call sites need no platform conditionals.

Replace the generator-expression-based -gcodeview selection in compilerconfig.cmake with an explicit check_cxx_compiler_flag probe at configure time (ARES_COMPILER_SUPPORTS_GCODEVIEW). This avoids passing -gcodeview to toolchains that do not support it and makes the fallback to DWARF visible in the configure log rather than silently resolved at build time.

- ruby/cmake/os-windows.cmake: call find_package(XAudio2) and consume XAudio2::XAudio2 via a generator expression; remove the old MSVC/else block that unconditionally linked xaudio2/xaudio2_9

- cmake/windows/compilerconfig.cmake: add -gcodeview capability probe; rewrite Clang and GCC debug-symbol blocks to branch on the cached result instead of a generator expression
