### PR TITLE
n64: fix Vulkan VI scanout and weave setting

### DIFF
--- a/ares/n64/vi/vi.cpp
+++ b/ares/n64/vi/vi.cpp
@@ -85,8 +85,8 @@ auto VI::main() -> void {
         if(++io.leapCounter == 5) io.leapCounter = 0;
         #if defined(VULKAN)
         if (vulkan.enable) {
-          gpuOutputValid = vulkan.scanoutAsync(io.field);
           vulkan.frame();
+          gpuOutputValid = vulkan.scanoutAsync(io.field);
         }
         #endif
         refreshed = true;

--- a/ares/n64/vulkan/vulkan.cpp
+++ b/ares/n64/vulkan/vulkan.cpp
@@ -167,7 +167,7 @@ auto Vulkan::scanoutAsync(bool field) -> bool {
   options.downscale_steps = supersampleScanout ? 16 : 0;
   options.persist_frame_on_invalid_input = true;  //this is a compatibility hack, but I'm not sure what for ...
   if(disableVideoInterfaceProcessing) {
-    options.vi = {false, false, false, false, false, false};
+    options.vi = {false, false, true, false, false, false};
   }
   if(!supersampleScanout){
     options.blend_previous_frame = weaveDeinterlacing;

--- a/ares/n64/vulkan/vulkan.cpp
+++ b/ares/n64/vulkan/vulkan.cpp
@@ -163,11 +163,11 @@ auto Vulkan::scanoutAsync(bool field) -> bool {
 
   //0 steps if scanning out at upscaled resolution.
   //each downscale step reduces output resolution to [width, height] * max(1, upscale >> downscale_steps)
-  ::RDP::ScanoutOptions options;
+  ::RDP::ScanoutOptions options{};
   options.downscale_steps = supersampleScanout ? 16 : 0;
   options.persist_frame_on_invalid_input = true;  //this is a compatibility hack, but I'm not sure what for ...
   if(disableVideoInterfaceProcessing) {
-    options.vi = {false, false, true, false, false, false};
+    options.vi = {false, false, false, false, false, false};
   }
   if(!supersampleScanout){
     options.blend_previous_frame = weaveDeinterlacing;

--- a/desktop-ui/settings/video.cpp
+++ b/desktop-ui/settings/video.cpp
@@ -89,7 +89,7 @@ auto VideoSettings::construct() -> void {
   weaveDeinterlacingOption.setText("Weave Deinterlacing").setChecked(settings.video.weaveDeinterlacing).onToggle([&] {
     settings.video.weaveDeinterlacing = weaveDeinterlacingOption.checked();
     Program::Guard guard;
-    if(emulator) emulator->setBoolean("(Experimental) Double the perceived vertical resolution; disabled when supersampling is used", settings.video.weaveDeinterlacing);
+    if(emulator) emulator->setBoolean("Weave Deinterlacing", settings.video.weaveDeinterlacing);
     if(weaveDeinterlacingOption.checked() == true) {
       renderSupersamplingOption.setChecked(false).setEnabled(false);
       settings.video.supersampling = false;


### PR DESCRIPTION
I noticed an issue with Ares when testing James Lambert's WIP homebrew game, [Spellcraft](https://github.com/lambertjamesd/spellcraft).
The image Ares displayed seemed to be cropped (I tested this with the current release, the prerelease, and the previous release):
<img width="320" height="240" alt="Ares" src="https://github.com/user-attachments/assets/2d73dc39-fe15-4493-ac91-f5ad484800e9" />

I thought this may possibly be a parallel rdp bug, so I checked Gopher64 and my own emulator:
<img width="320" height="240" alt="Gopher" src="https://github.com/user-attachments/assets/1cfd30bc-de10-4bc5-9e28-3371d9ecd875" />

<img width="320" height="240" alt="N64Emulator" src="https://github.com/user-attachments/assets/b8d3311a-21c1-4d9f-8b90-40db81f5d35d" />

Both of these work as expected, so I knew there was something specific with Ares.

I discovered that `vulkan.scanoutAsync(io.field)` being called before `vulkan.frame()`  could cause the VI scanout to be requested before parallel advanced its frame context. This would cause the scanout to be built against the old context instead of the fresh one.

On the way I also spotted another issue: when `Disable Video Interface Processing` was enabled, it was not actually disabling all of the VI processing flags. It was setting `options.vi` to `{false, false, true, false, false, false}`, which still left `serrate` enabled. Was this intentional?

I implemented these changes:
1. Call vulkan.frame() before vulkan.scanoutAsync() so parallel advances its frame context before scheduling the VI scanout
2. Restore all-disabled VI override when `Disable Video Interface Processing` is enabled

I also made a change to explicitly zero-initialize `RDP::ScanoutOptions`, but this does not change any behavior.
Another change was that the weave setting in the UI seemed to be writing to the wrong key.