### PR TITLE
fc: add support for Dendy region

### DIFF
--- a/ares/fc/apu/apu.hpp
+++ b/ares/fc/apu/apu.hpp
@@ -2,7 +2,7 @@ struct APU : Thread {
   Node::Object node;
   Node::Audio::Stream stream;
 
-  auto rate() const -> u32 { return Region::PAL() ? 16 : 12; }
+  auto rate() const -> u32 { return system.cpuDivider(); }
 
   //apu.cpp
   auto load(Node::Object) -> void;

--- a/ares/fc/cartridge/cartridge.hpp
+++ b/ares/fc/cartridge/cartridge.hpp
@@ -5,7 +5,7 @@ struct Cartridge : Thread {
   Node::Peripheral node;
   VFS::Pak pak;
 
-  auto rate() const -> u32 { return Region::PAL() ? 16 : 12; }
+  auto rate() const -> u32 { return system.cpuDivider(); }
   auto title() const -> string { return information.title; }
   auto region() const -> string { return information.region; }
 

--- a/ares/fc/cpu/cpu.hpp
+++ b/ares/fc/cpu/cpu.hpp
@@ -18,7 +18,7 @@ struct CPU : MOS6502, Thread {
     } tracer;
   } debugger;
 
-  auto rate() const -> u32 { return Region::PAL() ? 16 : 12; }
+  auto rate() const -> u32 { return system.cpuDivider(); }
 
   //cpu.cpp
   auto load(Node::Object) -> void;

--- a/ares/fc/cpu/memory.cpp
+++ b/ares/fc/cpu/memory.cpp
@@ -35,10 +35,10 @@ auto CPU::readIO(n16 address) -> n8 {
   case 0x4016: {
     auto port1 = controllerPort1.data();
     auto port3 = expansionPort.read1();
-    platform->input(system.controls.microphone);
+    if(system.controls.microphone) platform->input(system.controls.microphone);
     data.bit(0) = port1.bit(0);
     data.bit(1) = port3.bit(0);
-    data.bit(2) = system.controls.microphone->value() ? random().bit(0) : 0;
+    data.bit(2) = system.controls.microphone && system.controls.microphone->value() ? random().bit(0) : 0;
     data.bit(3) = port1.bit(1);
     data.bit(4) = port1.bit(2);
     return data;

--- a/ares/fc/fc.hpp
+++ b/ares/fc/fc.hpp
@@ -19,7 +19,8 @@ namespace ares::Famicom {
   struct Region {
     static inline auto NTSCJ() -> bool;
     static inline auto NTSCU() -> bool;
-    static inline auto PAL() -> bool;
+    static inline auto PAL()   -> bool;
+    static inline auto Dendy() -> bool;
   };
 
   #include <fc/controller/controller.hpp>

--- a/ares/fc/ppu/ppu.cpp
+++ b/ares/fc/ppu/ppu.cpp
@@ -23,7 +23,7 @@ auto PPU::load(Node::Object parent) -> void {
   screen->colors(1 << 9, std::bind_front(&PPU::color, this));
   screen->setSize(283, displayHeight());
   screen->setScale(1.0, 1.0);
-  Region::PAL() ? screen->setAspect(55.0, 43.0) :screen->setAspect(8.0, 7.0);
+  (Region::PAL() || Region::Dendy()) ? screen->setAspect(55.0, 43.0) : screen->setAspect(8.0, 7.0);
   screen->refreshRateHint(system.frequency() / rate(), 341, vlines());
 
   debugger.load(node);
@@ -61,10 +61,11 @@ auto PPU::step(u32 clocks) -> void {
     if (enable() && (io.ly < 240 || io.ly == L - 1))
       cycleScroll();
 
-    if(io.ly == 240 && io.lx ==   1) io.busAddress = var.address, cartridge.ppuAddressBus(io.busAddress);
-    if(io.ly == 240 && io.lx == 340) io.nmiHold = 1;
-    if(io.ly == 241 && io.lx ==   0) io.nmiFlag = io.nmiHold;
-    if(io.ly == 241 && io.lx ==   2) cpu.nmiLine(io.nmiEnable && io.nmiFlag);
+    u32 vbs = vblankScanline();
+    if(io.ly == vbs - 1 && io.lx ==   1) io.busAddress = var.address, cartridge.ppuAddressBus(io.busAddress);
+    if(io.ly == vbs - 1 && io.lx == 340) io.nmiHold = 1;
+    if(io.ly == vbs     && io.lx ==   0) io.nmiFlag = io.nmiHold;
+    if(io.ly == vbs     && io.lx ==   2) cpu.nmiLine(io.nmiEnable && io.nmiFlag);
 
     if(io.ly == L-2 && io.lx == 340) io.spriteZeroHit = 0, sprite.spriteOverflow = 0;
 

--- a/ares/fc/ppu/ppu.hpp
+++ b/ares/fc/ppu/ppu.hpp
@@ -19,9 +19,10 @@ struct PPU : Thread {
     } memory;
   } debugger;
 
-  auto rate() const -> u32 { return Region::PAL() ? 5 : 4; }
-  auto vlines() const -> u32 { return Region::PAL() ? 312 : 262; }
+  auto rate()          const -> u32 { return Region::PAL() || Region::Dendy() ? 5 : 4; }
+  auto vlines()        const -> u32 { return Region::PAL() || Region::Dendy() ? 312 : 262; }
   auto displayHeight() const -> u32 { return Region::PAL() ? 288 : 242; }
+  auto vblankScanline() const -> u32 { return Region::Dendy() ? 291 : 241; }
 
   //ppu.cpp
   auto load(Node::Object) -> void;

--- a/ares/fc/ppu/render.cpp
+++ b/ares/fc/ppu/render.cpp
@@ -72,7 +72,7 @@ auto PPU::renderPixel() -> void {
     color = io.emphasis << 6 | readCGRAM((n5)var.address);
   }
 
-  if(Region::PAL())
+  if(Region::PAL() || Region::Dendy())
     output[(x + 18) % 283] = color;
   else
     output[(x + 16) % 283] = color;
@@ -188,7 +188,7 @@ auto PPU::renderScanline() -> void {
 
   //337-338
   loadCHR(0x2000 | (n12)var.address);
-  bool skip = !Region::PAL() && enable() && io.field == 1 && io.ly == vlines() - 1;
+  bool skip = !Region::PAL() && !Region::Dendy() && enable() && io.field == 1 && io.ly == vlines() - 1;
   step(2);
 
   //339

--- a/ares/fc/system/controls.cpp
+++ b/ares/fc/system/controls.cpp
@@ -1,11 +1,19 @@
 auto System::Controls::load(Node::Object parent) -> void {
   node = parent->append<Node::Object>("Controls");
 
-  reset      = node->append<Node::Input::Button>("Reset");
-  microphone = node->append<Node::Input::Button>("Microphone");
+  reset = node->append<Node::Input::Button>("Reset");
+  if(system.region() != System::Region::Dendy) {
+    microphone = node->append<Node::Input::Button>("Microphone");
+  }
+}
+
+auto System::Controls::unload() -> void {
+  microphone.reset();
+  reset.reset();
+  node.reset();
 }
 
 auto System::Controls::poll() -> void {
   platform->input(reset);
-  platform->input(microphone);
+  if(microphone) platform->input(microphone);
 }

--- a/ares/fc/system/system.cpp
+++ b/ares/fc/system/system.cpp
@@ -8,6 +8,7 @@ auto enumerate() -> std::vector<string> {
     "[Nintendo] Famicom (NTSC-J)",
     "[Nintendo] Famicom (NTSC-U)",
     "[Nintendo] Famicom (PAL)",
+    "[Dendy] Dendy",
   };
 }
 
@@ -47,19 +48,28 @@ auto System::load(Node::System& root, string name) -> bool {
 
   information = {};
   if(name.find("NTSC-J")) {
-    information.name = "Famicom";
-    information.region = Region::NTSCJ;
-    information.frequency = Constants::Colorburst::NTSC * 6.0;
+    information.name        = "Famicom";
+    information.region      = Region::NTSCJ;
+    information.frequency   = Constants::Colorburst::NTSC * 6.0;
+    information.cpuDivider  = 12;
   }
   if(name.find("NTSC-U")) {
-    information.name = "Famicom";
-    information.region = Region::NTSCU;
-    information.frequency = Constants::Colorburst::NTSC * 6.0;
+    information.name        = "Famicom";
+    information.region      = Region::NTSCU;
+    information.frequency   = Constants::Colorburst::NTSC * 6.0;
+    information.cpuDivider  = 12;
   }
   if(name.find("PAL")) {
-    information.name = "Famicom";
-    information.region = Region::PAL;
-    information.frequency = Constants::Colorburst::PAL * 6.0;
+    information.name        = "Famicom";
+    information.region      = Region::PAL;
+    information.frequency   = Constants::Colorburst::PAL * 6.0;
+    information.cpuDivider  = 16;
+  }
+  if(name.find("Dendy")) {
+    information.name        = "Famicom";
+    information.region      = Region::Dendy;
+    information.frequency   = Constants::Colorburst::PAL * 6.0;
+    information.cpuDivider  = 15;
   }
 
   node = std::make_shared<Core::System>(information.name);
@@ -94,6 +104,7 @@ auto System::save() -> void {
 auto System::unload() -> void {
   if(!node) return;
   save();
+  controls.unload();
   cpu.unload();
   apu.unload();
   ppu.unload();

--- a/ares/fc/system/system.hpp
+++ b/ares/fc/system/system.hpp
@@ -10,14 +10,16 @@ struct System {
 
     //controls.cpp
     auto load(Node::Object) -> void;
+    auto unload() -> void;
     auto poll() -> void;
   } controls;
 
-  enum class Region : u32 { NTSCJ, NTSCU, PAL };
+  enum class Region : u32 { NTSCJ, NTSCU, PAL, Dendy };
 
-  auto name() const -> string { return information.name; }
-  auto region() const -> Region { return information.region; }
-  auto frequency() const -> f64 { return information.frequency; }
+  auto name()      const -> string { return information.name;      }
+  auto region()    const -> Region { return information.region;    }
+  auto frequency() const -> f64    { return information.frequency; }
+  auto cpuDivider() const -> u8    { return information.cpuDivider; }
 
   //system.cpp
   auto game() -> string;
@@ -34,9 +36,10 @@ struct System {
 
 private:
   struct Information {
-    string name = "Famicom";
-    Region region = Region::NTSCJ;
-    f64 frequency = Constants::Colorburst::NTSC * 6.0;
+    string name       = "Famicom";
+    Region region     = Region::NTSCJ;
+    f64    frequency  = Constants::Colorburst::NTSC * 6.0;
+    u8     cpuDivider = 12;
   } information;
 
   //serialization.cpp
@@ -47,4 +50,5 @@ extern System system;
 
 auto Region::NTSCJ() -> bool { return system.region() == System::Region::NTSCJ; }
 auto Region::NTSCU() -> bool { return system.region() == System::Region::NTSCU; }
-auto Region::PAL() -> bool { return system.region() == System::Region::PAL; }
+auto Region::PAL()   -> bool { return system.region() == System::Region::PAL;   }
+auto Region::Dendy() -> bool { return system.region() == System::Region::Dendy; }

--- a/desktop-ui/emulator/dendy.cpp
+++ b/desktop-ui/emulator/dendy.cpp
@@ -1,0 +1,43 @@
+struct Dendy : Famicom {
+  Dendy();
+  auto load() -> LoadResult override;
+};
+
+Dendy::Dendy() {
+  manufacturer = "Dendy";
+  name = "Dendy";
+
+  ports.clear();
+  allocatePorts(false);
+}
+
+auto Dendy::load() -> LoadResult {
+  game = mia::Medium::create("Famicom");
+  string location = Emulator::load(game, configuration.game);
+  if(!location) return noFileSelected;
+  LoadResult result = game->load(location);
+  if(result != successful) return result;
+
+  system = mia::System::create("Famicom");
+  result = system->load();
+  if(result != successful) return result;
+
+  if(!ares::Famicom::load(root, "[Dendy] Dendy")) return otherError;
+
+  if(auto port = root->find<ares::Node::Port>("Cartridge Slot")) {
+    port->allocate();
+    port->connect();
+  }
+
+  if(auto port = root->find<ares::Node::Port>("Controller Port 1")) {
+    port->allocate("Gamepad");
+    port->connect();
+  }
+
+  if(auto port = root->find<ares::Node::Port>("Controller Port 2")) {
+    port->allocate("Gamepad");
+    port->connect();
+  }
+
+  return successful;
+}

--- a/desktop-ui/emulator/emulators.cpp
+++ b/desktop-ui/emulator/emulators.cpp
@@ -26,6 +26,7 @@ namespace ares::Atari2600 {
   }
   #include "famicom.cpp"
   #include "famicom-disk-system.cpp"
+  #include "dendy.cpp"
 #endif
 
 #ifdef CORE_GB
@@ -198,6 +199,7 @@ auto Emulator::construct() -> void {
   #ifdef CORE_FC
   emulators.push_back(std::make_shared<Famicom>());
   emulators.push_back(std::make_shared<FamicomDiskSystem>());
+  emulators.push_back(std::make_shared<Dendy>());
   #endif
 
   #ifdef CORE_SFC

--- a/desktop-ui/emulator/famicom.cpp
+++ b/desktop-ui/emulator/famicom.cpp
@@ -6,6 +6,7 @@ struct Famicom : Emulator {
   auto input(ares::Node::Input::Input) -> void override;
   auto loadTape(ares::Node::Object node, string location) -> bool override;
   auto unloadTape(ares::Node::Object node) -> void override;
+  auto allocatePorts(bool withMicrophone) -> void;
 
   std::shared_ptr<mia::Pak> famicomDataRecorder{};
 };
@@ -14,30 +15,7 @@ Famicom::Famicom() {
   manufacturer = "Nintendo";
   name = "Famicom";
 
-  for(auto id : range(2)) {
-    InputPort port{string{"Controller Port ", 1 + id}};
-
-  { InputDevice device{"Gamepad"};
-    device.digital("Up",         virtualPorts[id].pad.up);
-    device.digital("Down",       virtualPorts[id].pad.down);
-    device.digital("Left",       virtualPorts[id].pad.left);
-    device.digital("Right",      virtualPorts[id].pad.right);
-    device.digital("B",          virtualPorts[id].pad.west);
-    device.digital("A",          virtualPorts[id].pad.south);
-    device.digital("Select",     virtualPorts[id].pad.select);
-    device.digital("Start",      virtualPorts[id].pad.start);
-    device.digital("Microphone", virtualPorts[id].pad.north);
-    port.append(device); }
-
-  { InputDevice device{"Zapper"};
-    device.relative("X",         virtualPorts[id].mouse.x);
-    device.relative("Y",         virtualPorts[id].mouse.y);
-    device.digital ("Trigger",   virtualPorts[id].mouse.left);
-    port.append(device);
-    }
-
-    ports.push_back(port);
-  }
+  allocatePorts(true);
 }
 
 auto Famicom::load() -> LoadResult {
@@ -212,3 +190,32 @@ auto Famicom::unloadTape(ares::Node::Object node) -> void {
     famicomDataRecorder.reset();
   }
 }
+
+auto Famicom::allocatePorts(bool withMicrophone) -> void {
+  for(auto id : range(2)) {
+    InputPort port{string{"Controller Port ", 1 + id}};
+
+  { InputDevice device{"Gamepad"};
+    device.digital("Up",     virtualPorts[id].pad.up);
+    device.digital("Down",   virtualPorts[id].pad.down);
+    device.digital("Left",   virtualPorts[id].pad.left);
+    device.digital("Right",  virtualPorts[id].pad.right);
+    device.digital("B",      virtualPorts[id].pad.west);
+    device.digital("A",      virtualPorts[id].pad.south);
+    device.digital("Select", virtualPorts[id].pad.select);
+    device.digital("Start",  virtualPorts[id].pad.start);
+    if (withMicrophone) {
+      device.digital("Microphone", virtualPorts[id].pad.north);
+    }
+    port.append(device); }
+
+  { InputDevice device{"Zapper"};
+    device.relative("X",       virtualPorts[id].mouse.x);
+    device.relative("Y",       virtualPorts[id].mouse.y);
+    device.digital ("Trigger", virtualPorts[id].mouse.left);
+    port.append(device); }
+
+    ports.push_back(port);
+  }
+}
+


### PR DESCRIPTION
- Implement Dendy-specific timings: CPU divider 15, 312 total scanlines, and vblank starting at scanline 291.
- Refactor CPU/APU rate calculation to use a dynamic system divider instead of hardcoded PAL/NTSC checks.
- Add Dendy to the system region enumeration and UI emulator list.
- Handle Dendy-specific hardware differences: disable microphone input and adjust PPU aspect ratio/pixel output offset to match PAL-like characteristics.
- Clean up controller and system unloading logic to prevent memory leaks.