### PR TITLE
cmake: Add missing include sources

### DIFF
--- a/ares/CMakeLists.txt
+++ b/ares/CMakeLists.txt
@@ -99,6 +99,18 @@ target_sources(
     ares/node/video/video.hpp
 )
 
+target_sources(
+  ares
+  PRIVATE
+    ares/node/debugger/debugger.hpp
+    ares/node/debugger/graphics.hpp
+    ares/node/debugger/memory.hpp
+    ares/node/debugger/properties.hpp
+    ares/node/debugger/tracer/tracer.hpp
+    ares/node/debugger/tracer/instruction.hpp
+    ares/node/debugger/tracer/notification.hpp
+)
+
 if(OS_WINDOWS)
   include(cmake/os-windows.cmake)
 elseif(OS_MACOS)

--- a/ares/fc/CMakeLists.txt
+++ b/ares/fc/CMakeLists.txt
@@ -152,6 +152,14 @@ ares_add_sources(
   CORE #
     fc
   INCLUDED #
+    controller/zapper/zapper.cpp
+    controller/zapper/zapper.hpp
+)
+
+ares_add_sources(
+  CORE #
+    fc
+  INCLUDED #
     cpu/cpu.hpp
     cpu/debugger.cpp
     cpu/memory.cpp
@@ -182,6 +190,8 @@ ares_add_sources(
   INCLUDED #
     expansion/family-keyboard/family-keyboard.cpp
     expansion/family-keyboard/family-keyboard.hpp
+    expansion/family-keyboard/famicom-data-recorder.cpp
+    expansion/family-keyboard/famicom-data-recorder.hpp
 )
 
 ares_add_sources(

--- a/ares/gb/CMakeLists.txt
+++ b/ares/gb/CMakeLists.txt
@@ -40,6 +40,20 @@ ares_add_sources(
   CORE #
     gb
   INCLUDED #
+    ppu/cgb.cpp
+    ppu/color.cpp
+    ppu/debugger.cpp
+    ppu/dmg.cpp
+    ppu/io.cpp
+    ppu/ppu.hpp
+    ppu/serialization.cpp
+    ppu/timing.cpp
+)
+
+ares_add_sources(
+  CORE #
+    gb
+  INCLUDED #
     bus/bus.hpp
 )
 

--- a/ares/md/CMakeLists.txt
+++ b/ares/md/CMakeLists.txt
@@ -111,6 +111,14 @@ ares_add_sources(
   CORE #
     md
   INCLUDED #
+    controller/mega-mouse/mega-mouse.cpp
+    controller/mega-mouse/mega-mouse.hpp
+)
+
+ares_add_sources(
+  CORE #
+    md
+  INCLUDED #
     cpu/bus.cpp
     cpu/cpu.hpp
     cpu/debugger.cpp

--- a/ares/n64/CMakeLists.txt
+++ b/ares/n64/CMakeLists.txt
@@ -42,6 +42,7 @@ ares_add_sources(
     n64
   INCLUDED #
     n64.hpp
+    accuracy.hpp
     CMakeLists.txt
 )
 
@@ -360,12 +361,16 @@ endif()
 ares_add_sources(
   CORE #
     n64
-  PRIMARY #
+  INCLUDED #
+    vulkan/parallel-rdp/parallel-rdp/luts.hpp
     vulkan/parallel-rdp/parallel-rdp/command_ring.hpp
+    vulkan/parallel-rdp/parallel-rdp/rdp_common.hpp
+    vulkan/parallel-rdp/parallel-rdp/rdp_data_structures.hpp
     vulkan/parallel-rdp/parallel-rdp/rdp_device.hpp
     vulkan/parallel-rdp/parallel-rdp/rdp_dump_write.hpp
     vulkan/parallel-rdp/parallel-rdp/rdp_renderer.hpp
     vulkan/parallel-rdp/parallel-rdp/video_interface.hpp
+    vulkan/parallel-rdp/parallel-rdp/worker_thread.hpp
     vulkan/parallel-rdp/vulkan/buffer.hpp
     vulkan/parallel-rdp/vulkan/buffer_pool.hpp
     vulkan/parallel-rdp/vulkan/command_buffer.hpp
@@ -388,6 +393,15 @@ ares_add_sources(
     vulkan/parallel-rdp/vulkan/semaphore_manager.hpp
     vulkan/parallel-rdp/vulkan/shader.hpp
     vulkan/parallel-rdp/vulkan/texture/texture_format.hpp
+    vulkan/parallel-rdp/vulkan/quirks.hpp
+    vulkan/parallel-rdp/vulkan/vulkan_common.hpp
+    vulkan/parallel-rdp/vulkan/limits.hpp
+    vulkan/parallel-rdp/vulkan/wsi.hpp
+    vulkan/parallel-rdp/vulkan/type_to_string.hpp
+    vulkan/parallel-rdp/vulkan/vulkan_headers.hpp
+    vulkan/parallel-rdp/vulkan/vulkan_prerotate.hpp
+    vulkan/parallel-rdp/vulkan/format.hpp
+    vulkan/parallel-rdp/vulkan/device_fossilize.hpp
     vulkan/parallel-rdp/util/arena_allocator.hpp
     vulkan/parallel-rdp/util/logging.hpp
     vulkan/parallel-rdp/util/thread_id.hpp
@@ -396,6 +410,18 @@ ares_add_sources(
     vulkan/parallel-rdp/util/timeline_trace_file.hpp
     vulkan/parallel-rdp/util/thread_name.hpp
     vulkan/parallel-rdp/util/environment.hpp
+    vulkan/parallel-rdp/util/hash.hpp
+    vulkan/parallel-rdp/util/intrusive.hpp
+    vulkan/parallel-rdp/util/intrusive_hash_map.hpp
+    vulkan/parallel-rdp/util/read_write_lock.hpp
+    vulkan/parallel-rdp/util/bitops.hpp
+    vulkan/parallel-rdp/util/small_vector.hpp
+    vulkan/parallel-rdp/util/intrusive_list.hpp
+    vulkan/parallel-rdp/util/object_pool.hpp
+    vulkan/parallel-rdp/util/temporary_hashmap.hpp
+    vulkan/parallel-rdp/util/enum_cast.hpp
+    vulkan/parallel-rdp/util/stack_allocator.hpp
+    vulkan/parallel-rdp/util/dynamic_array.hpp
 )
 
 target_include_directories(

--- a/nall/nall/cmake/sources.cmake
+++ b/nall/nall/cmake/sources.cmake
@@ -31,6 +31,8 @@ target_sources(
     inode.cpp
     inode.hpp
     instance.hpp
+    instruction-set.cpp
+    instruction-set.hpp
     interpolation.hpp
     intrinsics.hpp
     ips.hpp
@@ -64,6 +66,8 @@ target_sources(
     serial.hpp
     serializer.hpp
     set.hpp
+    smtp.cpp
+    smtp.hpp
     span-helpers.hpp
     stdint.hpp
     string.hpp
@@ -91,6 +95,7 @@ target_sources(
   nall
   PRIVATE #
     beat/single/apply.hpp
+    beat/single/create.hpp
 )
 
 target_sources(
@@ -128,9 +133,12 @@ target_sources(
     decode/cue.hpp
     decode/gzip.hpp
     decode/html.hpp
+    decode/huffman.hpp
     decode/inflate.hpp
     decode/mmi.hpp
+    decode/mtf.hpp
     decode/png.hpp
+    decode/rle.hpp
     decode/url.hpp
     decode/wav.hpp
     decode/zip.hpp
@@ -157,9 +165,15 @@ target_sources(
   PRIVATE #
     encode/base.hpp
     encode/base64.hpp
+    encode/bwt.hpp
     encode/html.hpp
+    encode/huffman.hpp
+    encode/lzsa.hpp
+    encode/mtf.hpp
     encode/png.hpp
+    encode/rle.hpp
     encode/url.hpp
+    encode/wav.hpp
     encode/zip.hpp
 )
 
@@ -179,7 +193,22 @@ target_sources(
     hash/crc32.hpp
     hash/crc64.hpp
     hash/hash.hpp
+    hash/sha224.hpp
     hash/sha256.hpp
+    hash/sha384.hpp
+    hash/sha512.hpp
+)
+
+
+target_sources(
+  nall
+  PRIVATE #
+    http/message.hpp
+    http/server.cpp
+    http/server.hpp
+    http/response.hpp
+    http/request.hpp
+    http/role.hpp
 )
 
 target_sources(
@@ -228,8 +257,13 @@ target_sources(
     recompiler/amd64/amd64.hpp
     recompiler/amd64/constants.hpp
     recompiler/amd64/emitter.hpp
+    recompiler/amd64/encoder-calls-windows.hpp
+    recompiler/amd64/encoder-calls-systemv.hpp
+    recompiler/amd64/encoder-instructions.hpp
     recompiler/generic/constants.hpp
     recompiler/generic/generic.hpp
+    recompiler/generic/encoder-calls.hpp
+    recompiler/generic/encoder-instructions.hpp
 )
 
 target_sources(
@@ -259,8 +293,11 @@ target_sources(
     string/eval/parser.hpp
     string/markup/bml.hpp
     string/markup/find.hpp
+    string/markup/json.hpp
     string/markup/node.hpp
     string/markup/xml.hpp
+    string/transform/dml.hpp
+    string/transform/cml.hpp
 )
 
 target_sources(


### PR DESCRIPTION
This fixes *most* of the missing includes, allowing them to show up in IDEs that depend on cmake being correct. 