### PR TITLE
desktop-ui: fix kiosk crash, ignore hotkeys while Tools window is focused

### DIFF
--- a/desktop-ui/input/hotkeys.cpp
+++ b/desktop-ui/input/hotkeys.cpp
@@ -179,8 +179,10 @@ auto InputManager::createHotkeys() -> void {
 
 auto InputManager::pollHotkeys() -> void {
   if(Application::modal()) return;
-  if(settingsWindow.focused()) return;
-
+  if(
+    program.settingsWindowConstructed && settingsWindow.focused() ||
+    program.toolsWindowConstructed && toolsWindow.focused()
+  ) return;
   if(settings.input.defocus != "Allow") {
     if (!presentation.focused() && !ruby::video.fullScreen()) return;
   }


### PR DESCRIPTION
`--kiosk` mode crashes as soon as it's launched, since we're checking for the status of `settingsWindow` which does not exist.
Also guarding against hotkeys firing while in the Tools menus, since they contain text boxes.