### PR TITLE
n64: add initial emux support

### DIFF
--- a/ares/ares/node/debugger/tracer/instruction.hpp
+++ b/ares/ares/node/debugger/tracer/instruction.hpp
@@ -28,6 +28,15 @@ struct Instruction : Tracer {
     for(auto& history : _history) history = ~0ull;
   }
 
+  auto setEnabled(bool enabled) -> void {
+    Tracer::setTerminal(enabled);
+    if(!enabled) {
+      _omitted = 0;
+      setMask(_mask);
+      setDepth(_depth);
+    }
+  }
+
   auto address(u64 address) -> bool {
     address &= ~0ull >> (64 - _addressBits);  //mask upper bits of address
     _address = address;

--- a/ares/ares/platform.hpp
+++ b/ares/ares/platform.hpp
@@ -8,6 +8,7 @@ enum class Event : u32 {
   Frame,
   Power,
   Synchronize,
+  Shutdown
 };
 
 struct Platform {

--- a/ares/n64/ai/ai.cpp
+++ b/ares/n64/ai/ai.cpp
@@ -37,7 +37,7 @@ auto AI::sample() -> void {
 
   if(io.dmaCount && io.dmaLength[0] && io.dmaEnable) {
     io.dmaAddress[0].bit(13,23) += io.dmaAddressCarry;
-    auto data = rdram.ram.read<Word>(io.dmaAddress[0], "AI");
+    auto data = rdram.ram.read<Word>(io.dmaAddress[0], RBusDevice::AI_DMA);
     dac.left  = (s16)(data >> 16) / 32768.0;
     dac.right = (s16)(data >>  0) / 32768.0;
 

--- a/ares/n64/aleck64/aleck64.hpp
+++ b/ares/n64/aleck64/aleck64.hpp
@@ -8,7 +8,7 @@ struct Aleck64 {
     Writable(Aleck64& self) : self(self) {}
 
     template<u32 Size>
-    auto writeBurst(u32 address, u32 *value, const char *peripheral) -> void {
+    auto writeBurst(u32 address, u32 *value, RBusDevice device) -> void {
       address = address & 0x00ff'ffff;
       if(address >= size) return;
       Memory::Writable::write<Word>(address | 0x00, value[0]);
@@ -24,7 +24,7 @@ struct Aleck64 {
     }
 
     template<u32 Size>
-    auto readBurst(u32 address, u32 *value, const char *peripheral) -> void {
+    auto readBurst(u32 address, u32 *value, RBusDevice device) -> void {
       address = address & 0x00ff'ffff;
       if(address >= size) {
         value[0] = value[1] = value[2] = value[3] = 0;

--- a/ares/n64/cartridge/flash.cpp
+++ b/ares/n64/cartridge/flash.cpp
@@ -86,7 +86,7 @@ auto Cartridge::Flash::writeWord(u32 address, u64 data) -> void {
     if(mode == Mode::Write) {
       for(u32 index = 0; index < 128; index += 2) {
         // FIXME: this is obviously wrong, the flash can't access RDRAM
-        u16 half = rdram.ram.read<Half>(source + index, "Flash");
+        u16 half = rdram.ram.read<Half>(source + index, RBusDevice::ARES_FLASH);
         Memory::Writable::write<Half>(offset + index, half);
       }
     }

--- a/ares/n64/cpu/cpu.cpp
+++ b/ares/n64/cpu/cpu.cpp
@@ -19,6 +19,7 @@ CPU cpu;
 #include "debugger.cpp"
 #include "serialization.cpp"
 #include "disassembler.cpp"
+#include "emux.cpp"
 
 auto CPU::load(Node::Object parent) -> void {
   node = parent->append<Node::Object>("CPU");
@@ -88,6 +89,8 @@ auto CPU::synchronize() -> void {
     scc.cause.interruptPending.bit(Interrupt::Timer) = 1;
   }
   scc.count += clocks;
+  profile.cpuCycles += clocks;
+  if (scc.status.exceptionLevel) profile.cpuCyclesExc += clocks;
 }
 
 auto CPU::instruction() -> void {
@@ -160,6 +163,7 @@ auto CPU::power(bool reset) -> void {
   for(auto& r : fpu.r) r.u64 = 0;
   fpu.csr = {};
   cop2 = {};
+  emuxState = {};
   fenv.setRound(float_env::toNearest);
   context.setMode();
 

--- a/ares/n64/cpu/cpu.hpp
+++ b/ares/n64/cpu/cpu.hpp
@@ -25,6 +25,7 @@ struct CPU : Thread {
       Node::Debugger::Tracer::Notification exception;
       Node::Debugger::Tracer::Notification interrupt;
       Node::Debugger::Tracer::Notification tlb;
+      Node::Debugger::Tracer::Notification emux;
     } tracer;
   } debugger;
 
@@ -114,22 +115,14 @@ struct CPU : Thread {
     struct Line;
     auto line(u64 vaddr) -> Line& { return lines[vaddr >> 5 & 0x1ff]; }
 
-    //used by the recompiler to simulate instruction cache fetch timing
-    auto step(u64 vaddr, u32 paddr) -> void {
-      auto& line = this->line(vaddr);
-      if(!line.hit(paddr)) {
-        self.step(48 * 2);
-        line.valid = 1;
-        line.tag   = paddr & ~0x0000'0fff;
-      } else {
-        self.step(1 * 2);
-      }
-    }
-
+    //call by recompiled blocks to prefetch instructions into the cache
     auto jitFetch(u64 vaddr, u32 paddr, CPU& cpu) -> void {
       auto& line = this->line(vaddr);
       if(!line.hit(paddr)) {
+        self.profile.icacheMisses++;
         line.fill(paddr, cpu);
+      } else {
+        self.profile.icacheHits++;
       }
     }
 
@@ -137,7 +130,10 @@ struct CPU : Thread {
     auto fetch(u64 vaddr, u32 paddr, CPU& cpu) -> u32 {
       auto& line = this->line(vaddr);
       if(!line.hit(paddr)) {
+        self.profile.icacheMisses++;
         line.fill(paddr, cpu);
+      } else {
+        self.profile.icacheHits++;
       }
       return line.read(paddr);
     }
@@ -190,6 +186,7 @@ struct CPU : Thread {
 
   //dcache.cpp
   struct DataCache {
+    CPU& self;
     struct Line;
     auto line(u64 vaddr) -> Line&;
     template<u32 Size> auto read(u64 vaddr, u32 paddr) -> u64;
@@ -219,7 +216,7 @@ struct CPU : Thread {
         u32 words[4];
       };
     } lines[512];
-  } dcache;
+  } dcache{*this};
 
   //tlb.cpp: Translation Lookaside Buffer
   struct TLB {
@@ -305,8 +302,8 @@ struct CPU : Thread {
   }
   template<u32 Size> auto busWrite(u32 address, u64 data) -> void;
   template<u32 Size> auto busRead(u32 address) -> u64;
-  template<u32 Size> auto busWriteBurst(u32 address, u32 *data) -> void;
-  template<u32 Size> auto busReadBurst(u32 address, u32 *data) -> void;
+  template<u32 Size> auto busWriteBurst(u32 address, u32 *data) -> bool;
+  template<u32 Size> auto busReadBurst(u32 address, u32 *data) -> bool;
   template<u32 Size> auto read(PhysAccess access) -> maybe<u64>;
   template<u32 Size> auto write(PhysAccess access, u64 data) -> bool;
   template<u32 Size> auto read(u64 vaddr) -> maybe<u64> {
@@ -317,6 +314,7 @@ struct CPU : Thread {
   }
   template<u32 Size> auto vaddrAlignedError(u64 vaddr, bool write) -> bool;
   auto addressException(u64 vaddr) -> void;
+  auto emuxException(u8 kind) -> void;
 
   template <u32 Size> auto readDebug(u64 vaddr) -> u64;
   template <u32 Size> auto writeDebug(u64 vaddr, u64 data) -> bool;
@@ -352,6 +350,7 @@ struct CPU : Thread {
     auto coprocessor3() -> void;
     auto arithmeticOverflow() -> void;
     auto trap() -> void;
+    auto emux() -> void;
     auto floatingPoint() -> void;
     auto watchAddress() -> void;
     auto nmi() -> void;
@@ -639,6 +638,11 @@ struct CPU : Thread {
     struct ParityError {
       n8 diagnostic;  //unused; for R4000 compatibility only
     } parityError;
+
+    //27
+    struct CacheError {
+      n32 unused;     //unused; for R4000 compatibility only
+    } cacheError;
 
     //28
     struct TagLo {
@@ -974,6 +978,40 @@ struct CPU : Thread {
     uint64_t vbase;
     uint64_t pbase;
   } devirtualizeCache;
+
+  //emux.cpp
+  union Profile {
+    struct {
+      s64 cpuCycles;
+      s64 cpuCyclesExc;
+      s64 icacheHits, icacheMisses, icacheWritebacks;
+      s64 dcacheHits, dcacheMisses, dcacheWritebacks;
+    };
+    s64 data[8];
+    Profile() : data{0} {}
+  } profile;
+
+  struct ProfileSlot {
+    Profile cpu;
+    RDRAM::Profile rdram;
+    n1 started = 0;
+
+    static auto global() -> ProfileSlot;
+  };
+
+  std::vector<ProfileSlot> profileSlots;
+
+  struct EmuxState {
+    n64 excMask;
+  } emuxState;
+
+  auto XDETECT(r64& rd, u64 code) -> void;
+  auto XLOG(cr64& rd, cr64& rt, u64 code) -> void;
+  auto XHEXDUMP(cr64& rd, cr64& rt) -> void;
+  auto XPROF(cr64& rd, u64 code) -> void;
+  auto XPROFREAD(cr64& rd, r64& rt) -> void;
+  auto XEXCEPTION(r64& rt) -> void;
+  auto XIOCTL(u64 code) -> void;
 };
 
 extern CPU cpu;

--- a/ares/n64/cpu/dcache.cpp
+++ b/ares/n64/cpu/dcache.cpp
@@ -65,7 +65,7 @@ auto CPU::DataCache::readDebug(u64 vaddr, u32 paddr) -> u64 {
   auto& line = this->line(vaddr);
   if(!line.hit(paddr)) {
     Thread dummyThread{};
-    return bus.read<Size>(paddr, dummyThread, "Ares Debugger");
+    return bus.read<Size>(paddr, dummyThread, RBusDevice::ARES_DEBUGGER);
   }
   return line.read<Size>(paddr);
 }
@@ -89,7 +89,7 @@ auto CPU::DataCache::writeDebug(u64 vaddr, u32 paddr, u64 data) -> void {
   auto& line = this->line(vaddr);
   if(!line.hit(paddr)) {
     Thread dummyThread{};
-    return bus.write<Size>(paddr, data, dummyThread, "Ares Debugger");
+    return bus.write<Size>(paddr, data, dummyThread, RBusDevice::ARES_DEBUGGER);
   }
   line.write<Size>(paddr, data);
 }

--- a/ares/n64/cpu/dcache.cpp
+++ b/ares/n64/cpu/dcache.cpp
@@ -4,11 +4,10 @@ auto CPU::DataCache::Line::hit(u32 paddr) const -> bool {
 
 auto CPU::DataCache::Line::fill(u32 paddr) -> void {
   cpu.step(40 * 2);
-  valid  = 1;
   dirty  = 0;
   tag    = paddr & ~0x0000'0fff;
   fillPc = cpu.ipu.pc;
-  cpu.busReadBurst<DCache>(tag | index, words);
+  valid  = cpu.busReadBurst<DCache>(tag | index, words);
 }
 
 auto CPU::DataCache::Line::writeBack() -> void {
@@ -50,10 +49,15 @@ template<u32 Size>
 auto CPU::DataCache::read(u64 vaddr, u32 paddr) -> u64 {
   auto& line = this->line(vaddr);
   if(!line.hit(paddr)) {
-    if(line.valid && line.dirty) line.writeBack();
+    if(line.valid && line.dirty) {
+      line.writeBack();
+      self.profile.dcacheWritebacks++;
+    }
     line.fill(paddr);
+    self.profile.dcacheMisses++;
   } else {
     cpu.step(1 * 2);
+    self.profile.dcacheHits++;
   }
   return line.read<Size>(paddr);
 }
@@ -74,10 +78,15 @@ template<u32 Size>
 auto CPU::DataCache::write(u64 vaddr, u32 paddr, u64 data) -> void {
   auto& line = this->line(vaddr);
   if(!line.hit(paddr)) {
-    if(line.valid && line.dirty) line.writeBack();
+    if(line.valid && line.dirty) {
+      line.writeBack();
+      self.profile.dcacheWritebacks++;
+    }
     line.fill(paddr);
+    self.profile.dcacheMisses++;
   } else {
     cpu.step(1 * 2);
+    self.profile.dcacheHits++;
   }
   line.write<Size>(paddr, data);
 }

--- a/ares/n64/cpu/debugger.cpp
+++ b/ares/n64/cpu/debugger.cpp
@@ -12,6 +12,9 @@ auto CPU::Debugger::load(Node::Object parent) -> void {
   tracer.exception = parent->append<Node::Debugger::Tracer::Notification>("Exception", "CPU");
   tracer.interrupt = parent->append<Node::Debugger::Tracer::Notification>("Interrupt", "CPU");
   tracer.tlb = parent->append<Node::Debugger::Tracer::Notification>("TLB", "CPU");
+  tracer.emux = parent->append<Node::Debugger::Tracer::Notification>("EMUX", "CPU");
+  tracer.emux->setAutoLineBreak(false);
+  tracer.emux->setTerminal(true);
 }
 
 auto CPU::Debugger::unload() -> void {

--- a/ares/n64/cpu/emux.cpp
+++ b/ares/n64/cpu/emux.cpp
@@ -1,0 +1,193 @@
+// emux - emulator extensions for homebrew developers
+
+auto CPU::ProfileSlot::global() -> ProfileSlot
+{
+  auto p = ProfileSlot{};
+  p.cpu = ::ares::Nintendo64::cpu.profile;
+  p.rdram = ::ares::Nintendo64::rdram.profile;
+  return p;
+}
+
+auto CPU::XDETECT(r64& rd, u64 code) -> void {
+  if(!system.homebrewMode) return;
+  n64 detect = 0;
+  detect.bit(0x20) = 1;  // XDETECT
+  detect.bit(0x25) = 1;  // XLOG
+  detect.bit(0x27) = 1;  // XHEXDUMP
+  detect.bit(0x28) = 1;  // XPROF
+  detect.bit(0x29) = 1;  // XPROFREAD
+  detect.bit(0x2a) = 1;  // XEXCEPTION
+  detect.bit(0x2c) = 1;  // XIOCTL
+  switch(code) {
+  case 0x00: rd.s64 = (s32)detect.bit(0x00, 0x1F); break;
+  case 0x01: rd.s64 = (s32)detect.bit(0x20, 0x3F); break;
+  default:   rd.s64 = 0; break;
+  }
+}
+
+auto CPU::XLOG(cr64& rd, cr64& rt, u64 code) -> void {
+    if(!system.homebrewMode) return;
+
+    auto& emux = debugger.tracer.emux;
+    u64 vaddr = rd.u64;
+    switch (code) {
+    case 0x00:
+        while (1) {
+            char ch = readDebug<Byte>(vaddr++);
+            if(!ch) break;
+            emux->notify(ch);
+        }
+        break;
+    case 0x01:
+        for(u64 n = 0; n < rt.u64; n++) {
+            char ch = readDebug<Byte>(vaddr++);
+            emux->notify(ch);
+        }
+        break;
+    }
+}
+
+auto CPU::XHEXDUMP(cr64& rd, cr64& rt) -> void {
+    if(!system.homebrewMode) return;
+
+    auto& emux = debugger.tracer.emux;
+    u64 vaddr = rd.u64;
+    u64 length = rt.u64 ? rt.u64 : 256;
+    string dump;
+
+    for(u64 n = 0; n < length; n += 16) {
+        dump.append(string{hex(vaddr + n, 16L), " ", hex(vaddr + n - rd.u64, 4L), ": "});
+        u8 mem[16]; u64 l = length - n < 16 ? length - n : 16;
+        for(u64 m = 0; m < l; m++)  mem[m] = readDebug<Byte>(vaddr + n + m);
+        for(u64 m = 0; m < 16; m++) {
+            if(m < l) dump.append(string{hex(mem[m], 2L), " "});
+            else       dump.append("   ");
+            if(m == 7) dump.append(" ");
+        } 
+        dump.append(" |");
+        for(u64 m = 0; m < l; ++m) {
+            if(mem[m] >= 32 && mem[m] <= 126) dump.append(string{(char)mem[m]});
+            else                              dump.append(".");
+        }
+        for(u64 m = l; m < 16; m++) dump.append(" ");
+        dump.append("|\n");
+    }
+
+    emux->notify(dump);
+}
+
+auto CPU::XPROF(cr64& rd, u64 code) -> void {
+    if(!system.homebrewMode) return;
+
+    if(code == 4) {  //reset profiling data
+        profileSlots.clear();
+        return;
+    }
+
+    u64 slot = rd.u64;
+    if (slot >= 1024) return;
+    if(profileSlots.size() <= slot) {
+        profileSlots.resize(slot + 1);
+    }
+
+    auto& prof = profileSlots[slot];
+    auto global = ProfileSlot::global();
+
+    if(code == 1) { //start profiling
+        for (int i=0; i<sizeof(prof.cpu.data)/sizeof(prof.cpu.data[0]); i++) {
+            prof.cpu.data[i] -= global.cpu.data[i];
+        }
+        for (int i=0; i<sizeof(prof.rdram.metrics)/sizeof(prof.rdram.metrics[0]); i++) {
+            prof.rdram.metrics[i].reads  -= global.rdram.metrics[i].reads;
+            prof.rdram.metrics[i].writes -= global.rdram.metrics[i].writes;
+        }
+        prof.started = 1;
+    }
+    if(code == 2) { //stop profiling
+        for (int i=0; i<sizeof(prof.cpu.data)/sizeof(prof.cpu.data[0]); i++) {
+            prof.cpu.data[i] += global.cpu.data[i];
+        }
+        for (int i=0; i<sizeof(prof.rdram.metrics)/sizeof(prof.rdram.metrics[0]); i++) {
+            prof.rdram.metrics[i].reads  += global.rdram.metrics[i].reads;
+            prof.rdram.metrics[i].writes += global.rdram.metrics[i].writes;
+        }
+        prof.started = 0;
+    }
+    if(code == 3) { //clear profiling data
+        prof = {};
+    }
+}
+
+auto CPU::XPROFREAD(cr64& rd, r64& rt) -> void {
+  if(!system.homebrewMode) return;
+
+  i64 slot = (i64)rd.u64;
+  if (slot >= profileSlots.size()) {
+    rt.u64 = 0;
+    return;
+  }
+
+  auto prof = (slot < 0 ? ProfileSlot::global() : profileSlots[slot]);
+
+  u64 code = rt.u64;
+  switch(code) {
+    case 0x0000: rt.u64 = prof.cpu.cpuCycles; break;
+    case 0x0001: rt.u64 = prof.cpu.cpuCyclesExc; break;
+    case 0x0010: rt.u64 = prof.cpu.icacheHits; break;
+    case 0x0011: rt.u64 = prof.cpu.icacheMisses; break;
+    case 0x0012: rt.u64 = prof.cpu.icacheWritebacks; break;
+    case 0x0020: rt.u64 = prof.cpu.dcacheHits; break;
+    case 0x0021: rt.u64 = prof.cpu.dcacheMisses; break;
+    case 0x0022: rt.u64 = prof.cpu.dcacheWritebacks; break;
+    case 0x0300: rt.u64 = prof.rdram.total().total(); break;
+    case 0x0301: rt.u64 = prof.rdram.total().reads; break;
+    case 0x0302: rt.u64 = prof.rdram.total().writes; break;
+    case 0x0310: rt.u64 = prof.rdram.metrics[(u32)RBusDevice::VR4300_ICACHE].total(); break;
+    case 0x0311: rt.u64 = prof.rdram.metrics[(u32)RBusDevice::VR4300_ICACHE].reads; break;
+    case 0x0312: rt.u64 = prof.rdram.metrics[(u32)RBusDevice::VR4300_ICACHE].writes; break;
+    case 0x0320: rt.u64 = prof.rdram.metrics[(u32)RBusDevice::VR4300_DCACHE].total(); break;
+    case 0x0321: rt.u64 = prof.rdram.metrics[(u32)RBusDevice::VR4300_DCACHE].reads; break;
+    case 0x0322: rt.u64 = prof.rdram.metrics[(u32)RBusDevice::VR4300_DCACHE].writes; break;
+    case 0x0330: rt.u64 = prof.rdram.metrics[(u32)RBusDevice::VR4300_UNCACHED].total(); break;
+    case 0x0331: rt.u64 = prof.rdram.metrics[(u32)RBusDevice::VR4300_UNCACHED].reads; break;
+    case 0x0332: rt.u64 = prof.rdram.metrics[(u32)RBusDevice::VR4300_UNCACHED].writes; break;
+    case 0x0340: rt.u64 = prof.rdram.metrics[(u32)RBusDevice::SP_DMA].total(); break;
+    case 0x0341: rt.u64 = prof.rdram.metrics[(u32)RBusDevice::SP_DMA].reads; break;
+    case 0x0342: rt.u64 = prof.rdram.metrics[(u32)RBusDevice::SP_DMA].writes; break;
+    case 0x0350: rt.u64 = prof.rdram.metrics[(u32)RBusDevice::PI_DMA].total(); break;
+    case 0x0351: rt.u64 = prof.rdram.metrics[(u32)RBusDevice::PI_DMA].reads; break;
+    case 0x0352: rt.u64 = prof.rdram.metrics[(u32)RBusDevice::PI_DMA].writes; break;
+    case 0x0360: rt.u64 = prof.rdram.metrics[(u32)RBusDevice::SI_DMA].total(); break;
+    case 0x0361: rt.u64 = prof.rdram.metrics[(u32)RBusDevice::SI_DMA].reads; break;
+    case 0x0362: rt.u64 = prof.rdram.metrics[(u32)RBusDevice::SI_DMA].writes; break;
+    case 0x0370: rt.u64 = prof.rdram.metrics[(u32)RBusDevice::DP_DRAW].total(); break;
+    case 0x0371: rt.u64 = prof.rdram.metrics[(u32)RBusDevice::DP_DRAW].reads; break;
+    case 0x0372: rt.u64 = prof.rdram.metrics[(u32)RBusDevice::DP_DRAW].writes; break;
+    case 0x0380: rt.u64 = prof.rdram.metrics[(u32)RBusDevice::AI_DMA].total(); break;
+    case 0x0381: rt.u64 = prof.rdram.metrics[(u32)RBusDevice::AI_DMA].reads; break;
+    case 0x0382: rt.u64 = prof.rdram.metrics[(u32)RBusDevice::AI_DMA].writes; break;
+    case 0x0390: rt.u64 = prof.rdram.metrics[(u32)RBusDevice::VI_DMA].total(); break;
+    case 0x0391: rt.u64 = prof.rdram.metrics[(u32)RBusDevice::VI_DMA].reads; break;
+    case 0x0392: rt.u64 = prof.rdram.metrics[(u32)RBusDevice::VI_DMA].writes; break;
+    case 0x03A0: rt.u64 = prof.rdram.metrics[(u32)RBusDevice::DP_DMA].total(); break;
+    case 0x03A1: rt.u64 = prof.rdram.metrics[(u32)RBusDevice::DP_DMA].reads; break;
+    case 0x03A2: rt.u64 = prof.rdram.metrics[(u32)RBusDevice::DP_DMA].writes; break;
+    default:     rt.u64 = 0; break;
+  }
+}
+
+auto CPU::XIOCTL(u64 code) -> void {
+  if(!system.homebrewMode) return;
+
+  switch(code) {
+    case 0x1: //exit
+      printf("[emux] Ares exit requested by application\n");
+      platform->event(ares::Event::Shutdown);
+      break;
+  }
+}
+
+auto CPU::XEXCEPTION(r64& rt) -> void {
+  if(!system.homebrewMode) return;
+  emuxState.excMask = rt.u64;
+}

--- a/ares/n64/cpu/exceptions.cpp
+++ b/ares/n64/cpu/exceptions.cpp
@@ -53,6 +53,7 @@ auto CPU::Exception::arithmeticOverflow()      -> void { trigger(12); }
 auto CPU::Exception::trap()                    -> void { trigger(13); }
 auto CPU::Exception::floatingPoint()           -> void { trigger(15); }
 auto CPU::Exception::watchAddress()            -> void { trigger(23); }
+auto CPU::Exception::emux()                    -> void { trigger(24); }
 
 auto CPU::Exception::nmi() -> void {
   self.scc.status.vectorLocation = 1;

--- a/ares/n64/cpu/interpreter-ipu.cpp
+++ b/ares/n64/cpu/interpreter-ipu.cpp
@@ -157,18 +157,25 @@ auto CPU::CACHE(u8 operation, cr64& rs, s16 imm) -> void {
   case 0x14: {  //icache fill
     auto& line = icache.line(access.vaddr);
     line.fill(access.paddr, cpu);
+    profile.icacheMisses++;
     break;
   }
 
   case 0x18: {  //icache hit write back
     auto& line = icache.line(access.vaddr);
-    if(line.hit(access.paddr)) line.writeBack(cpu);
+    if(line.hit(access.paddr)) {
+      line.writeBack(cpu);
+      profile.icacheWritebacks++;
+    }
     break;
   }
 
   case 0x01: {  //dcache index write back invalidate
     auto& line = dcache.line(access.vaddr);
-    if(line.valid && line.dirty) line.writeBack();
+    if(line.valid && line.dirty) {
+      line.writeBack();
+      profile.dcacheWritebacks++;
+    }
     line.valid = 0;
     break;
   }
@@ -192,7 +199,10 @@ auto CPU::CACHE(u8 operation, cr64& rs, s16 imm) -> void {
 
   case 0x0d: {  //dcache create dirty exclusive
     auto& line = dcache.line(access.vaddr);
-    if(!line.hit(access.paddr) && line.dirty) line.writeBack();
+    if(!line.hit(access.paddr) && line.dirty) {
+      line.writeBack();
+      profile.dcacheWritebacks++;
+    }
     line.tag   = access.paddr & ~0xfff;
     line.valid = 1;
     line.dirty = 1;
@@ -211,7 +221,10 @@ auto CPU::CACHE(u8 operation, cr64& rs, s16 imm) -> void {
   case 0x15: {  //dcache hit write back invalidate
     auto& line = dcache.line(access.vaddr);
     if(line.hit(access.paddr)) {
-      if(line.dirty) line.writeBack();
+      if(line.dirty) {
+        line.writeBack();
+        profile.dcacheWritebacks++;
+      }
       line.valid = 0;
     }
     break;
@@ -220,7 +233,10 @@ auto CPU::CACHE(u8 operation, cr64& rs, s16 imm) -> void {
   case 0x19: {  //dcache hit write back
     auto& line = dcache.line(access.vaddr);
     if(line.hit(access.paddr)) {
-      if(line.dirty) line.writeBack();
+      if(line.dirty) {
+        line.writeBack();
+        profile.dcacheWritebacks++;
+      }
     }
     break;
   }

--- a/ares/n64/cpu/interpreter-scc.cpp
+++ b/ares/n64/cpu/interpreter-scc.cpp
@@ -114,7 +114,7 @@ auto CPU::getControlRegister(n5 index) -> u64 {
     data.bit(0,7) = scc.parityError.diagnostic;
     break;
   case 27:  //cache error (unused)
-    data.bit(0,31) = 0;
+    data.bit(0,31) = scc.cacheError.unused;
     break;
   case 28:  //taglo
     data.bit(6, 7) = scc.tagLo.primaryCacheState;
@@ -250,6 +250,7 @@ auto CPU::setControlRegister(n5 index, n64 data) -> void {
     scc.parityError.diagnostic = data.bit(0,7);
     break;
   case 27:  //cache error (unused)
+    scc.cacheError.unused = 0; // emux spec: writes reset this register to the hardware value (0)
     break;
   case 28:  //taglo
     scc.tagLo.primaryCacheState          = data.bit(6, 7);

--- a/ares/n64/cpu/interpreter.cpp
+++ b/ares/n64/cpu/interpreter.cpp
@@ -2,6 +2,8 @@
 #define RD ipu.r[RDn]
 #define RT ipu.r[RTn]
 #define RS ipu.r[RSn]
+#define XRT ipu.r[XRTn]
+#define XRD ipu.r[XRDn]
 
 #define jp(id, name)      case id: return decoder##name(instruction)
 #define op(id, name, ...) case id: return name(__VA_ARGS__)
@@ -14,6 +16,9 @@
 #define FD     (OP >>  6 & 31)
 #define FS     (OP >> 11 & 31)
 #define FT     (OP >> 16 & 31)
+#define XRTn   (OP >> 15 & 31)
+#define XRDn   (OP >> 20 & 31)
+#define XCODE  (OP >> 6  & 511)
 #define IMMi16 s16(OP)
 #define IMMu16 u16(OP)
 #define IMMu26 (OP & 0x03ff'ffff)
@@ -219,6 +224,13 @@ auto CPU::decoderSCC(u32 instruction) -> void {
   op(0x06, TLBWR);
   op(0x08, TLBP);
   br(0x18, ERET);
+  op(0x20, XDETECT, XRD, XCODE);
+  op(0x25, XLOG, XRD, XRT, XCODE);
+  op(0x27, XHEXDUMP, XRD, XRT);
+  op(0x28, XPROF, XRD, XCODE);
+  op(0x29, XPROFREAD, XRD, XRT);
+  op(0x2a, XEXCEPTION, XRT);
+  op(0x2c, XIOCTL, XCODE);
   }
 
   //undefined instructions do not throw a reserved instruction exception
@@ -379,6 +391,8 @@ auto CPU::INVALID() -> void {
   exception.reservedInstruction();
 }
 
+#undef XRD
+#undef XRT
 #undef SA
 #undef RDn
 #undef RTn
@@ -386,6 +400,9 @@ auto CPU::INVALID() -> void {
 #undef FD
 #undef FS
 #undef FT
+#undef XRTn
+#undef XRDn
+#undef XCODE
 #undef IMMi16
 #undef IMMu16
 #undef IMMu26

--- a/ares/n64/cpu/memory.cpp
+++ b/ares/n64/cpu/memory.cpp
@@ -132,8 +132,8 @@ inline auto CPU::busWrite(u32 address, u64 data) -> void {
 }
 
 template<u32 Size>
-inline auto CPU::busWriteBurst(u32 address, u32 *data) -> void {
-  bus.writeBurst<Size>(address, data, *this);
+inline auto CPU::busWriteBurst(u32 address, u32 *data) -> bool {
+  return bus.writeBurst<Size>(address, data, *this);
 }
 
 template<u32 Size>
@@ -142,7 +142,7 @@ inline auto CPU::busRead(u32 address) -> u64 {
 }
 
 template<u32 Size>
-inline auto CPU::busReadBurst(u32 address, u32 *data) -> void {
+inline auto CPU::busReadBurst(u32 address, u32 *data) -> bool {
   return bus.readBurst<Size>(address, data, *this);
 }
 
@@ -217,6 +217,10 @@ auto CPU::addressException(u64 vaddr) -> void {
   scc.context.badVirtualAddress = vaddr >> 13;
   scc.xcontext.badVirtualAddress = vaddr >> 13;
   scc.xcontext.region = vaddr >> 62;
+}
+
+auto CPU::emuxException(u8 kind) -> void {
+  scc.cacheError.unused = kind;
 }
 
 template auto CPU::writeDebug<Byte>(u64, u64) -> bool;

--- a/ares/n64/cpu/memory.cpp
+++ b/ares/n64/cpu/memory.cpp
@@ -128,7 +128,7 @@ auto CPU::devirtualizeDebug(u64 vaddr) -> u64 {
 
 template<u32 Size>
 inline auto CPU::busWrite(u32 address, u64 data) -> void {
-  bus.write<Size>(address, data, *this, "CPU");
+  bus.write<Size>(address, data, *this, RBusDevice::VR4300_UNCACHED);
 }
 
 template<u32 Size>
@@ -138,7 +138,7 @@ inline auto CPU::busWriteBurst(u32 address, u32 *data) -> void {
 
 template<u32 Size>
 inline auto CPU::busRead(u32 address) -> u64 {
-  return bus.read<Size>(address, *this, "CPU");
+  return bus.read<Size>(address, *this, RBusDevice::VR4300_UNCACHED);
 }
 
 template<u32 Size>
@@ -167,7 +167,7 @@ auto CPU::readDebug(u64 vaddr) -> u64 {
   auto access = devirtualize<Read, Size>(vaddr, false, false);
   if(!access) return 0;
   if(access.cache) return dcache.readDebug<Size>(access.vaddr, access.paddr);
-  return bus.read<Size>(access.paddr, dummyThread, "Ares Debugger");
+  return bus.read<Size>(access.paddr, dummyThread, RBusDevice::ARES_DEBUGGER);
 }
 
 
@@ -186,7 +186,7 @@ auto CPU::writeDebug(u64 vaddr, u64 data) -> bool {
   if(!access) return false;
   GDB::server.reportMemWrite(access.vaddr, Size);
   if(access.cache) return dcache.writeDebug<Size>(access.vaddr, access.paddr, data), true;
-  return bus.write<Size>(access.paddr, data, dummyThread, "Ares Debugger"), true;
+  return bus.write<Size>(access.paddr, data, dummyThread, RBusDevice::ARES_DEBUGGER), true;
 }
 
 template<u32 Size>

--- a/ares/n64/cpu/recompiler.cpp
+++ b/ares/n64/cpu/recompiler.cpp
@@ -103,6 +103,9 @@ auto CPU::Recompiler::emit(u64 vaddr, u32 address, bool singleInstruction) -> Bl
 #define Fdn (instruction >>  6 & 31)
 #define Fsn (instruction >> 11 & 31)
 #define Ftn (instruction >> 16 & 31)
+#define XRtn   (instruction >> 15 & 31)
+#define XRdn   (instruction >> 20 & 31)
+#define XCODE  (instruction >> 6  & 511)
 
 #define Rd        IpuReg(r[0]) + Rdn * sizeof(r64)
 #define Rt        IpuReg(r[0]) + Rtn * sizeof(r64)
@@ -117,6 +120,9 @@ auto CPU::Recompiler::emit(u64 vaddr, u32 address, bool singleInstruction) -> Bl
 #define Fd        FpuReg(r[0]) + Fdn * sizeof(r64)
 #define Fs        FpuReg(r[0]) + Fsn * sizeof(r64)
 #define Ft        FpuReg(r[0]) + Ftn * sizeof(r64)
+
+#define XRd       IpuReg(r[0]) + XRdn * sizeof(r64)
+#define XRt       IpuReg(r[0]) + XRtn * sizeof(r64)
 
 #define i16 s16(instruction)
 #define n16 u16(instruction)
@@ -1145,6 +1151,48 @@ auto CPU::Recompiler::emitSCC(u32 instruction) -> bool {
     return 1;
   }
 
+  //XDETECT
+  case 0x20: {
+    callf(&CPU::XDETECT, mem(XRd), imm(XCODE));
+    return 0;
+  }
+
+  //XLOG
+  case 0x25: {
+    callf(&CPU::XLOG, mem(XRd), mem(XRt), imm(XCODE));
+    return 0;
+  }
+
+  //XHEXDUMP
+  case 0x27: {
+    callf(&CPU::XHEXDUMP, mem(XRd), mem(XRt));
+    return 0;
+  }
+
+  //XPROF
+  case 0x28: {
+    callf(&CPU::XPROF, mem(XRd), imm(XCODE));
+    return 0;
+  }
+
+  //XPROFREAD
+  case 0x29: {
+    callf(&CPU::XPROFREAD, mem(XRd), mem(XRt));
+    return 0;
+  }
+
+  //XEXCEPTION
+  case 0x2a: {
+    callf(&CPU::XEXCEPTION, mem(XRt));
+    return 0;
+  }
+
+  //XIOCTL
+  case 0x2c: {
+    callf(&CPU::XIOCTL, imm(XCODE));
+    return 0;
+  }
+
   }
 
   return 0;
@@ -1781,6 +1829,9 @@ auto CPU::Recompiler::emitCOP2(u32 instruction) -> bool {
 #undef Fdn
 #undef Fsn
 #undef Ftn
+#undef XRtn
+#undef XRdn
+#undef XCODE
 #undef Rd
 #undef Rt
 #undef Rt32
@@ -1793,6 +1844,8 @@ auto CPU::Recompiler::emitCOP2(u32 instruction) -> bool {
 #undef Fd
 #undef Fs
 #undef Ft
+#undef XRd
+#undef XRt
 #undef i16
 #undef n16
 #undef n26

--- a/ares/n64/cpu/recompiler.cpp
+++ b/ares/n64/cpu/recompiler.cpp
@@ -47,7 +47,7 @@ auto CPU::Recompiler::emit(u64 vaddr, u32 address, bool singleInstruction) -> Bl
   constexpr u32 branchToSelf = 0x1000'ffff;  //beq 0,0,<pc>
   u32 jumpToSelf = 2 << 26 | vaddr >> 2 & 0x3ff'ffff;  //j <pc>
   while(true) {
-    u32 instruction = bus.read<Word>(address, thread, "Ares Recompiler");
+    u32 instruction = bus.read<Word>(address, thread, RBusDevice::ARES_JIT);
     mov32(PipelineReg(nstate), imm(0));
     mov64(reg(0), PipelineReg(nextpc));
     mov64(PipelineReg(pc), reg(0));

--- a/ares/n64/cpu/serialization.cpp
+++ b/ares/n64/cpu/serialization.cpp
@@ -114,6 +114,7 @@ auto CPU::serialize(serializer& s) -> void {
   s(scc.xcontext.region);
   s(scc.xcontext.pageTableEntryBase);
   s(scc.parityError.diagnostic);
+  s(scc.cacheError.unused);
   s(scc.tagLo.primaryCacheState);
   s(scc.tagLo.physicalAddress);
   s(scc.epcError);

--- a/ares/n64/memory/bus.hpp
+++ b/ares/n64/memory/bus.hpp
@@ -25,13 +25,13 @@ inline auto Bus::read(u32 address, Thread& thread, RBusDevice device) -> u64 {
 }
 
 template<u32 Size>
-inline auto Bus::readBurst(u32 address, u32 *data, Thread& thread) -> void {
+inline auto Bus::readBurst(u32 address, u32 *data, Thread& thread) -> bool {
   static_assert(Size == DCache || Size == ICache);
   RBusDevice device;
   if constexpr(Size == DCache) device = RBusDevice::VR4300_DCACHE;
   if constexpr(Size == ICache) device = RBusDevice::VR4300_ICACHE;
 
-  if(address <= 0x03ef'ffff) return rdram.ram.readBurst<Size>(address, data, device);
+  if(address <= 0x03ef'ffff) return rdram.ram.readBurst<Size>(address, data, device), true;
   if(address <= 0x03ff'ffff) {
     // FIXME: not hardware validated, no idea of the behavior
     data[0] = rdram.readWord(address | 0x0, thread);
@@ -44,15 +44,15 @@ inline auto Bus::readBurst(u32 address, u32 *data, Thread& thread) -> void {
       data[6] = 0;
       data[7] = 0;
     }
-    return;
+    return true;
   }
 
   if(Model::Aleck64()) {
-    if(address <= 0xbfff'ffff) return freezeUncached(address);
-    if(address <= 0xc07f'ffff) return aleck64.sdram.readBurst<Size>(address, data, device);
+    if(address <= 0xbfff'ffff) return freezeUncached(address), false;
+    if(address <= 0xc07f'ffff) return aleck64.sdram.readBurst<Size>(address, data, device), true;
   }
 
-  return freezeUncached(address);
+  return freezeUncached(address), false;
 }
 
 template<u32 Size>
@@ -85,7 +85,7 @@ inline auto Bus::write(u32 address, u64 data, Thread& thread, RBusDevice device)
 }
 
 template<u32 Size>
-inline auto Bus::writeBurst(u32 address, u32 *data, Thread& thread) -> void {
+inline auto Bus::writeBurst(u32 address, u32 *data, Thread& thread) -> bool {
   static_assert(Size == DCache || Size == ICache);
   RBusDevice device;
   if constexpr(Size == DCache) device = RBusDevice::VR4300_DCACHE;
@@ -95,32 +95,47 @@ inline auto Bus::writeBurst(u32 address, u32 *data, Thread& thread) -> void {
     cpu.recompiler.invalidateRange(address, Size == DCache ? 16 : 32);
   }
 
-  if(address <= 0x03ef'ffff) return rdram.ram.writeBurst<Size>(address, data, device);
+  if(address <= 0x03ef'ffff) return rdram.ram.writeBurst<Size>(address, data, device), true;
   if(address <= 0x03ff'ffff) {
     // FIXME: not hardware validated, but a good guess
     rdram.writeWord(address | 0x0, data[0], thread);
-    return;
+    return true;
   }
 
   if(Model::Aleck64()) {
-    if(address <= 0xbfff'ffff) return freezeUncached(address);
-    if(address <= 0xc07f'ffff) return aleck64.sdram.writeBurst<Size>(address, data, device);
+    if(address <= 0xbfff'ffff) return freezeUncached(address), false;
+    if(address <= 0xc07f'ffff) return aleck64.sdram.writeBurst<Size>(address, data, device), true;
   }
 
-  return freezeUncached(address);
+  return freezeUncached(address), false;
 }
 
 inline auto Bus::freezeUnmapped(u32 address) -> void {
-  debug(unusual, "[Bus::freezeUnmapped] CPU frozen because of access to RCP unmapped area: 0x", hex(address, 8L));
+  debug(unusual, "[Bus::freezeUnmapped] CPU frozen because of access to RCP unmapped area: 0x", hex(address, 8L), " (PC: ", hex(cpu.ipu.pc, 8L), ")");
+  if(system.homebrewMode && cpu.emuxState.excMask.bit(3)) {
+    cpu.emuxException(3);
+    cpu.exception.emux();
+    return;
+  }
   cpu.scc.sysadFrozen = true;
 }
 
 inline auto Bus::freezeUncached(u32 address) -> void {
-  debug(unusual, "[Bus::freezeUncached] CPU frozen because of cached access to non-RDRAM area: 0x", hex(address, 8L));
+  debug(unusual, "[Bus::freezeUncached] CPU frozen because of cached access to non-RDRAM area: 0x", hex(address, 8L), " (PC: ", hex(cpu.ipu.pc, 8L), ")");
+  if(system.homebrewMode && cpu.emuxState.excMask.bit(1)) {
+    cpu.emuxException(1);
+    cpu.exception.emux();
+    return;
+  }
   cpu.scc.sysadFrozen = true;
 }
 
 inline auto Bus::freezeDualRead(u32 address) -> void {
-  debug(unusual, "[Bus::freezeDualRead] CPU frozen because of 64-bit read from non-RDRAM area: 0x ", hex(address, 8L));
+  debug(unusual, "[Bus::freezeDualRead] CPU frozen because of 64-bit read from non-RDRAM area: 0x ", hex(address, 8L), " (PC: ", hex(cpu.ipu.pc, 8L), ")");
+  if(system.homebrewMode && cpu.emuxState.excMask.bit(2)) {
+    cpu.emuxException(2);
+    cpu.exception.emux();
+    return;
+  }
   cpu.scc.sysadFrozen = true;
 }

--- a/ares/n64/memory/bus.hpp
+++ b/ares/n64/memory/bus.hpp
@@ -1,8 +1,8 @@
 template<u32 Size>
-inline auto Bus::read(u32 address, Thread& thread, const char *peripheral) -> u64 {
+inline auto Bus::read(u32 address, Thread& thread, RBusDevice device) -> u64 {
   static_assert(Size == Byte || Size == Half || Size == Word || Size == Dual);
 
-  if(address <= 0x03ef'ffff) return rdram.ram.read<Size>(address, peripheral);
+  if(address <= 0x03ef'ffff) return rdram.ram.read<Size>(address, device);
   if(address <= 0x03ff'ffff) return rdram.read<Size>(address, thread);
   if(Size == Dual)           return freezeDualRead(address), 0;
   if(address <= 0x0407'ffff) return rsp.read<Size>(address, thread);
@@ -27,8 +27,11 @@ inline auto Bus::read(u32 address, Thread& thread, const char *peripheral) -> u6
 template<u32 Size>
 inline auto Bus::readBurst(u32 address, u32 *data, Thread& thread) -> void {
   static_assert(Size == DCache || Size == ICache);
+  RBusDevice device;
+  if constexpr(Size == DCache) device = RBusDevice::VR4300_DCACHE;
+  if constexpr(Size == ICache) device = RBusDevice::VR4300_ICACHE;
 
-  if(address <= 0x03ef'ffff) return rdram.ram.readBurst<Size>(address, data, "CPU");
+  if(address <= 0x03ef'ffff) return rdram.ram.readBurst<Size>(address, data, device);
   if(address <= 0x03ff'ffff) {
     // FIXME: not hardware validated, no idea of the behavior
     data[0] = rdram.readWord(address | 0x0, thread);
@@ -46,21 +49,21 @@ inline auto Bus::readBurst(u32 address, u32 *data, Thread& thread) -> void {
 
   if(Model::Aleck64()) {
     if(address <= 0xbfff'ffff) return freezeUncached(address);
-    if(address <= 0xc07f'ffff) return aleck64.sdram.readBurst<Size>(address, data, "CPU");
+    if(address <= 0xc07f'ffff) return aleck64.sdram.readBurst<Size>(address, data, device);
   }
 
   return freezeUncached(address);
 }
 
 template<u32 Size>
-inline auto Bus::write(u32 address, u64 data, Thread& thread, const char *peripheral) -> void {
+inline auto Bus::write(u32 address, u64 data, Thread& thread, RBusDevice device) -> void {
   static_assert(Size == Byte || Size == Half || Size == Word || Size == Dual);
   if constexpr(Accuracy::CPU::Recompiler) {
     cpu.recompiler.invalidate(address + 0); if constexpr(Size == Dual)
     cpu.recompiler.invalidate(address + 4);
   }
 
-  if(address <= 0x03ef'ffff) return rdram.ram.write<Size>(address, data, peripheral);
+  if(address <= 0x03ef'ffff) return rdram.ram.write<Size>(address, data, device);
   if(address <= 0x03ff'ffff) return rdram.write<Size>(address, data, thread);
   if(address <= 0x0407'ffff) return rsp.write<Size>(address, data, thread);
   if(address <= 0x040b'ffff) return rsp.status.write<Size>(address, data, thread);
@@ -84,11 +87,15 @@ inline auto Bus::write(u32 address, u64 data, Thread& thread, const char *periph
 template<u32 Size>
 inline auto Bus::writeBurst(u32 address, u32 *data, Thread& thread) -> void {
   static_assert(Size == DCache || Size == ICache);
+  RBusDevice device;
+  if constexpr(Size == DCache) device = RBusDevice::VR4300_DCACHE;
+  if constexpr(Size == ICache) device = RBusDevice::VR4300_ICACHE;
+
   if constexpr(Accuracy::CPU::Recompiler) {
     cpu.recompiler.invalidateRange(address, Size == DCache ? 16 : 32);
   }
 
-  if(address <= 0x03ef'ffff) return rdram.ram.writeBurst<Size>(address, data, "CPU");
+  if(address <= 0x03ef'ffff) return rdram.ram.writeBurst<Size>(address, data, device);
   if(address <= 0x03ff'ffff) {
     // FIXME: not hardware validated, but a good guess
     rdram.writeWord(address | 0x0, data[0], thread);
@@ -97,7 +104,7 @@ inline auto Bus::writeBurst(u32 address, u32 *data, Thread& thread) -> void {
 
   if(Model::Aleck64()) {
     if(address <= 0xbfff'ffff) return freezeUncached(address);
-    if(address <= 0xc07f'ffff) return aleck64.sdram.writeBurst<Size>(address, data, "CPU");
+    if(address <= 0xc07f'ffff) return aleck64.sdram.writeBurst<Size>(address, data, device);
   }
 
   return freezeUncached(address);

--- a/ares/n64/memory/memory.hpp
+++ b/ares/n64/memory/memory.hpp
@@ -31,8 +31,8 @@ namespace Memory {
 
 struct Bus {
   //bus.hpp
-  template<u32 Size> auto read(u32 address, Thread& thread, const char *peripheral) -> u64;
-  template<u32 Size> auto write(u32 address, u64 data, Thread& thread, const char *peripheral) -> void;
+  template<u32 Size> auto read(u32 address, Thread& thread, RBusDevice device) -> u64;
+  template<u32 Size> auto write(u32 address, u64 data, Thread& thread, RBusDevice device) -> void;
 
   template<u32 Size> auto readBurst(u32 address, u32* data, Thread& thread) -> void;
   template<u32 Size> auto writeBurst(u32 address, u32* data, Thread& thread) -> void;

--- a/ares/n64/memory/memory.hpp
+++ b/ares/n64/memory/memory.hpp
@@ -34,8 +34,8 @@ struct Bus {
   template<u32 Size> auto read(u32 address, Thread& thread, RBusDevice device) -> u64;
   template<u32 Size> auto write(u32 address, u64 data, Thread& thread, RBusDevice device) -> void;
 
-  template<u32 Size> auto readBurst(u32 address, u32* data, Thread& thread) -> void;
-  template<u32 Size> auto writeBurst(u32 address, u32* data, Thread& thread) -> void;
+  template<u32 Size> auto readBurst(u32 address, u32* data, Thread& thread) -> bool;
+  template<u32 Size> auto writeBurst(u32 address, u32* data, Thread& thread) -> bool;
 
   auto freezeUnmapped(u32 address) -> void;
   auto freezeUncached(u32 address) -> void;

--- a/ares/n64/n64.hpp
+++ b/ares/n64/n64.hpp
@@ -98,6 +98,31 @@ namespace ares::Nintendo64 {
     static auto decode(u8 value) -> u8 { return (value >> 4) * 10 + (value & 15); }
   };
 
+  //Devices that can request RI to access RDRAM
+  enum class RBusDevice {
+    UNKNOWN,
+    VR4300_ICACHE,
+    VR4300_DCACHE,
+    VR4300_UNCACHED,
+    SP_DMA,
+    PI_DMA,
+    SI_DMA,
+    VI_DMA,
+    AI_DMA,
+    DP_DMA,
+    DP_DRAW,
+
+    NUM_RBUS_HW_DEVICES,
+    
+    //Virtual devices (internal to Ares)
+    ARES_DEBUGGER = NUM_RBUS_HW_DEVICES,
+    ARES_JIT,
+    ARES_IPL3,
+    ARES_FLASH,
+
+    NUM_RBUS_DEVICES,
+  };
+
   #include <n64/accuracy.hpp>
   #include <n64/memory/memory.hpp>
   #include <n64/system/system.hpp>
@@ -113,8 +138,8 @@ namespace ares::Nintendo64 {
   #include <n64/pif/pif.hpp>
   #include <n64/ri/ri.hpp>
   #include <n64/si/si.hpp>
-  #include <n64/cpu/cpu.hpp>
   #include <n64/rdram/rdram.hpp>
+  #include <n64/cpu/cpu.hpp>
   #include <n64/rsp/rsp.hpp>
   #include <n64/rdp/rdp.hpp>
   #include <n64/memory/bus.hpp>

--- a/ares/n64/pi/dma.cpp
+++ b/ares/n64/pi/dma.cpp
@@ -3,7 +3,7 @@ auto PI::dmaRead() -> void {
 
   u32 lastCacheline = 0xffff'ffff;
   for(u32 address = 0; address < io.readLength; address += 2) {
-    u16 data = rdram.ram.read<Half>(io.dramAddress + address, "PI DMA");
+    u16 data = rdram.ram.read<Half>(io.dramAddress + address, RBusDevice::PI_DMA);
     busWrite<Half>(io.pbusAddress + address, data);
   }
 }
@@ -34,12 +34,12 @@ auto PI::dmaWrite() -> void {
 
     if (firstBlock && curLen < 127-misalign) {
       for (i32 i = 0; i < curLen-misalign; i++) {
-        rdram.ram.write<Byte>(io.dramAddress++, mem[i], "PI DMA");
+        rdram.ram.write<Byte>(io.dramAddress++, mem[i], RBusDevice::PI_DMA);
       }
     } else {
       for (i32 i = 0; i < curLen-misalign; i+=2) {
-        rdram.ram.write<Byte>(io.dramAddress++, mem[i+0], "PI DMA");
-        rdram.ram.write<Byte>(io.dramAddress++, mem[i+1], "PI DMA");
+        rdram.ram.write<Byte>(io.dramAddress++, mem[i+0], RBusDevice::PI_DMA);
+        rdram.ram.write<Byte>(io.dramAddress++, mem[i+1], RBusDevice::PI_DMA);
       }
     }
 

--- a/ares/n64/pif/io.cpp
+++ b/ares/n64/pif/io.cpp
@@ -31,13 +31,13 @@ auto PIF::dmaRead(u32 address, u32 ramAddress) -> void {
   intA(Read, Size64);
   for(u32 offset = 0; offset < 64; offset += 4) {
     u32 data = readInt(address + offset);
-    rdram.ram.write<Word>(ramAddress + offset, data, "SI DMA");
+    rdram.ram.write<Word>(ramAddress + offset, data, RBusDevice::SI_DMA);
   }
 }
 
 auto PIF::dmaWrite(u32 address, u32 ramAddress) -> void {
   for(u32 offset = 0; offset < 64; offset += 4) {
-    u32 data = rdram.ram.read<Word>(ramAddress + offset, "SI DMA");
+    u32 data = rdram.ram.read<Word>(ramAddress + offset, RBusDevice::SI_DMA);
     writeInt(address + offset, data);
   }
   intA(Write, Size64);

--- a/ares/n64/rdram/debugger.cpp
+++ b/ares/n64/rdram/debugger.cpp
@@ -7,10 +7,10 @@ auto RDRAM::Debugger::load(Node::Object parent) -> void {
   }
   
   memory.ram->setRead([&](u32 address) -> u8 {
-    return rdram.ram.read<Byte>(address, "Ares Debugger");
+    return rdram.ram.read<Byte>(address, RBusDevice::ARES_DEBUGGER);
   });
   memory.ram->setWrite([&](u32 address, u8 data) -> void {
-    return rdram.ram.write<Byte>(address, data, "Ares Debugger");
+    return rdram.ram.write<Byte>(address, data, RBusDevice::ARES_DEBUGGER);
   });
 
   memory.dcache = parent->append<Node::Debugger::Memory>("DCache");
@@ -25,7 +25,7 @@ auto RDRAM::Debugger::load(Node::Object parent) -> void {
     if(line.hit(address)) {
       line.write<Byte>(address, data);
     } else {
-      rdram.ram.write<Byte>(address, data, "Ares Debugger");
+      rdram.ram.write<Byte>(address, data, RBusDevice::ARES_DEBUGGER);
     }
   });
 
@@ -80,29 +80,29 @@ auto RDRAM::Debugger::cacheErrorContext(string peripheral) -> string {
   return "";
 }
 
-auto RDRAM::Debugger::readWord(u32 address, int size, const char *peripheral) -> void {
+auto RDRAM::Debugger::readWord(u32 address, int size, RBusDevice device) -> void {
   if (system.homebrewMode && (address & ~15) != lastReadCacheline) {
     lastReadCacheline = address & ~15;
     auto& line = cpu.dcache.line(address);
     u16 dirtyMask = ((1 << size) - 1) << (address & 0xF);
     if (line.hit(address) && (line.dirty & dirtyMask)) {
-      string msg = { peripheral, " reading from RDRAM address 0x", hex(address), " which is modified in the cache (missing cache writeback?)\n"};
+      string msg = { rdram.requestorName(device), " reading from RDRAM address 0x", hex(address), " which is modified in the cache (missing cache writeback?)\n"};
       msg.append(string{ "\tCacheline was loaded at CPU PC: 0x", hex(line.fillPc, 16L), "\n" });
       msg.append(string{ "\tCacheline was last written at CPU PC: 0x", hex(line.dirtyPc, 16L), "\n" });
-      msg.append(cacheErrorContext(peripheral));
+      msg.append(cacheErrorContext(rdram.requestorName(device)));
       debug(unusual, msg);
     }
   }
 }
 
-auto RDRAM::Debugger::writeWord(u32 address, int size, u64 value, const char *peripheral) -> void {
+auto RDRAM::Debugger::writeWord(u32 address, int size, u64 value, RBusDevice device) -> void {
   if (system.homebrewMode && (address & ~15) != lastWrittenCacheline) {
     lastWrittenCacheline = address & ~15;
     auto& line = cpu.dcache.line(address);
     if (line.hit(address)) {
-      string msg = { peripheral, " writing to RDRAM address 0x", hex(address), " which is cached (missing cache invalidation?)\n"};
+      string msg = { rdram.requestorName(device), " writing to RDRAM address 0x", hex(address), " which is cached (missing cache invalidation?)\n"};
       msg.append(string{ "\tCacheline was loaded at CPU PC: 0x", hex(line.fillPc, 16L), "\n" });
-      msg.append(cacheErrorContext(peripheral));
+      msg.append(cacheErrorContext(rdram.requestorName(device)));
       debug(unusual, msg);
     }
   }

--- a/ares/n64/rdram/debugger.cpp
+++ b/ares/n64/rdram/debugger.cpp
@@ -64,11 +64,11 @@ auto RDRAM::Debugger::cacheErrorContext(string peripheral) -> string {
   if(peripheral == "CPU") {
     return { "\tCurrent CPU PC: 0x", hex(cpu.ipu.pc, 16L), "\n" };
   }
-  if(peripheral == "RSP DMA") {
+  if(peripheral == "SP DMA") {
     if(rsp.dma.current.originCpu) {
-      return { "\tRSP DMA started at CPU PC: 0x", hex(rsp.dma.current.originPc, 16L), "\n" };
+      return { "\tSP DMA started at CPU PC: 0x", hex(rsp.dma.current.originPc, 16L), "\n" };
     } else {
-      return { "\tRSP DMA started at RSP PC: 0x", hex(rsp.dma.current.originPc,  3L), "\n" };
+      return { "\tSP DMA started at RSP PC: 0x", hex(rsp.dma.current.originPc,  3L), "\n" };
     }
   }
   if(peripheral == "PI DMA") {
@@ -86,6 +86,7 @@ auto RDRAM::Debugger::readWord(u32 address, int size, RBusDevice device) -> void
     auto& line = cpu.dcache.line(address);
     u16 dirtyMask = ((1 << size) - 1) << (address & 0xF);
     if (line.hit(address) && (line.dirty & dirtyMask)) {
+      if(device == RBusDevice::SP_DMA) return; // ignore: prefer deferring to actual DMEM access, see RSP::Debugger::dmemReadWord
       string msg = { rdram.requestorName(device), " reading from RDRAM address 0x", hex(address), " which is modified in the cache (missing cache writeback?)\n"};
       msg.append(string{ "\tCacheline was loaded at CPU PC: 0x", hex(line.fillPc, 16L), "\n" });
       msg.append(string{ "\tCacheline was last written at CPU PC: 0x", hex(line.dirtyPc, 16L), "\n" });

--- a/ares/n64/rdram/rdram.cpp
+++ b/ares/n64/rdram/rdram.cpp
@@ -32,6 +32,7 @@ auto RDRAM::power(bool reset) -> void {
     ram.fill();
     for(auto& chip : chips) chip = {};
   }
+  profile = {};
 }
 
 }

--- a/ares/n64/rdram/rdram.hpp
+++ b/ares/n64/rdram/rdram.hpp
@@ -9,10 +9,10 @@ struct RDRAM : Memory::RCP<RDRAM> {
     Writable(RDRAM& self) : self(self) {}
 
     template<u32 Size>
-    auto read(u32 address, const char *peripheral) -> u64 {
+    auto read(u32 address, RBusDevice device) -> u64 {
       if (address >= size) return 0;
-      if (unlikely(peripheral && system.homebrewMode)) {
-        self.debugger.readWord(address, Size, peripheral);
+      if (unlikely(system.homebrewMode)) {
+        self.debugger.readWord(address, Size, device);
       }
       return Memory::Writable::read<Size>(address);
     }
@@ -76,10 +76,10 @@ struct RDRAM : Memory::RCP<RDRAM> {
     }
 
     template<u32 Size>
-    auto write(u32 address, u64 value, const char *peripheral) -> void {
+    auto write(u32 address, u64 value, RBusDevice device) -> void {
       if (address >= size) return;
-      if (unlikely(peripheral && system.homebrewMode)) {
-        self.debugger.writeWord(address, Size, value, peripheral);
+      if (unlikely(system.homebrewMode)) {
+        self.debugger.writeWord(address, Size, value, device);
       }
       if (unlikely(mi.initializeMode())) {
         writeRepeat<Size>(address, value, mi.initializeLength()+1);
@@ -89,7 +89,7 @@ struct RDRAM : Memory::RCP<RDRAM> {
     }
 
     template<u32 Size>
-    auto writeBurst(u32 address, u32 *value, const char *peripheral) -> void {
+    auto writeBurst(u32 address, u32 *value, RBusDevice device) -> void {
       if (address >= size) return;
       Memory::Writable::write<Word>(address | 0x00, value[0]);
       Memory::Writable::write<Word>(address | 0x04, value[1]);
@@ -104,7 +104,7 @@ struct RDRAM : Memory::RCP<RDRAM> {
     }
 
     template<u32 Size>
-    auto readBurst(u32 address, u32 *value, const char *peripheral) -> void {
+    auto readBurst(u32 address, u32 *value, RBusDevice device) -> void {
       if (address >= size) {
         value[0] = value[1] = value[2] = value[3] = 0;
         if (Size == ICache)
@@ -132,9 +132,9 @@ struct RDRAM : Memory::RCP<RDRAM> {
     //debugger.cpp
     auto load(Node::Object) -> void;
     auto io(bool mode, u32 chipID, u32 address, u32 data) -> void;
-    auto readWord(u32 address, int size, const char *peripheral) -> void;
-    auto writeWord(u32 address, int size, u64 value, const char *peripheral) -> void;
-    auto cacheErrorContext(string peripheral) -> string;
+    auto readWord(u32 address, int size, RBusDevice device) -> void;
+    auto writeWord(u32 address, int size, u64 value, RBusDevice device) -> void;
+    auto cacheErrorContext(string device) -> string;
 
     struct Memory {
       Node::Debugger::Memory ram;
@@ -147,6 +147,24 @@ struct RDRAM : Memory::RCP<RDRAM> {
   } debugger;
 
   //rdram.cpp
+  auto requestorName(RBusDevice requestor) -> const char* {
+    switch(requestor) {
+      case RBusDevice::VR4300_ICACHE:   return "VR4300 ICache";
+      case RBusDevice::VR4300_DCACHE:   return "VR4300 DCache";
+      case RBusDevice::VR4300_UNCACHED: return "VR4300 Uncached";
+      case RBusDevice::SP_DMA:          return "SP DMA";
+      case RBusDevice::PI_DMA:          return "PI DMA";
+      case RBusDevice::SI_DMA:          return "SI DMA";
+      case RBusDevice::VI_DMA:          return "VI DMA";
+      case RBusDevice::AI_DMA:          return "AI DMA";
+      case RBusDevice::DP_DMA:          return "DP DMA";
+      case RBusDevice::DP_DRAW:         return "DP Draw";
+      case RBusDevice::ARES_DEBUGGER:   return "Ares Debugger";
+      case RBusDevice::ARES_JIT:        return "Ares JIT";
+      case RBusDevice::ARES_IPL3:       return "Ares IPL3";
+      default:                          return "Unknown";
+    }
+  }
   auto load(Node::Object) -> void;
   auto unload() -> void;
   auto power(bool reset) -> void;

--- a/ares/n64/rdram/rdram.hpp
+++ b/ares/n64/rdram/rdram.hpp
@@ -13,6 +13,7 @@ struct RDRAM : Memory::RCP<RDRAM> {
       if (address >= size) return 0;
       if (unlikely(system.homebrewMode)) {
         self.debugger.readWord(address, Size, device);
+        self.profile.metrics[(u32)device].reads += Size;
       }
       return Memory::Writable::read<Size>(address);
     }
@@ -82,15 +83,25 @@ struct RDRAM : Memory::RCP<RDRAM> {
         self.debugger.writeWord(address, Size, value, device);
       }
       if (unlikely(mi.initializeMode())) {
-        writeRepeat<Size>(address, value, mi.initializeLength()+1);
+        u32 len = mi.initializeLength() + 1;
+        writeRepeat<Size>(address, value, len);
+        if(unlikely(system.homebrewMode)) {
+          self.profile.metrics[(u32)device].writes += len;
+        }
       } else {
         Memory::Writable::write<Size>(address, value);
+        if(unlikely(system.homebrewMode)) {
+          self.profile.metrics[(u32)device].writes += Size;
+        }
       }
     }
 
     template<u32 Size>
     auto writeBurst(u32 address, u32 *value, RBusDevice device) -> void {
       if (address >= size) return;
+      if (unlikely(system.homebrewMode)) {
+        self.profile.metrics[(u32)device].writes += Size;
+      }
       Memory::Writable::write<Word>(address | 0x00, value[0]);
       Memory::Writable::write<Word>(address | 0x04, value[1]);
       Memory::Writable::write<Word>(address | 0x08, value[2]);
@@ -110,6 +121,9 @@ struct RDRAM : Memory::RCP<RDRAM> {
         if (Size == ICache)
           value[4] = value[5] = value[6] = value[7] = 0;
         return;
+      }
+      if (unlikely(system.homebrewMode)) {
+        self.profile.metrics[(u32)device].reads += Size;
       }
       value[0] = Memory::Writable::read<Word>(address | 0x00);
       value[1] = Memory::Writable::read<Word>(address | 0x04);
@@ -165,6 +179,25 @@ struct RDRAM : Memory::RCP<RDRAM> {
       default:                          return "Unknown";
     }
   }
+
+  struct Metric {
+    u64 reads, writes;
+    auto total() const -> u64 { return reads + writes; }
+  };
+  
+  struct Profile {
+    Metric metrics[(u32)RBusDevice::NUM_RBUS_DEVICES];
+
+    auto total() -> Metric {
+      Metric total;
+      for(u32 n = 0; n < (u32)RBusDevice::NUM_RBUS_HW_DEVICES; n++) {
+        total.reads  += metrics[n].reads;
+        total.writes += metrics[n].writes;
+      }
+      return total;
+    }
+  } profile;
+
   auto load(Node::Object) -> void;
   auto unload() -> void;
   auto power(bool reset) -> void;

--- a/ares/n64/ri/ri.cpp
+++ b/ares/n64/ri/ri.cpp
@@ -27,8 +27,8 @@ auto RI::power(bool reset) -> void {
     io.refresh = 0x0006'3634;
 
     //store RDRAM size result into memory
-    rdram.ram.write<Word>(0x318, rdram.ram.size, "IPL3");  //CIC-NUS-6102
-    rdram.ram.write<Word>(0x3f0, rdram.ram.size, "IPL3");  //CIC-NUS-6105
+    rdram.ram.write<Word>(0x318, rdram.ram.size, RBusDevice::ARES_IPL3);  //CIC-NUS-6102
+    rdram.ram.write<Word>(0x3f0, rdram.ram.size, RBusDevice::ARES_IPL3);  //CIC-NUS-6105
   }
 }
 

--- a/ares/n64/rsp/debugger.cpp
+++ b/ares/n64/rsp/debugger.cpp
@@ -29,6 +29,10 @@ auto RSP::Debugger::load(Node::Object parent) -> void {
     });
   }
 
+  tracer.emux = parent->append<Node::Debugger::Tracer::Notification>("EMUX", "RSP");
+  tracer.emux->setAutoLineBreak(false);
+  tracer.emux->setTerminal(true);
+
   tracer.io = parent->append<Node::Debugger::Tracer::Notification>("I/O", "RSP");
 
   if (system.homebrewMode) {
@@ -45,6 +49,7 @@ auto RSP::Debugger::unload() -> void {
   memory.dmem.reset();
   memory.imem.reset();
   tracer.instruction.reset();
+  tracer.emux.reset();
   tracer.io.reset();
 }
 
@@ -52,11 +57,30 @@ auto RSP::Debugger::instruction() -> void {
   if(unlikely(tracer.instruction->enabled())) {
     u32 address = rsp.pipeline.address & 0xfff;
     u32 instruction = rsp.pipeline.instruction;
+    u32 cycle = rsp.pipeline.clocksTotal / 3 - tracer.traceStartCycle;
+
+    bool hasDblIssues = rsp.pipeline.dblIssueCount > 0 && cycle != 0;
+    string cycleStr = hasDblIssues
+      ? string{"   ^"}
+      : pad(cycle, 4, ' ');
+
     if(tracer.instruction->address(address)) {
       rsp.disassembler.showColors = 0;
-      tracer.instruction->notify(rsp.disassembler.disassemble(address, instruction), {});
+      string res{"[", cycleStr, "] ", 
+        "\033[A", // cursor up
+          pad(pad("", rsp.pipeline.stallCount, '*'), 3, ' '),
+        "\033[B", // cursor down
+        " | ",
+        rsp.disassembler.disassemble(address, instruction)
+      };
+      tracer.instruction->notify(res, {});
       rsp.disassembler.showColors = 1;
     }
+  }
+
+  if(tracer.instructionCountdown) {
+    if (--tracer.instructionCountdown == 0)
+      tracer.instruction->setEnabled(false);
   }
 }
 

--- a/ares/n64/rsp/decoder.cpp
+++ b/ares/n64/rsp/decoder.cpp
@@ -4,6 +4,9 @@
 #define RD    (instruction >> 11 & 31)
 #define RT    (instruction >> 16 & 31)
 #define RS    (instruction >> 21 & 31)
+#define XRT   (instruction >> 15 & 31)
+#define XRD   (instruction >> 20 & 31)
+#define XCODE (instruction >> 6  & 511)
 #define VD    (instruction >>  6 & 31)
 #define VS    (instruction >> 11 & 31)
 #define VT    (instruction >> 16 & 31)
@@ -226,6 +229,19 @@ auto RSP::decoderSCC(u32 instruction) const -> OpInfo {
   op(0x0e, INVALID);
   op(0x0f, INVALID);
   }
+
+  switch(instruction & 0x3f) {
+  op(0x20, XDETECT, RDefB(XRD));
+  op(0x23, XTRACESTART);
+  op(0x24, XTRACESTOP);
+  op(0x25, XLOG, RUse(XRD), RUse(XRT));
+  op(0x26, XLOGREGS, RUse(XRD));
+  op(0x27, XHEXDUMP, RUse(XRD), RUse(XRT));
+  op(0x28, XPROF, RUse(XRD));
+  op(0x29, XPROFREAD, RUse(XRD), RUse(XRT), RDefB(XRT));
+  op(0x2a, XEXCEPTION, RUse(XRT));
+  op(0x2c, XIOCTL);
+  }
   return {};
 }
 
@@ -378,6 +394,9 @@ auto RSP::decoderSWC2(u32 instruction) const -> OpInfo {
 #undef RD
 #undef RT
 #undef RS
+#undef XRT
+#undef XRD
+#undef XCODE
 #undef VD
 #undef VS
 #undef VT

--- a/ares/n64/rsp/disassembler.cpp
+++ b/ares/n64/rsp/disassembler.cpp
@@ -5,7 +5,7 @@ auto RSP::Disassembler::disassemble(u32 address, u32 instruction) -> string {
   auto v = EXECUTE();
   if(v.empty()) v = {"invalid", string{"$", hex(instruction, 8L)}};
   if(!instruction) v = {"nop"};
-  auto s = pad(v.front(), -8L);
+  auto s = pad(v.front(), -12L);
   v.erase(v.begin());
   return {s, nall::merge(v, ",")};
 }
@@ -284,10 +284,41 @@ auto RSP::Disassembler::SCC() -> std::vector<string> {
   auto rtValue = [&] { return ipuRegisterValue(instruction >> 16 & 31); };
   auto sdName  = [&] { return sccRegisterName (instruction >> 11 & 31); };
   auto sdValue = [&] { return sccRegisterValue(instruction >> 11 & 31); };
+  auto xrtName = [&] { return ipuRegisterName (instruction >> 15 & 31); };
+  auto xrtValue = [&] { return ipuRegisterValue(instruction >> 15 & 31); };
+  auto xrdValue = [&] { return ipuRegisterValue(instruction >> 20 & 31); };
+  auto xcode = [&] { return instruction >> 6 & 511; };
+  auto xcodeImm = [&] { return immediate(xcode(), 9L); };
 
   switch(instruction >> 21 & 0x1f) {
   case 0x00: return {"mfc0", rtName(), sdValue()};
   case 0x04: return {"mtc0", sdName(), rtValue()};
+  }
+
+  switch(instruction & 0x3f) {
+  case 0x20:
+    if(xcode() == 1) return {"xdetect", xrdValue()};
+    return {"xdetect", xrdValue(), xcodeImm()};
+  case 0x23:
+    if(xcode() == 0) return {"xtrace-start"};
+    return {"xtrace-start", xcodeImm()};
+  case 0x24: return {"xtrace-stop"};
+  case 0x25:
+    if(xcode() == 0) return {"xlog", xrdValue()};
+    return {"xlog", xrdValue(), xrtValue(), xcodeImm()};
+  case 0x26:
+    if(!(instruction >> 20 & 31)) return {"xlogregs", xcodeImm()};
+    return {"xlogregs", xrdValue(), xcodeImm()};
+  case 0x27: return {"xhexdump", xrdValue(), xrtValue(), xcodeImm()};
+  case 0x28: return {"xprof", xrdValue(), xcodeImm()};
+  case 0x29: return {"xprof-read", xrdValue(), xrtName()};
+  case 0x2a: return {"xexception", xrtValue()};
+  case 0x2c:
+    if(xcode() == 1) return {"xioctl", "exit"};
+    if(xcode() == 2) return {"xioctl", "fast"};
+    if(xcode() == 3) return {"xioctl", "slow"};
+    if(xcode() == 4) return {"xioctl", "pause"};
+    return {"xioctl", xcodeImm()};
   }
 
   return {};

--- a/ares/n64/rsp/dma.cpp
+++ b/ares/n64/rsp/dma.cpp
@@ -31,7 +31,7 @@ auto RSP::dmaTransferStep() -> void {
       }
     }
     for(u32 i = 0; i <= dma.current.length; i += 8) {
-        u64 data = rdram.ram.read<Dual>(dma.current.dramAddress, nullptr);
+        u64 data = rdram.ram.read<Dual>(dma.current.dramAddress, RBusDevice::SP_DMA);
         region.write<Dual>(dma.current.pbusAddress, data);
         if (system.homebrewMode) {
           rsp.debugger.dmaReadWord(dma.current.dramAddress, dma.current.pbusRegion, dma.current.pbusAddress);
@@ -43,7 +43,7 @@ auto RSP::dmaTransferStep() -> void {
   if(dma.busy.write) {
     for(u32 i = 0; i <= dma.current.length; i += 8) {
         u64 data = region.read<Dual>(dma.current.pbusAddress);
-        rdram.ram.write<Dual>(dma.current.dramAddress, data, "RSP DMA");
+        rdram.ram.write<Dual>(dma.current.dramAddress, data, RBusDevice::SP_DMA);
         dma.current.dramAddress += 8;
         dma.current.pbusAddress += 8;
     }

--- a/ares/n64/rsp/emux.cpp
+++ b/ares/n64/rsp/emux.cpp
@@ -1,0 +1,223 @@
+namespace {
+
+auto readRspByte(u32 address) -> u8 {
+  u32 a = address & 0x1fff;
+  if(a & 0x1000) return rsp.imem.read<Byte>(a & 0xfff);
+  return rsp.dmem.read<Byte>(a & 0xfff);
+}
+
+auto toSignedOrHex(u32 value, bool decimal) -> string {
+  if(decimal) return string{(s32)value};
+  return hex(value, 8L);
+}
+
+}
+
+auto RSP::XDETECT(r32& rd, u32 code) -> void {
+  if(!system.homebrewMode) return;
+  n64 detect = 0;
+  detect.bit(0x20) = 1;
+  detect.bit(0x23) = 1;
+  detect.bit(0x24) = 1;
+  detect.bit(0x25) = 1;
+  detect.bit(0x26) = 1;
+  detect.bit(0x27) = 1;
+  detect.bit(0x28) = 1;
+  detect.bit(0x29) = 1;
+  detect.bit(0x2a) = 1;
+  detect.bit(0x2c) = 1;
+  switch(code) {
+  case 0x00: rd.u32 = detect.bit(0x00, 0x1f); break;
+  case 0x01: rd.u32 = detect.bit(0x20, 0x3f); break;
+  default:   rd.u32 = 0; break;
+  }
+}
+
+auto RSP::XTRACESTART(u32 code) -> void {
+  if(!system.homebrewMode) return;
+  debugger.tracer.instruction->setEnabled(true);
+  debugger.tracer.instructionCountdown = code;
+  debugger.tracer.traceStartCycle = pipeline.clocksTotal / 3;
+}
+
+auto RSP::XTRACESTOP() -> void {
+  if(!system.homebrewMode) return;
+  debugger.tracer.instruction->setEnabled(false);
+}
+
+auto RSP::XLOG(cr32& rd, cr32& rt, u32 code) -> void {
+  if(!system.homebrewMode) return;
+  auto& emux = debugger.tracer.emux;
+  string out;
+  u32 address = rd.u32;
+  switch(code) {
+  case 0x00:
+    for(u32 n : range(1_MiB)) {
+      u8 c = readRspByte(address++);
+      if(!c) break;
+      out.append((char)c);
+    }
+    break;
+  case 0x01:
+    for(u32 n : range(rt.u32)) out.append((char)readRspByte(address++));
+    break;
+  }
+  if(out) emux->notify(out);
+}
+
+auto RSP::XLOGREGS(cr32& rd, u32 code) -> void {
+  if(!system.homebrewMode) return;
+  static const char* gprNames[32] = {
+    "zr", "at", "v0", "v1", "a0", "a1", "a2", "a3",
+    "t0", "t1", "t2", "t3", "t4", "t5", "t6", "t7",
+    "s0", "s1", "s2", "s3", "s4", "s5", "s6", "s7",
+    "t8", "t9", "k0", "k1", "gp", "sp", "fp", "ra"
+  };
+  static const char* cop0Names[16] = {
+    "dma_spaddr", "dma_ramaddr", "dma_read", "dma_write",
+    "sp_status", "dma_full", "dma_busy", "semaphore",
+    "dp_start", "dp_end", "dp_current", "dp_status",
+    "dp_clock", "dp_busy", "dp_pipe_busy", "dp_tmem_busy"
+  };
+  auto& emux = debugger.tracer.emux;
+  u32 mask = rd.u32;
+  u32 mode = code & 3;
+  bool decimal = code & (1 << 2);
+  bool extra = code & (1 << 4);
+  string out;
+
+  if(mode == 3) {
+    u32 columns = 0;
+    for(u32 i : range(32)) {
+      if(mask && !(mask & (1u << i))) continue;
+      out.append(gprNames[i], ": ", toSignedOrHex(ipu.r[i].u32, decimal));
+      columns++;
+      if(columns == 4) { out.append("\n"); columns = 0; }
+      else out.append("   ");
+    }
+    if(extra) out.append("pc: ", toSignedOrHex(ipu.pc, decimal), "\n");
+    else if(columns) out.append("\n");
+  }
+
+  if(mode == 0) {
+    u32 columns = 0;
+    for(u32 i : range(16)) {
+      if(mask && !(mask & (1u << i))) continue;
+      u32 value = i == 7 ? (u32)status.semaphore : (i & 8 ? rdp.readWord(i & 7, *this) : ioRead(i & 7, *this));
+      out.append(cop0Names[i], ": ", toSignedOrHex(value, decimal));
+      columns++;
+      if(columns == 4) { out.append("\n"); columns = 0; }
+      else out.append("   ");
+    }
+    if(columns) out.append("\n");
+  }
+
+  if(mode == 2) {
+    auto dumpVector = [&](cr128& value) -> string {
+      string line;
+      for(u32 i : range(8)) {
+        if(decimal) line.append(pad((s32)value.s16(i), -6L, ' '));
+        else        line.append(hex(value.u16(i), 4L));
+        if(i != 7) line.append(" ");
+        if(i == 3) line.append(" ");
+      }
+      return line;
+    };
+
+    auto dumpFlags = [&](cr128& high, cr128& low) -> string {
+      string line;
+      for(u32 i : range(8)) {
+        line.append(high.get(i) ? "1" : "-");
+        if(i == 3) line.append(" ");
+      }
+      line.append(" ");
+      for(u32 i : range(8)) {
+        line.append(low.get(i) ? "1" : "-");
+        if(i == 3) line.append(" ");
+      }
+      return line;
+    };
+
+    u32 columns = 0;
+    for(u32 i : range(32)) {
+      if(mask && !(mask & (1u << i))) continue;
+      out.append("v", pad(i, 2L, '0'), ": ", dumpVector(vpu.r[i]));
+      columns++;
+      if(columns == 2) { out.append("\n"); columns = 0; }
+      else out.append("   ");
+    }
+    if(columns) out.append("\n");
+    if(extra) {
+      out.append("acch: ", dumpVector(vpu.acch), "   vco: ", dumpFlags(vpu.vcoh, vpu.vcol), "\n");
+      out.append("accm: ", dumpVector(vpu.accm), "   vcc: ", dumpFlags(vpu.vcch, vpu.vccl), "\n");
+      string vce;
+      for(u32 i : range(8)) {
+        vce.append(vpu.vce.get(i) ? "1" : "-");
+        if(i == 3) vce.append(" ");
+      }
+      out.append("accl: ", dumpVector(vpu.accl), "   vce: ", vce, "\n");
+    }
+  }
+
+  if(out) emux->notify(out);
+}
+
+auto RSP::XHEXDUMP(cr32& rd, cr32& rt, u32 code) -> void {
+  if(!system.homebrewMode) return;
+  auto& emux = debugger.tracer.emux;
+  u32 address = rd.u32;
+  u32 length = rt.u32;
+  string dump;
+  (void)code;
+
+  for(u32 n = 0; n < length; n += 16) {
+    dump.append(hex(address + n, 8L), " ", hex(n, 4L), ": ");
+    u8 data[16] = {};
+    u32 line = min(16u, length - n);
+    for(u32 m : range(line)) data[m] = readRspByte(address + n + m);
+    for(u32 m : range(16)) {
+      if(m < line) dump.append(hex(data[m], 2L), " ");
+      else         dump.append("   ");
+      if(m == 7) dump.append(" ");
+    }
+    dump.append(" |");
+    for(u32 m : range(line)) {
+      u8 c = data[m];
+      if(c >= 32 && c <= 126) dump.append(string{(char)c});
+      else                    dump.append(".");
+    }
+    for(u32 m = line; m < 16; m++) dump.append(" ");
+    dump.append("|\n");
+  }
+
+  if(dump) emux->notify(dump);
+}
+
+auto RSP::XPROF(cr32& rd, u32 code) -> void {
+  if(!system.homebrewMode) return;
+  CPU::r64 slot;
+  slot.u64 = rd.u32;
+  cpu.XPROF(slot, code);
+}
+
+auto RSP::XPROFREAD(cr32& rd, r32& rt) -> void {
+  if(!system.homebrewMode) return;
+  CPU::r64 slot;
+  CPU::r64 metric;
+  slot.s64 = s32(rd.u32);
+  metric.u64 = rt.u32;
+  cpu.XPROFREAD(slot, metric);
+  rt.u32 = metric.u64;
+}
+
+auto RSP::XEXCEPTION(cr32& rt) -> void {
+  if(!system.homebrewMode) return;
+  CPU::r64 mask;
+  mask.u64 = rt.u32;
+  cpu.XEXCEPTION(mask);
+}
+
+auto RSP::XIOCTL(u32 code) -> void {
+  if(!system.homebrewMode) return;
+  cpu.XIOCTL(code);
+}

--- a/ares/n64/rsp/interpreter.cpp
+++ b/ares/n64/rsp/interpreter.cpp
@@ -2,6 +2,8 @@
 #define RD ipu.r[RDn]
 #define RT ipu.r[RTn]
 #define RS ipu.r[RSn]
+#define XRT ipu.r[XRTn]
+#define XRD ipu.r[XRDn]
 #define VD vpu.r[VDn]
 #define VS vpu.r[VSn]
 #define VT vpu.r[VTn]
@@ -34,6 +36,9 @@
 #define RDn    (OP >> 11 & 31)
 #define RTn    (OP >> 16 & 31)
 #define RSn    (OP >> 21 & 31)
+#define XRTn   (OP >> 15 & 31)
+#define XRDn   (OP >> 20 & 31)
+#define XCODE  (OP >> 6  & 511)
 #define VDn    (OP >>  6 & 31)
 #define VSn    (OP >> 11 & 31)
 #define VTn    (OP >> 16 & 31)
@@ -235,6 +240,19 @@ auto RSP::interpreterSCC() -> void {
   op(0x0e, INVALID);
   op(0x0f, INVALID);
   }
+
+  switch(OP & 0x3f) {
+  op(0x20, XDETECT, XRD, XCODE);
+  op(0x23, XTRACESTART, XCODE);
+  op(0x24, XTRACESTOP);
+  op(0x25, XLOG, XRD, XRT, XCODE);
+  op(0x26, XLOGREGS, XRD, XCODE);
+  op(0x27, XHEXDUMP, XRD, XRT, XCODE);
+  op(0x28, XPROF, XRD, XCODE);
+  op(0x29, XPROFREAD, XRD, XRT);
+  op(0x2a, XEXCEPTION, XRT);
+  op(0x2c, XIOCTL, XCODE);
+  }
 }
 
 auto RSP::interpreterVU() -> void {
@@ -380,6 +398,9 @@ auto RSP::INVALID() -> void {
 #undef RDn
 #undef RTn
 #undef RSn
+#undef XRTn
+#undef XRDn
+#undef XCODE
 #undef VDn
 #undef VSn
 #undef VTn
@@ -396,6 +417,8 @@ auto RSP::INVALID() -> void {
 #undef RD
 #undef RT
 #undef RS
+#undef XRT
+#undef XRD
 #undef VD
 #undef VS
 #undef VT

--- a/ares/n64/rsp/recompiler.cpp
+++ b/ares/n64/rsp/recompiler.cpp
@@ -128,12 +128,17 @@ auto RSP::Recompiler::emit(u12 address) -> Block* {
 #define Rdn (instruction >> 11 & 31)
 #define Rtn (instruction >> 16 & 31)
 #define Rsn (instruction >> 21 & 31)
+#define XRtn (instruction >> 15 & 31)
+#define XRdn (instruction >> 20 & 31)
+#define XCODE (instruction >> 6 & 511)
 #define Vdn (instruction >>  6 & 31)
 #define Vsn (instruction >> 11 & 31)
 #define Vtn (instruction >> 16 & 31)
 #define Rd  IpuReg(r[0]) + Rdn * sizeof(r32)
 #define Rt  IpuReg(r[0]) + Rtn * sizeof(r32)
 #define Rs  IpuReg(r[0]) + Rsn * sizeof(r32)
+#define XRd IpuReg(r[0]) + XRdn * sizeof(r32)
+#define XRt IpuReg(r[0]) + XRtn * sizeof(r32)
 #define Vd  VuReg(r[0]) + Vdn * sizeof(r128)
 #define Vs  VuReg(r[0]) + Vsn * sizeof(r128)
 #define Vt  VuReg(r[0]) + Vtn * sizeof(r128)
@@ -517,7 +522,6 @@ auto RSP::Recompiler::emitSPECIAL(u32 instruction) -> bool {
     mlshr32(mem(Rd), mem(Rs), mem(Rs));
     return 0;
   }
-
   }
 
   return 0;
@@ -587,6 +591,70 @@ auto RSP::Recompiler::emitSCC(u32 instruction) -> bool {
 
   //INVALID
   case range27(0x05, 0x1f): {
+    return 0;
+  }
+
+  }
+
+  switch(instruction & 0x3f) {
+
+  //XDETECT
+  case 0x20: {
+    callf(&RSP::XDETECT, mem(XRd), imm(XCODE));
+    return 0;
+  }
+
+  //XTRACE-START
+  case 0x23: {
+    callf(&RSP::XTRACESTART, imm(XCODE));
+    return 0;
+  }
+
+  //XTRACE-STOP
+  case 0x24: {
+    callf(&RSP::XTRACESTOP);
+    return 0;
+  }
+
+  //XLOG
+  case 0x25: {
+    callf(&RSP::XLOG, mem(XRd), mem(XRt), imm(XCODE));
+    return 0;
+  }
+
+  //XLOGREGS
+  case 0x26: {
+    callf(&RSP::XLOGREGS, mem(XRd), imm(XCODE));
+    return 0;
+  }
+
+  //XHEXDUMP
+  case 0x27: {
+    callf(&RSP::XHEXDUMP, mem(XRd), mem(XRt), imm(XCODE));
+    return 0;
+  }
+
+  //XPROF
+  case 0x28: {
+    callf(&RSP::XPROF, mem(XRd), imm(XCODE));
+    return 0;
+  }
+
+  //XPROFREAD
+  case 0x29: {
+    callf(&RSP::XPROFREAD, mem(XRd), mem(XRt));
+    return 0;
+  }
+
+  //XEXCEPTION
+  case 0x2a: {
+    callf(&RSP::XEXCEPTION, mem(XRt));
+    return 0;
+  }
+
+  //XIOCTL
+  case 0x2c: {
+    callf(&RSP::XIOCTL, imm(XCODE));
     return 0;
   }
 
@@ -1208,12 +1276,17 @@ auto RSP::Recompiler::isTerminal(u32 instruction) -> bool {
 #undef Rdn
 #undef Rtn
 #undef Rsn
+#undef XRtn
+#undef XRdn
+#undef XCODE
 #undef Vdn
 #undef Vsn
 #undef Vtn
 #undef Rd
 #undef Rt
 #undef Rs
+#undef XRd
+#undef XRt
 #undef Vd
 #undef Vs
 #undef Vt

--- a/ares/n64/rsp/rsp.cpp
+++ b/ares/n64/rsp/rsp.cpp
@@ -14,6 +14,7 @@ RSP rsp;
 #include "debugger.cpp"
 #include "serialization.cpp"
 #include "disassembler.cpp"
+#include "emux.cpp"
 
 auto RSP::load(Node::Object parent) -> void {
   node = parent->append<Node::Object>("RSP");
@@ -48,6 +49,7 @@ auto RSP::instruction() -> void {
     auto block = recompiler.block(ipu.pc);
     block->execute(*this);
   } else {
+    pipeline.dblIssueCount = 0;
     u32 instruction = imem.read<Word>(ipu.pc);
     instructionPrologue(instruction);
     pipeline.begin();
@@ -60,6 +62,7 @@ auto RSP::instruction() -> void {
       OpInfo op1 = decoderEXECUTE(instruction);
 
       if(canDualIssue(op0, op1)) {
+        pipeline.dblIssueCount = 1;
         instructionEpilogue<0>(0);
         instructionPrologue(instruction);
         pipeline.issue(op1);
@@ -74,6 +77,7 @@ auto RSP::instruction() -> void {
   //this handles all stepping for the interpreter
   //with the recompiler, it only steps for taken branch stalls
   step(pipeline.clocks);
+  pipeline.clocksTotal += pipeline.clocks;
 }
 
 auto RSP::instructionPrologue(u32 instruction) -> void {
@@ -86,6 +90,7 @@ template<bool Recompiled>
 auto RSP::instructionEpilogue(u32 clocks) -> s32 {
   if constexpr(Recompiled) {
     step(clocks);
+    pipeline.clocksTotal += clocks;
 
     assert(ipu.r[0].u32 == 0);
   } else {

--- a/ares/n64/rsp/rsp.hpp
+++ b/ares/n64/rsp/rsp.hpp
@@ -67,7 +67,10 @@ struct RSP : Thread, Memory::RCP<RSP> {
 
     struct Tracer {
       Node::Debugger::Tracer::Instruction instruction;
+      Node::Debugger::Tracer::Notification emux;
       Node::Debugger::Tracer::Notification io;
+      i32 instructionCountdown = 0;
+      u32 traceStartCycle = 0;
     } tracer;
   } debugger;
 
@@ -119,6 +122,11 @@ struct RSP : Thread, Memory::RCP<RSP> {
     u32 address;
     u32 instruction;
     u32 clocks;
+
+    u32 clocksTotal;
+    u32 stallCount;
+    u32 dblIssueCount;
+
     u1 singleIssue;
 
     struct Stage {
@@ -147,6 +155,8 @@ struct RSP : Thread, Memory::RCP<RSP> {
 
     auto begin() -> void {
       clocks = 0;
+      stallCount = 0;
+      dblIssueCount = 0;
     }
 
     auto end() -> void {
@@ -167,6 +177,7 @@ struct RSP : Thread, Memory::RCP<RSP> {
       previous[1] = previous[0];
       previous[0] = {};
       clocks += 3;
+      ++stallCount;
     }
 
     auto issue(const OpInfo& op) -> void {
@@ -482,6 +493,18 @@ struct RSP : Thread, Memory::RCP<RSP> {
   template<u8 e> auto VSUBC(r128& vd, cr128& vs, cr128& vt) -> void;
   template<u8 e> auto VXOR(r128& rd, cr128& vs, cr128& vt) -> void;
   template<u8 e> auto VZERO(r128& rd, cr128& vs, cr128& vt) -> void;
+
+  //emux.cpp
+  auto XDETECT(r32& rd, u32 code) -> void;
+  auto XTRACESTART(u32 code) -> void;
+  auto XTRACESTOP() -> void;
+  auto XLOG(cr32& rd, cr32& rt, u32 code) -> void;
+  auto XLOGREGS(cr32& rd, u32 code) -> void;
+  auto XHEXDUMP(cr32& rd, cr32& rt, u32 code) -> void;
+  auto XPROF(cr32& rd, u32 code) -> void;
+  auto XPROFREAD(cr32& rd, r32& rt) -> void;
+  auto XEXCEPTION(cr32& rt) -> void;
+  auto XIOCTL(u32 code) -> void;
 
 //unserialized:
   u16 reciprocals[512];

--- a/ares/n64/system/serialization.cpp
+++ b/ares/n64/system/serialization.cpp
@@ -1,4 +1,4 @@
-static const string SerializerVersion = "v148";
+static const string SerializerVersion = "v149";
 
 auto System::serialize(bool synchronize) -> serializer {
   serializer s;

--- a/ares/n64/system/system.cpp
+++ b/ares/n64/system/system.cpp
@@ -217,7 +217,7 @@ auto System::initDebugHooks() -> void {
     } else if (address >= 0xffff'ffff'a000'0000ull && address + byteCount <= 0xffff'ffff'a3ef'ffffull) {
       Thread dummyThread{};
       for(u32 i : range(byteCount)) {
-        auto val = bus.read<Byte>(address & 0x1fff'ffff, dummyThread, "Ares Debugger");
+        auto val = bus.read<Byte>(address & 0x1fff'ffff, dummyThread, RBusDevice::ARES_DEBUGGER);
         hexByte(resPtr, val);
         resPtr += 2;
         address++;
@@ -229,7 +229,7 @@ auto System::initDebugHooks() -> void {
       // as the user would expect.
       Thread dummyThread{};
       for(u32 i : range(byteCount / 4)) {
-        u64 value = bus.read<Word>(address & 0x1fff'ffff, dummyThread, "Ares Debugger");
+        u64 value = bus.read<Word>(address & 0x1fff'ffff, dummyThread, RBusDevice::ARES_DEBUGGER);
         hexByte(resPtr + 0, (value >> 24) & 0xff);
         hexByte(resPtr + 2, (value >> 16) & 0xff);
         hexByte(resPtr + 4, (value >> 8) & 0xff);
@@ -278,7 +278,7 @@ auto System::initDebugHooks() -> void {
     } else if (address >= 0xffff'ffff'a000'0000ull && address + data.size() <= 0xffff'ffff'a3ef'ffffull) {
       Thread dummyThread{};
       for(auto b : data) {
-        bus.write<Byte>(address & 0x1fff'ffff, b, dummyThread, "Ares Debugger");
+        bus.write<Byte>(address & 0x1fff'ffff, b, dummyThread, RBusDevice::ARES_DEBUGGER);
         address++;
       }
     } else if (address >= 0xffff'ffff'a400'0000ull && address + data.size() <= 0xffff'ffff'bfff'ffffull) {
@@ -288,7 +288,7 @@ auto System::initDebugHooks() -> void {
       Thread dummyThread{};
       for(u32 i = 0; i < data.size() / 4; i++) {
         u64 value = ((u64)data[i*4+0]<<24) | ((u64)data[i*4+1]<<16) | ((u64)data[i*4+2]<<8) | ((u64)data[i*4+3]<<0);
-        bus.write<Word>(address & 0x1fff'ffff, value, dummyThread, "Ares Debugger");
+        bus.write<Word>(address & 0x1fff'ffff, value, dummyThread, RBusDevice::ARES_DEBUGGER);
         address += 4;
       }
     }

--- a/ares/n64/vi/vi.cpp
+++ b/ares/n64/vi/vi.cpp
@@ -198,7 +198,7 @@ auto VI::refresh() -> void {
         auto line = screen->pixels(1).data() + (dy - vscan_start) * hscan_len;
         u32 x0 = vi.io.xsubpixel + vi.io.xscale * (dx0 - vi.io.hstart);
         for(i32 dx = dx0; dx < dx1; dx++) {
-          u16 data = rdram.ram.read<Half>(address + (x0 >> 10) * 2, "VI");
+          u16 data = rdram.ram.read<Half>(address + (x0 >> 10) * 2, RBusDevice::VI_DMA);
           line[dx - hscan_start] = 1 << 24 | data >> 1;
           x0 += vi.io.xscale;
         }
@@ -216,7 +216,7 @@ auto VI::refresh() -> void {
         auto line = screen->pixels(1).data() + (dy - vscan_start) * hscan_len;
         u32 x0 = vi.io.xsubpixel + vi.io.xscale * (dx0 - vi.io.hstart);
         for(i32 dx = dx0; dx < dx1; dx++) {
-          u32 data = rdram.ram.read<Word>(address + (x0 >> 10) * 4, "VI");
+          u32 data = rdram.ram.read<Word>(address + (x0 >> 10) * 4, RBusDevice::VI_DMA);
           line[dx - hscan_start] = data >> 8;
           x0 += vi.io.xscale;
         }

--- a/ares/n64/vulkan/vulkan.cpp
+++ b/ares/n64/vulkan/vulkan.cpp
@@ -95,8 +95,8 @@ auto Vulkan::render() -> bool {
 
   if(!command.source) {
     do {
-      buffer[queueSize * 2 + 0] = rdram.ram.read<Word>(current, "RDP DMA"); current += 4;
-      buffer[queueSize * 2 + 1] = rdram.ram.read<Word>(current, "RDP DMA"); current += 4;
+      buffer[queueSize * 2 + 0] = rdram.ram.read<Word>(current, RBusDevice::DP_DMA); current += 4;
+      buffer[queueSize * 2 + 1] = rdram.ram.read<Word>(current, RBusDevice::DP_DMA); current += 4;
       queueSize++;
     } while(--length);
   } else {

--- a/desktop-ui/program/platform.cpp
+++ b/desktop-ui/program/platform.cpp
@@ -27,6 +27,9 @@ auto Program::pak(ares::Node::Object node) -> std::shared_ptr<vfs::directory> {
 }
 
 auto Program::event(ares::Event event) -> void {
+  if(event == ares::Event::Shutdown) {
+    quit();
+  }
 }
 
 auto Program::log(ares::Node::Debugger::Tracer::Tracer node, string_view message) -> void {

--- a/desktop-ui/program/program.cpp
+++ b/desktop-ui/program/program.cpp
@@ -158,10 +158,18 @@ auto Program::main() -> void {
     propertiesViewer.liveRefresh();
     tapeViewer.liveRefresh();
   }
+  if (_quitRequested) {
+    quit();
+  }
 }
 
 auto Program::quit() -> void {
+  if (_programThread) {
+    _quitRequested = true;
+    return;
+  }
   Program::Guard guard;
+  _quitRequested = false;
   _quitting = true;
   if(lock.owns_lock()) {
     lock.unlock();

--- a/desktop-ui/program/program.hpp
+++ b/desktop-ui/program/program.hpp
@@ -126,6 +126,7 @@ private:
 
   atomic<bool> _quitting = false;
   atomic<bool> _needsResize = false;
+  atomic<bool> _quitRequested = false;  // quit requested by emulator thread
 
   /// Mutex used to manage access to the status message queue.
   std::recursive_mutex _messageMutex;


### PR DESCRIPTION
Emux is a spec for emulator extensions to help homebrew development.
The spec can be found here at the time of writing:
https://hackmd.io/@rasky/r1k7na6Jn

Usage of emux is gated behind the "homebrew development mode" setting.

These commits introduce support for several extensions on both the CPU and the RSP.