### PR TITLE
gba: fix wave RAM bank selection

### DIFF
--- a/ares/gba/apu/wave.cpp
+++ b/ares/gba/apu/wave.cpp
@@ -66,7 +66,7 @@ auto APU::Wave::write(u32 address, n8 byte) -> void {
 }
 
 auto APU::Wave::freeBank() const -> n1 {
-  return bank && apu.sequencer.masterenable;
+  return !(bank && apu.sequencer.masterenable);
 }
 
 auto APU::Wave::readRAM(u32 address) const -> n8 {


### PR DESCRIPTION
Fixes a regression from #1997 which caused the wrong wave RAM bank to be selected for reading/writing.

Should fix #2253 (thanks to @jsgroth for finding the cause of the bug).