### PR TITLE
refactor: move reset state from MOS6502 to system-level CPU

### DIFF
--- a/ares/a26/cpu/cpu.cpp
+++ b/ares/a26/cpu/cpu.cpp
@@ -19,6 +19,12 @@ auto CPU::unload() -> void {
 }
 
 auto CPU::main() -> void {
+  if(io.resetPending) {
+    debugger.interrupt("Reset");
+    reset();
+    io.resetPending = 0;
+  }
+
   debugger.instruction();
   instruction();
 }
@@ -31,10 +37,11 @@ auto CPU::step(u32 clocks) -> void {
 
 auto CPU::power(bool reset) -> void {
   MOS6502::BCD = 1;
-  MOS6502::power();
+  if(!reset) MOS6502::power();
   Thread::create(system.frequency() / 3, std::bind_front(&CPU::main, this));
 
   io = {};
+  io.resetPending = 1;
 }
 
 }

--- a/ares/a26/cpu/cpu.hpp
+++ b/ares/a26/cpu/cpu.hpp
@@ -5,9 +5,11 @@ struct CPU : MOS6502, Thread {
     //debugger.cpp
     auto load(Node::Object) -> void;
     auto instruction() -> void;
+    auto interrupt(string_view) -> void;
 
     struct Tracer {
       Node::Debugger::Tracer::Instruction instruction;
+      Node::Debugger::Tracer::Notification interrupt;
     } tracer;
   } debugger;
 
