### PR TITLE
fix: load configured shader on --kiosk startup

### DIFF
--- a/desktop-ui/program/drivers.cpp
+++ b/desktop-ui/program/drivers.cpp
@@ -7,7 +7,15 @@ auto Program::videoDriverUpdate() -> void {
   ruby::video.setExclusive(settings.video.exclusive);
   ruby::video.setBlocking(settings.video.blocking);
   ruby::video.setFlush(settings.video.flush);
-  ruby::video.setShader(settings.video.shader);
+  if(!settings.video.shader.imatch("None")) {
+    string location = locate("Shaders/");
+    #if defined(PLATFORM_LINUX) || defined(PLATFORM_BSD)
+    if(!inode::exists(location)) location = locate("../libretro/shaders/shaders_slang/");
+    #endif
+    ruby::video.setShader({location, settings.video.shader});
+  } else {
+    ruby::video.setShader(settings.video.shader);
+  }
   ruby::video.setForceSRGB(settings.video.forceSRGB);
   ruby::video.setThreadedRenderer(settings.video.threadedRenderer);
   ruby::video.setNativeFullScreen(settings.video.nativeFullScreen);


### PR DESCRIPTION
Kiosk mode skipped the shader loading path used by the regular UI, so startup passed the raw config value from Video/Shader directly to `ruby::video.setShader()`.
For preset shaders this value should be a relative name, which left the backend thinking a shader was selected while no shader chain was actually loaded.