### PR TITLE
Per-core input remapping with a VirtualPad fallback

### DIFF
--- a/desktop-ui/emulator/game-boy-advance.cpp
+++ b/desktop-ui/emulator/game-boy-advance.cpp
@@ -5,6 +5,18 @@ struct GameBoyAdvance : Emulator {
   auto save() -> bool override;
   auto pak(ares::Node::Object) -> std::shared_ptr<vfs::directory> override;
   string deviceName;
+
+  InputDigital up;
+  InputDigital down;
+  InputDigital left;
+  InputDigital right;
+  InputDigital a;
+  InputDigital b;
+  InputDigital l;
+  InputDigital r;
+  InputDigital select;
+  InputDigital start;
+  InputRumble rumble;
 };
 
 GameBoyAdvance::GameBoyAdvance() {
@@ -13,20 +25,32 @@ GameBoyAdvance::GameBoyAdvance() {
 
   firmware.push_back({"BIOS", "World", "fd2547724b505f487e6dcb29ec2ecff3af35a841a77ab2e85fd87350abd36570"});
 
+  up.fallback = &virtualPorts[0].pad.up;
+  down.fallback = &virtualPorts[0].pad.down;
+  left.fallback = &virtualPorts[0].pad.left;
+  right.fallback = &virtualPorts[0].pad.right;
+  a.fallback = &virtualPorts[0].pad.south;
+  b.fallback = &virtualPorts[0].pad.east;
+  l.fallback = &virtualPorts[0].pad.l_bumper;
+  r.fallback = &virtualPorts[0].pad.r_bumper;
+  select.fallback = &virtualPorts[0].pad.select;
+  start.fallback = &virtualPorts[0].pad.start;
+  rumble.fallback = &virtualPorts[0].pad.rumble;
+
   { InputPort port{string{"Game Boy Advance"}};
 
   { InputDevice device{"Controls"};
-    device.digital("Up",     virtualPorts[0].pad.up);
-    device.digital("Down",   virtualPorts[0].pad.down);
-    device.digital("Left",   virtualPorts[0].pad.left);
-    device.digital("Right",  virtualPorts[0].pad.right);
-    device.digital("B",      virtualPorts[0].pad.south);
-    device.digital("A",      virtualPorts[0].pad.east);
-    device.digital("L",      virtualPorts[0].pad.l_bumper);
-    device.digital("R",      virtualPorts[0].pad.r_bumper);
-    device.digital("Select", virtualPorts[0].pad.select);
-    device.digital("Start",  virtualPorts[0].pad.start);
-    device.rumble ("Rumble", virtualPorts[0].pad.rumble);
+    device.digital("Up",     up);
+    device.digital("Down",   down);
+    device.digital("Left",   left);
+    device.digital("Right",  right);
+    device.digital("B",      b);
+    device.digital("A",      a);
+    device.digital("L",      l);
+    device.digital("R",      r);
+    device.digital("Select", select);
+    device.digital("Start",  start);
+    device.rumble ("Rumble", rumble);
     port.append(device); }
 
     ports.push_back(port);

--- a/desktop-ui/emulator/game-boy-advance.cpp
+++ b/desktop-ui/emulator/game-boy-advance.cpp
@@ -6,10 +6,7 @@ struct GameBoyAdvance : Emulator {
   auto pak(ares::Node::Object) -> std::shared_ptr<vfs::directory> override;
   string deviceName;
 
-  InputDigital up;
-  InputDigital down;
-  InputDigital left;
-  InputDigital right;
+  Dpad dpad;
   InputDigital a;
   InputDigital b;
   InputDigital l;
@@ -25,25 +22,25 @@ GameBoyAdvance::GameBoyAdvance() {
 
   firmware.push_back({"BIOS", "World", "fd2547724b505f487e6dcb29ec2ecff3af35a841a77ab2e85fd87350abd36570"});
 
-  up.fallback = &virtualPorts[0].pad.up;
-  down.fallback = &virtualPorts[0].pad.down;
-  left.fallback = &virtualPorts[0].pad.left;
-  right.fallback = &virtualPorts[0].pad.right;
-  a.fallback = &virtualPorts[0].pad.south;
-  b.fallback = &virtualPorts[0].pad.east;
-  l.fallback = &virtualPorts[0].pad.l_bumper;
-  r.fallback = &virtualPorts[0].pad.r_bumper;
-  select.fallback = &virtualPorts[0].pad.select;
-  start.fallback = &virtualPorts[0].pad.start;
-  rumble.fallback = &virtualPorts[0].pad.rumble;
+  link(dpad.up, virtualPorts[0].pad.up);
+  link(dpad.down, virtualPorts[0].pad.down);
+  link(dpad.left, virtualPorts[0].pad.left);
+  link(dpad.right, virtualPorts[0].pad.right);
+  link(a, virtualPorts[0].pad.south);
+  link(b, virtualPorts[0].pad.east);
+  link(l, virtualPorts[0].pad.l_bumper);
+  link(r, virtualPorts[0].pad.r_bumper);
+  link(select, virtualPorts[0].pad.select);
+  link(start, virtualPorts[0].pad.start);
+  link(rumble, virtualPorts[0].pad.rumble);
 
   { InputPort port{string{"Game Boy Advance"}};
 
   { InputDevice device{"Controls"};
-    device.digital("Up",     up);
-    device.digital("Down",   down);
-    device.digital("Left",   left);
-    device.digital("Right",  right);
+    device.digital("Up",     dpad.up);
+    device.digital("Down",   dpad.down);
+    device.digital("Left",   dpad.left);
+    device.digital("Right",  dpad.right);
     device.digital("B",      b);
     device.digital("A",      a);
     device.digital("L",      l);

--- a/desktop-ui/emulator/game-boy-advance.cpp
+++ b/desktop-ui/emulator/game-boy-advance.cpp
@@ -7,12 +7,7 @@ struct GameBoyAdvance : Emulator {
   string deviceName;
 
   Dpad dpad;
-  InputDigital a;
-  InputDigital b;
-  InputDigital l;
-  InputDigital r;
-  InputDigital select;
-  InputDigital start;
+  InputDigital a, b, l, r, select, start;
   InputRumble rumble;
 };
 

--- a/desktop-ui/emulator/nintendo-64.cpp
+++ b/desktop-ui/emulator/nintendo-64.cpp
@@ -8,29 +8,15 @@ struct Nintendo64 : Emulator {
   auto pak(ares::Node::Object) -> std::shared_ptr<vfs::directory> override;
 
   struct GamepadMappings {
-    InputAnalog lstickUp;
-    InputAnalog lstickDown;
-    InputAnalog lstickLeft;
-    InputAnalog lstickRight;
+    InputAnalog lstickUp, lstickDown, lstickLeft, lstickRight;
     Dpad dpad;
-    InputDigital b;
-    InputDigital a;
-    InputDigital cUp;
-    InputDigital cDown;
-    InputDigital cLeft;
-    InputDigital cRight;
-    InputDigital l;
-    InputDigital r;
-    InputDigital z;
-    InputDigital start;
+    InputDigital b, a, cUp, cDown, cLeft, cRight, l, r, z, start;
     InputRumble rumble;
   };
 
   struct MouseMappings {
-    InputRelative x;
-    InputRelative y;
-    InputDigital left;
-    InputDigital right;
+    InputRelative x, y;
+    InputDigital left, right;
   };
 
   GamepadMappings gamepadMappings[4];

--- a/desktop-ui/emulator/nintendo-64.cpp
+++ b/desktop-ui/emulator/nintendo-64.cpp
@@ -7,6 +7,37 @@ struct Nintendo64 : Emulator {
   auto save() -> bool override;
   auto pak(ares::Node::Object) -> std::shared_ptr<vfs::directory> override;
 
+  struct GamepadMappings {
+    InputAnalog lstickUp;
+    InputAnalog lstickDown;
+    InputAnalog lstickLeft;
+    InputAnalog lstickRight;
+    InputDigital up;
+    InputDigital down;
+    InputDigital left;
+    InputDigital right;
+    InputDigital b;
+    InputDigital a;
+    InputDigital cUp;
+    InputDigital cDown;
+    InputDigital cLeft;
+    InputDigital cRight;
+    InputDigital l;
+    InputDigital r;
+    InputDigital z;
+    InputDigital start;
+    InputRumble rumble;
+  };
+
+  struct MouseMappings {
+    InputRelative x;
+    InputRelative y;
+    InputDigital left;
+    InputDigital right;
+  };
+
+  GamepadMappings gamepadMappings[4];
+  MouseMappings mouseMappings[4];
   std::shared_ptr<mia::Pak> disk;
   u32 regionID = 0;
   sTimer diskInsertTimer;
@@ -17,37 +48,64 @@ Nintendo64::Nintendo64() {
   name = "Nintendo 64";
 
   for(auto id : range(4)) {
+    auto& gamepad = gamepadMappings[id];
+    gamepad.lstickUp.fallback = &virtualPorts[id].pad.lstick_up;
+    gamepad.lstickDown.fallback = &virtualPorts[id].pad.lstick_down;
+    gamepad.lstickLeft.fallback = &virtualPorts[id].pad.lstick_left;
+    gamepad.lstickRight.fallback = &virtualPorts[id].pad.lstick_right;
+    gamepad.up.fallback = &virtualPorts[id].pad.up;
+    gamepad.down.fallback = &virtualPorts[id].pad.down;
+    gamepad.left.fallback = &virtualPorts[id].pad.left;
+    gamepad.right.fallback = &virtualPorts[id].pad.right;
+    gamepad.b.fallback = &virtualPorts[id].pad.west;
+    gamepad.a.fallback = &virtualPorts[id].pad.south;
+    gamepad.cUp.fallback = &virtualPorts[id].pad.rstick_up;
+    gamepad.cDown.fallback = &virtualPorts[id].pad.rstick_down;
+    gamepad.cLeft.fallback = &virtualPorts[id].pad.rstick_left;
+    gamepad.cRight.fallback = &virtualPorts[id].pad.rstick_right;
+    gamepad.l.fallback = &virtualPorts[id].pad.l_bumper;
+    gamepad.r.fallback = &virtualPorts[id].pad.r_bumper;
+    gamepad.z.fallback = &virtualPorts[id].pad.r_trigger;
+    gamepad.start.fallback = &virtualPorts[id].pad.start;
+    gamepad.rumble.fallback = &virtualPorts[id].pad.rumble;
+
+    auto& mouse = mouseMappings[id];
+    mouse.x.fallback = &virtualPorts[id].mouse.x;
+    mouse.y.fallback = &virtualPorts[id].mouse.y;
+    mouse.left.fallback = &virtualPorts[id].mouse.left;
+    mouse.right.fallback = &virtualPorts[id].mouse.right;
+
     InputPort port{string{"Controller Port ", 1 + id}};
 
   { InputDevice device{"Gamepad"};
-    device.analog ("L-Up",    virtualPorts[id].pad.lstick_up);
-    device.analog ("L-Down",  virtualPorts[id].pad.lstick_down);
-    device.analog ("L-Left",  virtualPorts[id].pad.lstick_left);
-    device.analog ("L-Right", virtualPorts[id].pad.lstick_right);
-    device.digital("Up",      virtualPorts[id].pad.up);
-    device.digital("Down",    virtualPorts[id].pad.down);
-    device.digital("Left",    virtualPorts[id].pad.left);
-    device.digital("Right",   virtualPorts[id].pad.right);
-    device.digital("B",       virtualPorts[id].pad.west);
-    device.digital("A",       virtualPorts[id].pad.south);
-    device.digital("C-Up",    virtualPorts[id].pad.rstick_up);
-    device.digital("C-Down",  virtualPorts[id].pad.rstick_down);
-    device.digital("C-Left",  virtualPorts[id].pad.rstick_left);
-    device.digital("C-Right", virtualPorts[id].pad.rstick_right);
-    device.digital("L",       virtualPorts[id].pad.l_bumper);
-    device.digital("R",       virtualPorts[id].pad.r_bumper);
-    device.digital("Z",       virtualPorts[id].pad.r_trigger);
-    device.digital("Start",   virtualPorts[id].pad.start);
-    device.rumble ("Rumble",  virtualPorts[id].pad.rumble);
-    device.analog ("X-Axis",  virtualPorts[id].pad.lstick_left, virtualPorts[id].pad.lstick_right);
-    device.analog ("Y-Axis",  virtualPorts[id].pad.lstick_up,   virtualPorts[id].pad.lstick_down);
+    device.analog ("L-Up",    gamepad.lstickUp);
+    device.analog ("L-Down",  gamepad.lstickDown);
+    device.analog ("L-Left",  gamepad.lstickLeft);
+    device.analog ("L-Right", gamepad.lstickRight);
+    device.digital("Up",      gamepad.up);
+    device.digital("Down",    gamepad.down);
+    device.digital("Left",    gamepad.left);
+    device.digital("Right",   gamepad.right);
+    device.digital("B",       gamepad.b);
+    device.digital("A",       gamepad.a);
+    device.digital("C-Up",    gamepad.cUp);
+    device.digital("C-Down",  gamepad.cDown);
+    device.digital("C-Left",  gamepad.cLeft);
+    device.digital("C-Right", gamepad.cRight);
+    device.digital("L",       gamepad.l);
+    device.digital("R",       gamepad.r);
+    device.digital("Z",       gamepad.z);
+    device.digital("Start",   gamepad.start);
+    device.rumble ("Rumble",  gamepad.rumble);
+    device.analog ("X-Axis",  gamepad.lstickLeft, gamepad.lstickRight);
+    device.analog ("Y-Axis",  gamepad.lstickUp,   gamepad.lstickDown);
     port.append(device); }
 
   { InputDevice device{"Mouse"};
-    device.relative("X",     virtualPorts[id].mouse.x);
-    device.relative("Y",     virtualPorts[id].mouse.y);
-    device.digital ("Left",  virtualPorts[id].mouse.left);
-    device.digital ("Right", virtualPorts[id].mouse.right);
+    device.relative("X",     mouse.x);
+    device.relative("Y",     mouse.y);
+    device.digital ("Left",  mouse.left);
+    device.digital ("Right", mouse.right);
     port.append(device); }
   
     ports.push_back(port);

--- a/desktop-ui/emulator/nintendo-64.cpp
+++ b/desktop-ui/emulator/nintendo-64.cpp
@@ -12,10 +12,7 @@ struct Nintendo64 : Emulator {
     InputAnalog lstickDown;
     InputAnalog lstickLeft;
     InputAnalog lstickRight;
-    InputDigital up;
-    InputDigital down;
-    InputDigital left;
-    InputDigital right;
+    Dpad dpad;
     InputDigital b;
     InputDigital a;
     InputDigital cUp;
@@ -49,31 +46,31 @@ Nintendo64::Nintendo64() {
 
   for(auto id : range(4)) {
     auto& gamepad = gamepadMappings[id];
-    gamepad.lstickUp.fallback = &virtualPorts[id].pad.lstick_up;
-    gamepad.lstickDown.fallback = &virtualPorts[id].pad.lstick_down;
-    gamepad.lstickLeft.fallback = &virtualPorts[id].pad.lstick_left;
-    gamepad.lstickRight.fallback = &virtualPorts[id].pad.lstick_right;
-    gamepad.up.fallback = &virtualPorts[id].pad.up;
-    gamepad.down.fallback = &virtualPorts[id].pad.down;
-    gamepad.left.fallback = &virtualPorts[id].pad.left;
-    gamepad.right.fallback = &virtualPorts[id].pad.right;
-    gamepad.b.fallback = &virtualPorts[id].pad.west;
-    gamepad.a.fallback = &virtualPorts[id].pad.south;
-    gamepad.cUp.fallback = &virtualPorts[id].pad.rstick_up;
-    gamepad.cDown.fallback = &virtualPorts[id].pad.rstick_down;
-    gamepad.cLeft.fallback = &virtualPorts[id].pad.rstick_left;
-    gamepad.cRight.fallback = &virtualPorts[id].pad.rstick_right;
-    gamepad.l.fallback = &virtualPorts[id].pad.l_bumper;
-    gamepad.r.fallback = &virtualPorts[id].pad.r_bumper;
-    gamepad.z.fallback = &virtualPorts[id].pad.r_trigger;
-    gamepad.start.fallback = &virtualPorts[id].pad.start;
-    gamepad.rumble.fallback = &virtualPorts[id].pad.rumble;
+    link(gamepad.lstickUp, virtualPorts[id].pad.lstick_up);
+    link(gamepad.lstickDown, virtualPorts[id].pad.lstick_down);
+    link(gamepad.lstickLeft, virtualPorts[id].pad.lstick_left);
+    link(gamepad.lstickRight, virtualPorts[id].pad.lstick_right);
+    link(gamepad.dpad.up, virtualPorts[id].pad.up);
+    link(gamepad.dpad.down, virtualPorts[id].pad.down);
+    link(gamepad.dpad.left, virtualPorts[id].pad.left);
+    link(gamepad.dpad.right, virtualPorts[id].pad.right);
+    link(gamepad.b, virtualPorts[id].pad.west);
+    link(gamepad.a, virtualPorts[id].pad.south);
+    link(gamepad.cUp, virtualPorts[id].pad.rstick_up);
+    link(gamepad.cDown, virtualPorts[id].pad.rstick_down);
+    link(gamepad.cLeft, virtualPorts[id].pad.rstick_left);
+    link(gamepad.cRight, virtualPorts[id].pad.rstick_right);
+    link(gamepad.l, virtualPorts[id].pad.l_bumper);
+    link(gamepad.r, virtualPorts[id].pad.r_bumper);
+    link(gamepad.z, virtualPorts[id].pad.r_trigger);
+    link(gamepad.start, virtualPorts[id].pad.start);
+    link(gamepad.rumble, virtualPorts[id].pad.rumble);
 
     auto& mouse = mouseMappings[id];
-    mouse.x.fallback = &virtualPorts[id].mouse.x;
-    mouse.y.fallback = &virtualPorts[id].mouse.y;
-    mouse.left.fallback = &virtualPorts[id].mouse.left;
-    mouse.right.fallback = &virtualPorts[id].mouse.right;
+    link(mouse.x, virtualPorts[id].mouse.x);
+    link(mouse.y, virtualPorts[id].mouse.y);
+    link(mouse.left, virtualPorts[id].mouse.left);
+    link(mouse.right, virtualPorts[id].mouse.right);
 
     InputPort port{string{"Controller Port ", 1 + id}};
 
@@ -82,10 +79,10 @@ Nintendo64::Nintendo64() {
     device.analog ("L-Down",  gamepad.lstickDown);
     device.analog ("L-Left",  gamepad.lstickLeft);
     device.analog ("L-Right", gamepad.lstickRight);
-    device.digital("Up",      gamepad.up);
-    device.digital("Down",    gamepad.down);
-    device.digital("Left",    gamepad.left);
-    device.digital("Right",   gamepad.right);
+    device.digital("Up",      gamepad.dpad.up);
+    device.digital("Down",    gamepad.dpad.down);
+    device.digital("Left",    gamepad.dpad.left);
+    device.digital("Right",   gamepad.dpad.right);
     device.digital("B",       gamepad.b);
     device.digital("A",       gamepad.a);
     device.digital("C-Up",    gamepad.cUp);

--- a/desktop-ui/emulator/super-famicom.cpp
+++ b/desktop-ui/emulator/super-famicom.cpp
@@ -5,10 +5,7 @@ struct SuperFamicom : Emulator {
   auto pak(ares::Node::Object) -> std::shared_ptr<vfs::directory> override;
 
   struct GamepadMappings {
-    InputDigital up;
-    InputDigital down;
-    InputDigital left;
-    InputDigital right;
+    Dpad dpad;
     InputDigital b;
     InputDigital a;
     InputDigital y;
@@ -20,10 +17,7 @@ struct SuperFamicom : Emulator {
   };
 
   struct RumbleGamepadMappings {
-    InputDigital up;
-    InputDigital down;
-    InputDigital left;
-    InputDigital right;
+    Dpad dpad;
     InputDigital b;
     InputDigital a;
     InputDigital y;
@@ -60,10 +54,7 @@ struct SuperFamicom : Emulator {
   };
 
   struct NttDataKeypadMappings {
-    InputDigital up;
-    InputDigital down;
-    InputDigital left;
-    InputDigital right;
+    Dpad dpad;
     InputDigital b;
     InputDigital a;
     InputDigital y;
@@ -110,94 +101,94 @@ SuperFamicom::SuperFamicom() {
 
   for(auto id : range(2)) {
     auto& gamepad = gamepadMappings[id];
-    gamepad.up.fallback = &virtualPorts[id].pad.up;
-    gamepad.down.fallback = &virtualPorts[id].pad.down;
-    gamepad.left.fallback = &virtualPorts[id].pad.left;
-    gamepad.right.fallback = &virtualPorts[id].pad.right;
-    gamepad.b.fallback = &virtualPorts[id].pad.south;
-    gamepad.a.fallback = &virtualPorts[id].pad.east;
-    gamepad.y.fallback = &virtualPorts[id].pad.west;
-    gamepad.x.fallback = &virtualPorts[id].pad.north;
-    gamepad.l.fallback = &virtualPorts[id].pad.l_bumper;
-    gamepad.r.fallback = &virtualPorts[id].pad.r_bumper;
-    gamepad.select.fallback = &virtualPorts[id].pad.select;
-    gamepad.start.fallback = &virtualPorts[id].pad.start;
+    link(gamepad.dpad.up, virtualPorts[id].pad.up);
+    link(gamepad.dpad.down, virtualPorts[id].pad.down);
+    link(gamepad.dpad.left, virtualPorts[id].pad.left);
+    link(gamepad.dpad.right, virtualPorts[id].pad.right);
+    link(gamepad.b, virtualPorts[id].pad.south);
+    link(gamepad.a, virtualPorts[id].pad.east);
+    link(gamepad.y, virtualPorts[id].pad.west);
+    link(gamepad.x, virtualPorts[id].pad.north);
+    link(gamepad.l, virtualPorts[id].pad.l_bumper);
+    link(gamepad.r, virtualPorts[id].pad.r_bumper);
+    link(gamepad.select, virtualPorts[id].pad.select);
+    link(gamepad.start, virtualPorts[id].pad.start);
 
     auto& rumbleGamepad = rumbleGamepadMappings[id];
-    rumbleGamepad.up.fallback = &virtualPorts[id].pad.up;
-    rumbleGamepad.down.fallback = &virtualPorts[id].pad.down;
-    rumbleGamepad.left.fallback = &virtualPorts[id].pad.left;
-    rumbleGamepad.right.fallback = &virtualPorts[id].pad.right;
-    rumbleGamepad.b.fallback = &virtualPorts[id].pad.south;
-    rumbleGamepad.a.fallback = &virtualPorts[id].pad.east;
-    rumbleGamepad.y.fallback = &virtualPorts[id].pad.west;
-    rumbleGamepad.x.fallback = &virtualPorts[id].pad.north;
-    rumbleGamepad.l.fallback = &virtualPorts[id].pad.l_bumper;
-    rumbleGamepad.r.fallback = &virtualPorts[id].pad.r_bumper;
-    rumbleGamepad.select.fallback = &virtualPorts[id].pad.select;
-    rumbleGamepad.start.fallback = &virtualPorts[id].pad.start;
-    rumbleGamepad.rumble.fallback = &virtualPorts[id].pad.rumble;
+    link(rumbleGamepad.dpad.up, virtualPorts[id].pad.up);
+    link(rumbleGamepad.dpad.down, virtualPorts[id].pad.down);
+    link(rumbleGamepad.dpad.left, virtualPorts[id].pad.left);
+    link(rumbleGamepad.dpad.right, virtualPorts[id].pad.right);
+    link(rumbleGamepad.b, virtualPorts[id].pad.south);
+    link(rumbleGamepad.a, virtualPorts[id].pad.east);
+    link(rumbleGamepad.y, virtualPorts[id].pad.west);
+    link(rumbleGamepad.x, virtualPorts[id].pad.north);
+    link(rumbleGamepad.l, virtualPorts[id].pad.l_bumper);
+    link(rumbleGamepad.r, virtualPorts[id].pad.r_bumper);
+    link(rumbleGamepad.select, virtualPorts[id].pad.select);
+    link(rumbleGamepad.start, virtualPorts[id].pad.start);
+    link(rumbleGamepad.rumble, virtualPorts[id].pad.rumble);
 
     auto& mouse = mouseMappings[id];
-    mouse.x.fallback = &virtualPorts[id].mouse.x;
-    mouse.y.fallback = &virtualPorts[id].mouse.y;
-    mouse.left.fallback = &virtualPorts[id].mouse.left;
-    mouse.right.fallback = &virtualPorts[id].mouse.right;
+    link(mouse.x, virtualPorts[id].mouse.x);
+    link(mouse.y, virtualPorts[id].mouse.y);
+    link(mouse.left, virtualPorts[id].mouse.left);
+    link(mouse.right, virtualPorts[id].mouse.right);
 
     auto& justifier = justifierMappings[id];
-    justifier.x.fallback = &virtualPorts[id].mouse.x;
-    justifier.y.fallback = &virtualPorts[id].mouse.y;
-    justifier.trigger.fallback = &virtualPorts[id].mouse.left;
-    justifier.start.fallback = &virtualPorts[id].mouse.right;
+    link(justifier.x, virtualPorts[id].mouse.x);
+    link(justifier.y, virtualPorts[id].mouse.y);
+    link(justifier.trigger, virtualPorts[id].mouse.left);
+    link(justifier.start, virtualPorts[id].mouse.right);
 
     auto& superScope = superScopeMappings[id];
-    superScope.x.fallback = &virtualPorts[id].mouse.x;
-    superScope.y.fallback = &virtualPorts[id].mouse.y;
-    superScope.trigger.fallback = &virtualPorts[id].mouse.left;
-    superScope.cursor.fallback = &virtualPorts[id].mouse.middle;
-    superScope.turbo.fallback = &virtualPorts[id].mouse.right;
-    superScope.pause.fallback = &virtualPorts[id].pad.start;
+    link(superScope.x, virtualPorts[id].mouse.x);
+    link(superScope.y, virtualPorts[id].mouse.y);
+    link(superScope.trigger, virtualPorts[id].mouse.left);
+    link(superScope.cursor, virtualPorts[id].mouse.middle);
+    link(superScope.turbo, virtualPorts[id].mouse.right);
+    link(superScope.pause, virtualPorts[id].pad.start);
 
     auto& keypad = keypadMappings[id];
-    keypad.up.fallback = &virtualPorts[id].pad.up;
-    keypad.down.fallback = &virtualPorts[id].pad.down;
-    keypad.left.fallback = &virtualPorts[id].pad.left;
-    keypad.right.fallback = &virtualPorts[id].pad.right;
-    keypad.b.fallback = &virtualPorts[id].pad.south;
-    keypad.a.fallback = &virtualPorts[id].pad.east;
-    keypad.y.fallback = &virtualPorts[id].pad.west;
-    keypad.x.fallback = &virtualPorts[id].pad.north;
-    keypad.l.fallback = &virtualPorts[id].pad.l_bumper;
-    keypad.r.fallback = &virtualPorts[id].pad.r_bumper;
-    keypad.back.fallback = &virtualPorts[id].pad.select;
-    keypad.next.fallback = &virtualPorts[id].pad.start;
-    keypad.one.fallback = &virtualPorts[id].pad.one;
-    keypad.two.fallback = &virtualPorts[id].pad.two;
-    keypad.three.fallback = &virtualPorts[id].pad.three;
-    keypad.four.fallback = &virtualPorts[id].pad.four;
-    keypad.five.fallback = &virtualPorts[id].pad.five;
-    keypad.six.fallback = &virtualPorts[id].pad.six;
-    keypad.seven.fallback = &virtualPorts[id].pad.seven;
-    keypad.eight.fallback = &virtualPorts[id].pad.eight;
-    keypad.nine.fallback = &virtualPorts[id].pad.nine;
-    keypad.zero.fallback = &virtualPorts[id].pad.zero;
-    keypad.star.fallback = &virtualPorts[id].pad.star;
-    keypad.clear.fallback = &virtualPorts[id].pad.clear;
-    keypad.pound.fallback = &virtualPorts[id].pad.pound;
-    keypad.point.fallback = &virtualPorts[id].pad.point;
-    keypad.end.fallback = &virtualPorts[id].pad.end;
+    link(keypad.dpad.up, virtualPorts[id].pad.up);
+    link(keypad.dpad.down, virtualPorts[id].pad.down);
+    link(keypad.dpad.left, virtualPorts[id].pad.left);
+    link(keypad.dpad.right, virtualPorts[id].pad.right);
+    link(keypad.b, virtualPorts[id].pad.south);
+    link(keypad.a, virtualPorts[id].pad.east);
+    link(keypad.y, virtualPorts[id].pad.west);
+    link(keypad.x, virtualPorts[id].pad.north);
+    link(keypad.l, virtualPorts[id].pad.l_bumper);
+    link(keypad.r, virtualPorts[id].pad.r_bumper);
+    link(keypad.back, virtualPorts[id].pad.select);
+    link(keypad.next, virtualPorts[id].pad.start);
+    link(keypad.one, virtualPorts[id].pad.one);
+    link(keypad.two, virtualPorts[id].pad.two);
+    link(keypad.three, virtualPorts[id].pad.three);
+    link(keypad.four, virtualPorts[id].pad.four);
+    link(keypad.five, virtualPorts[id].pad.five);
+    link(keypad.six, virtualPorts[id].pad.six);
+    link(keypad.seven, virtualPorts[id].pad.seven);
+    link(keypad.eight, virtualPorts[id].pad.eight);
+    link(keypad.nine, virtualPorts[id].pad.nine);
+    link(keypad.zero, virtualPorts[id].pad.zero);
+    link(keypad.star, virtualPorts[id].pad.star);
+    link(keypad.clear, virtualPorts[id].pad.clear);
+    link(keypad.pound, virtualPorts[id].pad.pound);
+    link(keypad.point, virtualPorts[id].pad.point);
+    link(keypad.end, virtualPorts[id].pad.end);
 
     auto& twinTap = twinTapMappings[id];
-    twinTap.one.fallback = &virtualPorts[id].pad.south;
-    twinTap.two.fallback = &virtualPorts[id].pad.east;
+    link(twinTap.one, virtualPorts[id].pad.south);
+    link(twinTap.two, virtualPorts[id].pad.east);
 
     InputPort port{string{"Controller Port ", 1 + id}};
 
   { InputDevice device{"Gamepad"};
-    device.digital("Up",     gamepad.up);
-    device.digital("Down",   gamepad.down);
-    device.digital("Left",   gamepad.left);
-    device.digital("Right",  gamepad.right);
+    device.digital("Up",     gamepad.dpad.up);
+    device.digital("Down",   gamepad.dpad.down);
+    device.digital("Left",   gamepad.dpad.left);
+    device.digital("Right",  gamepad.dpad.right);
     device.digital("B",      gamepad.b);
     device.digital("A",      gamepad.a);
     device.digital("Y",      gamepad.y);
@@ -209,10 +200,10 @@ SuperFamicom::SuperFamicom() {
     port.append(device); }
 
   { InputDevice device{"Rumble Gamepad"};
-    device.digital("Up",     rumbleGamepad.up);
-    device.digital("Down",   rumbleGamepad.down);
-    device.digital("Left",   rumbleGamepad.left);
-    device.digital("Right",  rumbleGamepad.right);
+    device.digital("Up",     rumbleGamepad.dpad.up);
+    device.digital("Down",   rumbleGamepad.dpad.down);
+    device.digital("Left",   rumbleGamepad.dpad.left);
+    device.digital("Right",  rumbleGamepad.dpad.right);
     device.digital("B",      rumbleGamepad.b);
     device.digital("A",      rumbleGamepad.a);
     device.digital("Y",      rumbleGamepad.y);
@@ -239,10 +230,10 @@ SuperFamicom::SuperFamicom() {
     port.append(device); }
 
   { InputDevice device{"NTT Data Keypad"};
-    device.digital("Up", keypad.up);
-    device.digital("Down", keypad.down);
-    device.digital("Left", keypad.left);
-    device.digital("Right", keypad.right);
+    device.digital("Up", keypad.dpad.up);
+    device.digital("Down", keypad.dpad.down);
+    device.digital("Left", keypad.dpad.left);
+    device.digital("Right", keypad.dpad.right);
     device.digital("B", keypad.b);
     device.digital("A", keypad.a);
     device.digital("Y", keypad.y);

--- a/desktop-ui/emulator/super-famicom.cpp
+++ b/desktop-ui/emulator/super-famicom.cpp
@@ -4,6 +4,103 @@ struct SuperFamicom : Emulator {
   auto save() -> bool override;
   auto pak(ares::Node::Object) -> std::shared_ptr<vfs::directory> override;
 
+  struct GamepadMappings {
+    InputDigital up;
+    InputDigital down;
+    InputDigital left;
+    InputDigital right;
+    InputDigital b;
+    InputDigital a;
+    InputDigital y;
+    InputDigital x;
+    InputDigital l;
+    InputDigital r;
+    InputDigital select;
+    InputDigital start;
+  };
+
+  struct RumbleGamepadMappings {
+    InputDigital up;
+    InputDigital down;
+    InputDigital left;
+    InputDigital right;
+    InputDigital b;
+    InputDigital a;
+    InputDigital y;
+    InputDigital x;
+    InputDigital l;
+    InputDigital r;
+    InputDigital select;
+    InputDigital start;
+    InputRumble rumble;
+  };
+
+  struct PointerMappings {
+    InputRelative x;
+    InputRelative y;
+    InputDigital left;
+    InputDigital middle;
+    InputDigital right;
+  };
+
+  struct JustifierMappings {
+    InputRelative x;
+    InputRelative y;
+    InputDigital trigger;
+    InputDigital start;
+  };
+
+  struct SuperScopeMappings {
+    InputRelative x;
+    InputRelative y;
+    InputDigital trigger;
+    InputDigital cursor;
+    InputDigital turbo;
+    InputDigital pause;
+  };
+
+  struct NttDataKeypadMappings {
+    InputDigital up;
+    InputDigital down;
+    InputDigital left;
+    InputDigital right;
+    InputDigital b;
+    InputDigital a;
+    InputDigital y;
+    InputDigital x;
+    InputDigital l;
+    InputDigital r;
+    InputDigital back;
+    InputDigital next;
+    InputDigital one;
+    InputDigital two;
+    InputDigital three;
+    InputDigital four;
+    InputDigital five;
+    InputDigital six;
+    InputDigital seven;
+    InputDigital eight;
+    InputDigital nine;
+    InputDigital zero;
+    InputDigital star;
+    InputDigital clear;
+    InputDigital pound;
+    InputDigital point;
+    InputDigital end;
+  };
+
+  struct TwinTapMappings {
+    InputDigital one;
+    InputDigital two;
+  };
+
+  GamepadMappings gamepadMappings[2];
+  RumbleGamepadMappings rumbleGamepadMappings[2];
+  PointerMappings mouseMappings[2];
+  JustifierMappings justifierMappings[2];
+  SuperScopeMappings superScopeMappings[2];
+  NttDataKeypadMappings keypadMappings[2];
+  TwinTapMappings twinTapMappings[2];
   std::shared_ptr<mia::Pak> gb, bs, stA, stB;
 };
 
@@ -12,95 +109,177 @@ SuperFamicom::SuperFamicom() {
   name = "Super Famicom";
 
   for(auto id : range(2)) {
+    auto& gamepad = gamepadMappings[id];
+    gamepad.up.fallback = &virtualPorts[id].pad.up;
+    gamepad.down.fallback = &virtualPorts[id].pad.down;
+    gamepad.left.fallback = &virtualPorts[id].pad.left;
+    gamepad.right.fallback = &virtualPorts[id].pad.right;
+    gamepad.b.fallback = &virtualPorts[id].pad.south;
+    gamepad.a.fallback = &virtualPorts[id].pad.east;
+    gamepad.y.fallback = &virtualPorts[id].pad.west;
+    gamepad.x.fallback = &virtualPorts[id].pad.north;
+    gamepad.l.fallback = &virtualPorts[id].pad.l_bumper;
+    gamepad.r.fallback = &virtualPorts[id].pad.r_bumper;
+    gamepad.select.fallback = &virtualPorts[id].pad.select;
+    gamepad.start.fallback = &virtualPorts[id].pad.start;
+
+    auto& rumbleGamepad = rumbleGamepadMappings[id];
+    rumbleGamepad.up.fallback = &virtualPorts[id].pad.up;
+    rumbleGamepad.down.fallback = &virtualPorts[id].pad.down;
+    rumbleGamepad.left.fallback = &virtualPorts[id].pad.left;
+    rumbleGamepad.right.fallback = &virtualPorts[id].pad.right;
+    rumbleGamepad.b.fallback = &virtualPorts[id].pad.south;
+    rumbleGamepad.a.fallback = &virtualPorts[id].pad.east;
+    rumbleGamepad.y.fallback = &virtualPorts[id].pad.west;
+    rumbleGamepad.x.fallback = &virtualPorts[id].pad.north;
+    rumbleGamepad.l.fallback = &virtualPorts[id].pad.l_bumper;
+    rumbleGamepad.r.fallback = &virtualPorts[id].pad.r_bumper;
+    rumbleGamepad.select.fallback = &virtualPorts[id].pad.select;
+    rumbleGamepad.start.fallback = &virtualPorts[id].pad.start;
+    rumbleGamepad.rumble.fallback = &virtualPorts[id].pad.rumble;
+
+    auto& mouse = mouseMappings[id];
+    mouse.x.fallback = &virtualPorts[id].mouse.x;
+    mouse.y.fallback = &virtualPorts[id].mouse.y;
+    mouse.left.fallback = &virtualPorts[id].mouse.left;
+    mouse.right.fallback = &virtualPorts[id].mouse.right;
+
+    auto& justifier = justifierMappings[id];
+    justifier.x.fallback = &virtualPorts[id].mouse.x;
+    justifier.y.fallback = &virtualPorts[id].mouse.y;
+    justifier.trigger.fallback = &virtualPorts[id].mouse.left;
+    justifier.start.fallback = &virtualPorts[id].mouse.right;
+
+    auto& superScope = superScopeMappings[id];
+    superScope.x.fallback = &virtualPorts[id].mouse.x;
+    superScope.y.fallback = &virtualPorts[id].mouse.y;
+    superScope.trigger.fallback = &virtualPorts[id].mouse.left;
+    superScope.cursor.fallback = &virtualPorts[id].mouse.middle;
+    superScope.turbo.fallback = &virtualPorts[id].mouse.right;
+    superScope.pause.fallback = &virtualPorts[id].pad.start;
+
+    auto& keypad = keypadMappings[id];
+    keypad.up.fallback = &virtualPorts[id].pad.up;
+    keypad.down.fallback = &virtualPorts[id].pad.down;
+    keypad.left.fallback = &virtualPorts[id].pad.left;
+    keypad.right.fallback = &virtualPorts[id].pad.right;
+    keypad.b.fallback = &virtualPorts[id].pad.south;
+    keypad.a.fallback = &virtualPorts[id].pad.east;
+    keypad.y.fallback = &virtualPorts[id].pad.west;
+    keypad.x.fallback = &virtualPorts[id].pad.north;
+    keypad.l.fallback = &virtualPorts[id].pad.l_bumper;
+    keypad.r.fallback = &virtualPorts[id].pad.r_bumper;
+    keypad.back.fallback = &virtualPorts[id].pad.select;
+    keypad.next.fallback = &virtualPorts[id].pad.start;
+    keypad.one.fallback = &virtualPorts[id].pad.one;
+    keypad.two.fallback = &virtualPorts[id].pad.two;
+    keypad.three.fallback = &virtualPorts[id].pad.three;
+    keypad.four.fallback = &virtualPorts[id].pad.four;
+    keypad.five.fallback = &virtualPorts[id].pad.five;
+    keypad.six.fallback = &virtualPorts[id].pad.six;
+    keypad.seven.fallback = &virtualPorts[id].pad.seven;
+    keypad.eight.fallback = &virtualPorts[id].pad.eight;
+    keypad.nine.fallback = &virtualPorts[id].pad.nine;
+    keypad.zero.fallback = &virtualPorts[id].pad.zero;
+    keypad.star.fallback = &virtualPorts[id].pad.star;
+    keypad.clear.fallback = &virtualPorts[id].pad.clear;
+    keypad.pound.fallback = &virtualPorts[id].pad.pound;
+    keypad.point.fallback = &virtualPorts[id].pad.point;
+    keypad.end.fallback = &virtualPorts[id].pad.end;
+
+    auto& twinTap = twinTapMappings[id];
+    twinTap.one.fallback = &virtualPorts[id].pad.south;
+    twinTap.two.fallback = &virtualPorts[id].pad.east;
+
     InputPort port{string{"Controller Port ", 1 + id}};
 
   { InputDevice device{"Gamepad"};
-    device.digital("Up",     virtualPorts[id].pad.up);
-    device.digital("Down",   virtualPorts[id].pad.down);
-    device.digital("Left",   virtualPorts[id].pad.left);
-    device.digital("Right",  virtualPorts[id].pad.right);
-    device.digital("B",      virtualPorts[id].pad.south);
-    device.digital("A",      virtualPorts[id].pad.east);
-    device.digital("Y",      virtualPorts[id].pad.west);
-    device.digital("X",      virtualPorts[id].pad.north);
-    device.digital("L",      virtualPorts[id].pad.l_bumper);
-    device.digital("R",      virtualPorts[id].pad.r_bumper);
-    device.digital("Select", virtualPorts[id].pad.select);
-    device.digital("Start",  virtualPorts[id].pad.start);
+    device.digital("Up",     gamepad.up);
+    device.digital("Down",   gamepad.down);
+    device.digital("Left",   gamepad.left);
+    device.digital("Right",  gamepad.right);
+    device.digital("B",      gamepad.b);
+    device.digital("A",      gamepad.a);
+    device.digital("Y",      gamepad.y);
+    device.digital("X",      gamepad.x);
+    device.digital("L",      gamepad.l);
+    device.digital("R",      gamepad.r);
+    device.digital("Select", gamepad.select);
+    device.digital("Start",  gamepad.start);
     port.append(device); }
 
   { InputDevice device{"Rumble Gamepad"};
-    device.digital("Up",     virtualPorts[id].pad.up);
-    device.digital("Down",   virtualPorts[id].pad.down);
-    device.digital("Left",   virtualPorts[id].pad.left);
-    device.digital("Right",  virtualPorts[id].pad.right);
-    device.digital("B",      virtualPorts[id].pad.south);
-    device.digital("A",      virtualPorts[id].pad.east);
-    device.digital("Y",      virtualPorts[id].pad.west);
-    device.digital("X",      virtualPorts[id].pad.north);
-    device.digital("L",      virtualPorts[id].pad.l_bumper);
-    device.digital("R",      virtualPorts[id].pad.r_bumper);
-    device.digital("Select", virtualPorts[id].pad.select);
-    device.digital("Start",  virtualPorts[id].pad.start);
-    device.rumble("Rumble",  virtualPorts[id].pad.rumble);
+    device.digital("Up",     rumbleGamepad.up);
+    device.digital("Down",   rumbleGamepad.down);
+    device.digital("Left",   rumbleGamepad.left);
+    device.digital("Right",  rumbleGamepad.right);
+    device.digital("B",      rumbleGamepad.b);
+    device.digital("A",      rumbleGamepad.a);
+    device.digital("Y",      rumbleGamepad.y);
+    device.digital("X",      rumbleGamepad.x);
+    device.digital("L",      rumbleGamepad.l);
+    device.digital("R",      rumbleGamepad.r);
+    device.digital("Select", rumbleGamepad.select);
+    device.digital("Start",  rumbleGamepad.start);
+    device.rumble("Rumble",  rumbleGamepad.rumble);
     port.append(device); }
 
   { InputDevice device{"Justifier"};
-    device.relative("X",       virtualPorts[id].mouse.x);
-    device.relative("Y",       virtualPorts[id].mouse.y);
-    device.digital ("Trigger", virtualPorts[id].mouse.left);
-    device.digital ("Start",   virtualPorts[id].mouse.right);
+    device.relative("X",       justifier.x);
+    device.relative("Y",       justifier.y);
+    device.digital ("Trigger", justifier.trigger);
+    device.digital ("Start",   justifier.start);
     port.append(device); }
 
   { InputDevice device{"Mouse"};
-    device.relative("X",     virtualPorts[id].mouse.x);
-    device.relative("Y",     virtualPorts[id].mouse.y);
-    device.digital ("Left",  virtualPorts[id].mouse.left);
-    device.digital ("Right", virtualPorts[id].mouse.right);
+    device.relative("X",     mouse.x);
+    device.relative("Y",     mouse.y);
+    device.digital ("Left",  mouse.left);
+    device.digital ("Right", mouse.right);
     port.append(device); }
 
   { InputDevice device{"NTT Data Keypad"};
-    device.digital("Up", virtualPorts[id].pad.up);
-    device.digital("Down", virtualPorts[id].pad.down);
-    device.digital("Left", virtualPorts[id].pad.left);
-    device.digital("Right", virtualPorts[id].pad.right);
-    device.digital("B", virtualPorts[id].pad.south);
-    device.digital("A", virtualPorts[id].pad.east);
-    device.digital("Y", virtualPorts[id].pad.west);
-    device.digital("X", virtualPorts[id].pad.north);
-    device.digital("L", virtualPorts[id].pad.l_bumper);
-    device.digital("R", virtualPorts[id].pad.r_bumper);
-    device.digital("Back", virtualPorts[id].pad.select);
-    device.digital("Next", virtualPorts[id].pad.start);
-    device.digital("1", virtualPorts[id].pad.one);
-    device.digital("2", virtualPorts[id].pad.two);
-    device.digital("3", virtualPorts[id].pad.three);
-    device.digital("4", virtualPorts[id].pad.four);
-    device.digital("5", virtualPorts[id].pad.five);
-    device.digital("6", virtualPorts[id].pad.six);
-    device.digital("7", virtualPorts[id].pad.seven);
-    device.digital("8", virtualPorts[id].pad.eight);
-    device.digital("9", virtualPorts[id].pad.nine);
-    device.digital("0", virtualPorts[id].pad.zero);
-    device.digital("*", virtualPorts[id].pad.star);
-    device.digital("C", virtualPorts[id].pad.clear);
-    device.digital("#", virtualPorts[id].pad.pound);
-    device.digital(".", virtualPorts[id].pad.point);
-    device.digital("End", virtualPorts[id].pad.end);
+    device.digital("Up", keypad.up);
+    device.digital("Down", keypad.down);
+    device.digital("Left", keypad.left);
+    device.digital("Right", keypad.right);
+    device.digital("B", keypad.b);
+    device.digital("A", keypad.a);
+    device.digital("Y", keypad.y);
+    device.digital("X", keypad.x);
+    device.digital("L", keypad.l);
+    device.digital("R", keypad.r);
+    device.digital("Back", keypad.back);
+    device.digital("Next", keypad.next);
+    device.digital("1", keypad.one);
+    device.digital("2", keypad.two);
+    device.digital("3", keypad.three);
+    device.digital("4", keypad.four);
+    device.digital("5", keypad.five);
+    device.digital("6", keypad.six);
+    device.digital("7", keypad.seven);
+    device.digital("8", keypad.eight);
+    device.digital("9", keypad.nine);
+    device.digital("0", keypad.zero);
+    device.digital("*", keypad.star);
+    device.digital("C", keypad.clear);
+    device.digital("#", keypad.pound);
+    device.digital(".", keypad.point);
+    device.digital("End", keypad.end);
     port.append(device); }
 
   { InputDevice device{"Super Scope"};
-    device.relative("X",       virtualPorts[id].mouse.x);
-    device.relative("Y",       virtualPorts[id].mouse.y);
-    device.digital ("Trigger", virtualPorts[id].mouse.left);
-    device.digital ("Cursor",  virtualPorts[id].mouse.middle);
-    device.digital ("Turbo",   virtualPorts[id].mouse.right);
-    device.digital ("Pause",   virtualPorts[id].pad.start);
+    device.relative("X",       superScope.x);
+    device.relative("Y",       superScope.y);
+    device.digital ("Trigger", superScope.trigger);
+    device.digital ("Cursor",  superScope.cursor);
+    device.digital ("Turbo",   superScope.turbo);
+    device.digital ("Pause",   superScope.pause);
     port.append(device); }
 
   { InputDevice device{"Twin Tap"};
-    device.digital("1", virtualPorts[id].pad.south);
-    device.digital("2", virtualPorts[id].pad.east);
+    device.digital("1", twinTap.one);
+    device.digital("2", twinTap.two);
     port.append(device); }
 
     ports.push_back(port);

--- a/desktop-ui/emulator/super-famicom.cpp
+++ b/desktop-ui/emulator/super-famicom.cpp
@@ -6,83 +6,39 @@ struct SuperFamicom : Emulator {
 
   struct GamepadMappings {
     Dpad dpad;
-    InputDigital b;
-    InputDigital a;
-    InputDigital y;
-    InputDigital x;
-    InputDigital l;
-    InputDigital r;
-    InputDigital select;
-    InputDigital start;
+    InputDigital b, a, y, x, l, r, select, start;
   };
 
   struct RumbleGamepadMappings {
     Dpad dpad;
-    InputDigital b;
-    InputDigital a;
-    InputDigital y;
-    InputDigital x;
-    InputDigital l;
-    InputDigital r;
-    InputDigital select;
-    InputDigital start;
+    InputDigital b, a, y, x, l, r, select, start;
     InputRumble rumble;
   };
 
   struct PointerMappings {
-    InputRelative x;
-    InputRelative y;
-    InputDigital left;
-    InputDigital middle;
-    InputDigital right;
+    InputRelative x, y;
+    InputDigital left, middle, right;
   };
 
   struct JustifierMappings {
-    InputRelative x;
-    InputRelative y;
-    InputDigital trigger;
-    InputDigital start;
+    InputRelative x, y;
+    InputDigital trigger, start;
   };
 
   struct SuperScopeMappings {
-    InputRelative x;
-    InputRelative y;
-    InputDigital trigger;
-    InputDigital cursor;
-    InputDigital turbo;
-    InputDigital pause;
+    InputRelative x, y;
+    InputDigital trigger, cursor, turbo, pause;
   };
 
   struct NttDataKeypadMappings {
     Dpad dpad;
-    InputDigital b;
-    InputDigital a;
-    InputDigital y;
-    InputDigital x;
-    InputDigital l;
-    InputDigital r;
-    InputDigital back;
-    InputDigital next;
-    InputDigital one;
-    InputDigital two;
-    InputDigital three;
-    InputDigital four;
-    InputDigital five;
-    InputDigital six;
-    InputDigital seven;
-    InputDigital eight;
-    InputDigital nine;
-    InputDigital zero;
-    InputDigital star;
-    InputDigital clear;
-    InputDigital pound;
-    InputDigital point;
-    InputDigital end;
+    InputDigital b, a, y, x, l, r, back, next;
+    InputDigital one, two, three, four, five, six, seven, eight, nine, zero;
+    InputDigital star, clear, pound, point, end;
   };
 
   struct TwinTapMappings {
-    InputDigital one;
-    InputDigital two;
+    InputDigital one, two;
   };
 
   GamepadMappings gamepadMappings[2];

--- a/desktop-ui/input/input.cpp
+++ b/desktop-ui/input/input.cpp
@@ -51,6 +51,27 @@ auto InputMapping::unbind(u32 binding) -> void {
   assignments[binding] = {};
 }
 
+auto InputMapping::hasAssignments() const -> bool {
+  for(auto& assignment : assignments) {
+    if(assignment) return true;
+  }
+  return false;
+}
+
+auto InputMapping::icon(u32 binding) -> multiFactorImage {
+  lock_guard<recursive_mutex> inputLock(program.inputMutex);
+  if(binding >= BindingLimit) return {};
+  if(hasAssignments() || !fallback) return bindings[binding].icon();
+  return fallback->icon(binding);
+}
+
+auto InputMapping::text(u32 binding) -> string {
+  lock_guard<recursive_mutex> inputLock(program.inputMutex);
+  if(binding >= BindingLimit) return {};
+  if(hasAssignments() || !fallback) return bindings[binding].text();
+  return fallback->text(binding);
+}
+
 auto InputMapping::Binding::icon() -> multiFactorImage {
   lock_guard<recursive_mutex> inputLock(program.inputMutex);
   if(!device && deviceID) return Icon::Device::Joypad;
@@ -135,6 +156,7 @@ auto InputDigital::bind(u32 binding, std::shared_ptr<HID::Device> device, u32 gr
 
 auto InputDigital::value() -> s16 {
   lock_guard<recursive_mutex> inputLock(program.inputMutex);
+  if(!hasAssignments() && fallback) return fallback->value();
   s16 result = 0;
 
   for(auto& binding : bindings) {
@@ -255,6 +277,7 @@ auto InputAnalog::bind(u32 binding, std::shared_ptr<HID::Device> device, u32 gro
 
 auto InputAnalog::value() -> s16 {
   lock_guard<recursive_mutex> inputLock(program.inputMutex);
+  if(!hasAssignments() && fallback) return fallback->value();
   s32 result = 0;
 
   for(auto& binding : bindings) {
@@ -324,6 +347,7 @@ auto InputAbsolute::bind(u32 binding, std::shared_ptr<HID::Device> device, u32 g
 
 auto InputAbsolute::value() -> s16 {
   lock_guard<recursive_mutex> inputLock(program.inputMutex);
+  if(!hasAssignments() && fallback) return fallback->value();
   s32 result = 0;
 
   for(auto& binding : bindings) {
@@ -383,6 +407,7 @@ auto InputRelative::bind(u32 binding, std::shared_ptr<HID::Device> device, u32 g
 
 auto InputRelative::value() -> s16 {
   lock_guard<recursive_mutex> inputLock(program.inputMutex);
+  if(!hasAssignments() && fallback) return fallback->value();
   s32 result = 0;
 
   for(auto& binding : bindings) {
@@ -433,6 +458,12 @@ auto InputRumble::value() -> s16 {
 }
 
 auto InputRumble::rumble(u16 strong, u16 weak) -> void {
+  if(!hasAssignments() && fallback) {
+    if(auto fallbackRumble = dynamic_cast<InputRumble*>(fallback)) {
+      fallbackRumble->rumble(strong, weak);
+      return;
+    }
+  }
   for(auto& binding : bindings) {
     if(!binding.device) continue;
     ruby::input.rumble(binding.deviceID, strong, weak);
@@ -494,6 +525,13 @@ auto InputManager::bind() -> void {
   for(auto& port : virtualPorts) {
     for(auto& input : port.pad.inputs) input.mapping->bind();
     for(auto& input : port.mouse.inputs) input.mapping->bind();
+  }
+  for(auto& emulator : emulators) {
+    for(auto& port : emulator->ports) {
+      for(auto& device : port.devices) {
+        for(auto& input : device.inputs) input.mapping->bind();
+      }
+    }
   }
   for(auto& mapping : hotkeys) mapping.bind();
 }

--- a/desktop-ui/input/input.hpp
+++ b/desktop-ui/input/input.hpp
@@ -69,6 +69,18 @@ struct InputRumble : InputMapping {
   auto rumble(u16 strong, u16 weak) -> void;
 };
 
+template<typename Mapping, typename Fallback>
+inline auto link(Mapping& mapping, Fallback& fallback) -> void {
+  mapping.fallback = &fallback;
+}
+
+struct Dpad {
+  InputDigital up;
+  InputDigital down;
+  InputDigital left;
+  InputDigital right;
+};
+
 struct InputHotkey : InputDigital {
   InputHotkey(string name) : name(name) {}
   auto& onPress(std::function<void ()> press) { return this->press = press, *this; }

--- a/desktop-ui/input/input.hpp
+++ b/desktop-ui/input/input.hpp
@@ -7,12 +7,16 @@ struct InputMapping {
   auto bind(u32 binding, string assignment) -> void;
   auto unbind() -> void;
   auto unbind(u32 binding) -> void;
+  auto hasAssignments() const -> bool;
+  auto icon(u32 binding) -> multiFactorImage;
+  auto text(u32 binding) -> string;
 
   virtual auto bind(u32 binding, std::shared_ptr<HID::Device>, u32 groupID, u32 inputID, s16 oldValue, s16 newValue) -> bool = 0;
   virtual auto value() -> s16 = 0;
   virtual auto pressed() -> bool { return false; }
 
   string assignments[BindingLimit];
+  InputMapping* fallback = nullptr;
 
   struct Binding {
     auto icon() -> multiFactorImage;

--- a/desktop-ui/settings/input.cpp
+++ b/desktop-ui/settings/input.cpp
@@ -75,8 +75,14 @@ auto InputSettings::refresh() -> void {
       //do not remove identifier from mappings currently being assigned
       if(activeMapping && &activeMapping() == &input && activeBinding == binding) continue;
       auto cell = inputList.item(index).cell(1 + binding);
-      cell.setIcon(input.mapping->icon(binding));
-      cell.setText(input.mapping->text(binding));
+      auto mapping = input.mapping;
+      if(mapping->assignments[binding] || !mapping->fallback) {
+        cell.setIcon(mapping->icon(binding));
+        cell.setText(mapping->text(binding));
+      } else {
+        cell.setIcon(mapping->fallback->icon(binding));
+        cell.setText(mapping->fallback->text(binding));
+      }
     }
     index++;
   }

--- a/desktop-ui/settings/input.cpp
+++ b/desktop-ui/settings/input.cpp
@@ -77,9 +77,11 @@ auto InputSettings::refresh() -> void {
       auto cell = inputList.item(index).cell(1 + binding);
       auto mapping = input.mapping;
       if(mapping->assignments[binding] || !mapping->fallback) {
+        cell.setForegroundColor();
         cell.setIcon(mapping->icon(binding));
         cell.setText(mapping->text(binding));
       } else {
+        cell.setForegroundColor(SystemColor::PlaceholderText);
         cell.setIcon(mapping->fallback->icon(binding));
         cell.setText(mapping->fallback->text(binding));
       }
@@ -182,7 +184,7 @@ auto InputSettings::eventAssign(TableViewCell cell) -> void {
     activeMapping = device.inputs[item.offset()];
     activeBinding = max(0, (s32)cell.offset() - 1);
 
-    item.cell(1 + activeBinding).setIcon(Icon::Go::Right).setText("(assign ...)");
+    item.cell(1 + activeBinding).setForegroundColor().setIcon(Icon::Go::Right).setText("(assign ...)");
     assignLabel.setText({"Press a key or button for mapping #", 1 + activeBinding, " [", activeMapping->name, "] ..."});
     refresh();
     settingsWindow.setDismissable(false);

--- a/desktop-ui/settings/input.cpp
+++ b/desktop-ui/settings/input.cpp
@@ -75,8 +75,8 @@ auto InputSettings::refresh() -> void {
       //do not remove identifier from mappings currently being assigned
       if(activeMapping && &activeMapping() == &input && activeBinding == binding) continue;
       auto cell = inputList.item(index).cell(1 + binding);
-      cell.setIcon(input.mapping->bindings[binding].icon());
-      cell.setText(input.mapping->bindings[binding].text());
+      cell.setIcon(input.mapping->icon(binding));
+      cell.setText(input.mapping->text(binding));
     }
     index++;
   }

--- a/desktop-ui/settings/settings.cpp
+++ b/desktop-ui/settings/settings.cpp
@@ -203,13 +203,24 @@ auto Settings::process(bool load) -> void {
         for(auto& input : device.inputs) {
           if(!input.mapping->fallback) continue;
           string value;
-          name = {base, "/Input/", portName, "/", deviceName, "/", sanitizeInputName(input.name)};
+          auto inputName = sanitizeInputName(input.name);
+          auto overrideSettingsPrefix = string{base, "/Input/"};
+          if(portName != base) overrideSettingsPrefix.append(portName, "/");
+          auto overrideSettingsPath = string{overrideSettingsPrefix, deviceName, "/", inputName};
+          auto fallbackSettingsPath = string{base, "/Input/", portName, "/", deviceName, "/", inputName};
           if(load == 0) {
             if(!input.mapping->hasAssignments()) continue;
             for(auto& assignment : input.mapping->assignments) value.append(assignment, ";");
             value.trimRight(";", 1L);
           }
-          bind(string, name, value);
+          if(load) {
+            if(auto node = operator[](overrideSettingsPath)) value = node.string();
+            else if(overrideSettingsPath != fallbackSettingsPath) {
+              if(auto fallbackNode = operator[](fallbackSettingsPath)) value = fallbackNode.string();
+            }
+          } else {
+            operator()(overrideSettingsPath).setValue(value);
+          }
           if(load == 1) {
             auto parts = nall::split(value, ";");
             parts.resize(BindingLimit);

--- a/desktop-ui/settings/settings.cpp
+++ b/desktop-ui/settings/settings.cpp
@@ -189,6 +189,35 @@ auto Settings::process(bool load) -> void {
       name.replace(" ", "-");
       bind(string, name, firmware.location);
     }
+
+    // normalize port/device/input labels using the same compact style as other
+    // settings keys. for ex: "LaserActive (SEGA PAC)" becomes "LaserActiveSEGAPAC"
+    auto sanitizeInputName = [](string name) -> string {
+      return string{name}.replace(" ", "").replace("(", "").replace(")", "");
+    };
+
+    for(auto& port : emulator->ports) {
+      auto portName = sanitizeInputName(port.name);
+      for(auto& device : port.devices) {
+        auto deviceName = sanitizeInputName(device.name);
+        for(auto& input : device.inputs) {
+          if(!input.mapping->fallback) continue;
+          string value;
+          name = {base, "/Input/", portName, "/", deviceName, "/", sanitizeInputName(input.name)};
+          if(load == 0) {
+            if(!input.mapping->hasAssignments()) continue;
+            for(auto& assignment : input.mapping->assignments) value.append(assignment, ";");
+            value.trimRight(";", 1L);
+          }
+          bind(string, name, value);
+          if(load == 1) {
+            auto parts = nall::split(value, ";");
+            parts.resize(BindingLimit);
+            for(u32 binding : range(BindingLimit)) input.mapping->assignments[binding] = parts[binding];
+          }
+        }
+      }
+    }
   }
 
   #undef bind


### PR DESCRIPTION
This is a proof of concept for per-core input bindings built on top of the existing `VirtualPad` model.

Currently, all(?) core controls point directly at `virtualPorts[N]`, which means rebinding a system-specific control can unexpectedly mutate the shared VirtualPad bindings. This branch begins separating those concepts.

The idea here is:

- `VirtualPad` remains the root/default binding layer
- core inputs can own their own local mappings
- if a core input has no local assignment, it implicitly falls back to the corresponding `VirtualPad` binding
- if a user overrides a core input, that override only affects that core input and does not mutate `VirtualPad`

## What this PR does

- adds fallback support to `InputMapping`
- updates input UI display helpers to show effective bindings through fallback
- updates binding traversal so core-owned mappings are rebound too
- adds sparse settings serialization for core-owned input overrides
- implements Game Boy Advance as the initial proof of concept

## Current scope

This PR **only implements this model for the Game Boy Advance** for now.

GBA now owns its own logical mappings (`Up`, `Down`, `A`, `B`, etc.), but those mappings still inherit from `VirtualPad1` by default unless the user explicitly overrides them.

That makes this branch a safe first step, as:
- it proves the data model
- it proves fallback behavior
- it proves sparse serialization
- it avoids having to convert every core at once

## Intended next step

If this approach is accepted, the same pattern can be generalized to all the other cores.