@@ -39,6 +41,7 @@ struct CPU : MOS6502, Thread {
 
 //protected:
   struct IO {
+    n1  resetPending = 0;
     n1  rdyLine = 1;
     n32 scanlineCycles = 0;
     n8 openBus = 0;

--- a/ares/a26/cpu/debugger.cpp
+++ b/ares/a26/cpu/debugger.cpp
@@ -9,4 +9,8 @@ auto CPU::Debugger::instruction() -> void {
   }
 }
 
-
+auto CPU::Debugger::interrupt(string_view type) -> void {
+  if(tracer.interrupt->enabled()) {
+    tracer.interrupt->notify(type);
+  }
+}

--- a/ares/a26/cpu/serialization.cpp
+++ b/ares/a26/cpu/serialization.cpp
@@ -1,6 +1,7 @@
 auto CPU::serialize(serializer& s) -> void {
   MOS6502::serialize(s);
   Thread::serialize(s);
+  s(io.resetPending);
   s(io.rdyLine);
   s(io.openBus);
 }

--- a/ares/a26/system/serialization.cpp
+++ b/ares/a26/system/serialization.cpp
@@ -1,4 +1,4 @@
-static const string SerializerVersion = "v139";
+static const string SerializerVersion = "v140";
 
 auto System::serialize(bool synchronize) -> serializer {
   if(synchronize) scheduler.enter(Scheduler::Mode::Synchronize);

--- a/ares/component/processor/mos6502/instruction.cpp
+++ b/ares/component/processor/mos6502/instruction.cpp
@@ -25,12 +25,9 @@ auto MOS6502::reset() -> void {
   I = 1;
   PCL = read(vector++);
 L PCH = read(vector++);
-  resetting = 0;
 }
 
 auto MOS6502::instruction() -> void {
-  if(resetting) reset();
-
   switch(opcode()) {
   op(0x00, None,   addr(Implied),        fp(BRK))
   op(0x01, Load,   addr(IndirectX),      fp(ORA))

--- a/ares/component/processor/mos6502/mos6502.cpp
+++ b/ares/component/processor/mos6502/mos6502.cpp
@@ -35,19 +35,13 @@ namespace ares {
 #undef N
 #undef L
 
-auto MOS6502::power(bool reset) -> void {
- if(reset) {
-   resetting = 1;
-   return;
- }
-
+auto MOS6502::power() -> void {
   A   = 0x00;
   X   = 0x00;
   Y   = 0x00;
   S   = 0x00;
   P   = 0x04;
   MDR = 0x00;
-  resetting = 1;
 }
 
 }

--- a/ares/component/processor/mos6502/mos6502.hpp
+++ b/ares/component/processor/mos6502/mos6502.hpp
@@ -18,7 +18,7 @@ struct MOS6502 {
   virtual auto readDebugger(n16 addr) -> n8 { return 0; }
 
   //mos6502.cpp
-  auto power(bool reset = false) -> void;
+  auto power() -> void;
 
   //memory.cpp
   auto idle() -> void;
@@ -189,7 +189,6 @@ struct MOS6502 {
   n16 PC;
   n16 MAR;
   n8  MDR;
-  n1  resetting = 0;
 };
 
 }

--- a/ares/component/processor/mos6502/serialization.cpp
+++ b/ares/component/processor/mos6502/serialization.cpp
@@ -13,5 +13,4 @@ auto MOS6502::serialize(serializer& s) -> void {
   s(PC);
   s(MAR);
   s(MDR);
-  s(resetting);
 }

--- a/ares/fc/cpu/cpu.cpp
+++ b/ares/fc/cpu/cpu.cpp
@@ -24,8 +24,17 @@ auto CPU::unload() -> void {
 
 auto CPU::main() -> void {
   if(io.interruptPending) {
-    debugger.interrupt("IRQ");
-    interrupt();
+    if(io.resetPending) {
+      debugger.interrupt("Reset");
+      reset();
+      io.resetPending = 0;
+    } else if(io.nmiPending) {
+      debugger.interrupt("NMI");
+      interrupt();
+    } else {
+      debugger.interrupt("IRQ");
+      interrupt();
+    }
   }
 
   debugger.instruction();
@@ -41,7 +50,7 @@ auto CPU::step(u32 clocks) -> void {
 
 auto CPU::power(bool reset) -> void {
   MOS6502::BCD = 0;
-  MOS6502::power(reset);
+  if(!reset) MOS6502::power();
   Thread::create(system.frequency(), std::bind_front(&CPU::main, this));
 
   if(!reset) {
@@ -49,6 +58,8 @@ auto CPU::power(bool reset) -> void {
   }
 
   io = {};
+  io.resetPending = 1;
+  io.interruptPending = 1;
 }
 
 }

--- a/ares/fc/cpu/cpu.hpp
+++ b/ares/fc/cpu/cpu.hpp
@@ -63,6 +63,7 @@ struct CPU : MOS6502, Thread {
 //protected:
   struct IO {
     n1  interruptPending;
+    n1  resetPending;
     n1  nmiPending;
     n1  nmiLine;
     n1  irqLine;

--- a/ares/fc/cpu/serialization.cpp
+++ b/ares/fc/cpu/serialization.cpp
@@ -3,6 +3,7 @@ auto CPU::serialize(serializer& s) -> void {
   Thread::serialize(s);
   s(ram);
   s(io.interruptPending);
+  s(io.resetPending);
   s(io.nmiPending);
   s(io.nmiLine);
   s(io.irqLine);

--- a/ares/fc/cpu/timing.cpp
+++ b/ares/fc/cpu/timing.cpp
@@ -18,11 +18,11 @@ auto CPU::write(n16 address, n8 data) -> void {
 }
 
 auto CPU::lastCycle() -> void {
-  io.interruptPending = ((io.irqLine | io.apuLine) & !P.i) | io.nmiPending;
+  io.interruptPending = irqPending() | io.nmiPending;
 }
 
 auto CPU::cancelNmi() -> void {
-  io.interruptPending = ((io.irqLine | io.apuLine) & !P.i);
+  io.interruptPending = irqPending();
 }
 
 auto CPU::delayIrq() -> void {
@@ -35,6 +35,7 @@ auto CPU::irqPending() -> bool {
 
 auto CPU::nmi(n16& vector) -> void {
   if(io.nmiPending) {
+    if(irqPending()) debugger.interrupt("Haijack IRQ by NMI");
     io.nmiPending = false;
     vector = 0xfffa;
   }

--- a/ares/fc/system/serialization.cpp
+++ b/ares/fc/system/serialization.cpp
@@ -1,4 +1,4 @@
-static const string SerializerVersion = "v151";
+static const string SerializerVersion = "v152";
 
 auto System::serialize(bool synchronize) -> serializer {
   if(synchronize) scheduler.enter(Scheduler::Mode::Synchronize);


### PR DESCRIPTION
Refactor reset handling to align with project architecture by removing the 'resetting' flag from the MOS6502 core. The reset state is now managed via 'resetPending' within the specific A2600 and Famicom CPU implementations.

- MOS6502: Remove resetting flag and internal reset logic from power().
- CPU: Introduce io.resetPending to handle reset triggers in the main loop.
- Debugger: Add interrupt/reset notification support for better tracing.
- Serialization: Update A26 (v140) and FC (v152) versions for state changes.