### PR TITLE
Fix MMI extension loading and detection

### DIFF
--- a/desktop-ui/settings/importexport.cpp
+++ b/desktop-ui/settings/importexport.cpp
@@ -1,7 +1,7 @@
 auto ImportExportSettings::construct() -> void {
   setCollapsible();
   useImported.setText("Set Imported File As Current Settings File");
-  useImported.setChecked(settings.video.colorBleed).onToggle([&] { imported = useImported.checked(); });
+  useImported.setChecked(false).onToggle([&] { imported = useImported.checked(); });
   refresh();
 
   importButton.setText("Import" ELLIPSIS).onActivate([&] {

--- a/mia/medium/mega-cd.cpp
+++ b/mia/medium/mega-cd.cpp
@@ -1,12 +1,5 @@
 struct MegaCD : CompactDisc {
   auto name() -> string override { return "Mega CD"; }
-  auto extensions() -> std::vector<string> override {
-#if defined(ARES_ENABLE_CHD)
-    return {"cue", "chd"};
-#else
-    return {"cue"};
-#endif
-  }
   auto load(string location) -> LoadResult override;
   auto save(string location) -> bool override;
   auto analyze(string location) -> string;

--- a/mia/medium/mega-ld.cpp
+++ b/mia/medium/mega-ld.cpp
@@ -1,5 +1,5 @@
 struct MegaLD : LaserDisc {
-  auto name() -> string override { return "Mega LD"; }
+  auto name() -> string override { return "LaserActive (SEGA PAC)"; }
   auto load(string location) -> LoadResult override;
   auto save(string location) -> bool override;
 };
@@ -10,6 +10,7 @@ auto MegaLD::load(string location) -> LoadResult {
   if(!location.iendsWith(".mmi")) return invalidROM;
   if(!mmiArchive.open(location)) return invalidROM;
   if(!mmiArchive.media().size()) return invalidROM;
+  if(mmiArchive.system() != "MegaLD") return invalidROM;
 
   this->location = location;
   this->manifest = mmiArchive.manifest();

--- a/mia/medium/pc-engine-cd.cpp
+++ b/mia/medium/pc-engine-cd.cpp
@@ -1,12 +1,5 @@
 struct PCEngineCD : CompactDisc {
   auto name() -> string override { return "PC Engine CD"; }
-  auto extensions() -> std::vector<string> override {
-#if defined(ARES_ENABLE_CHD)
-    return {"cue", "chd"};
-#else
-    return {"cue"};
-#endif
-  }
   auto load(string location) -> LoadResult override;
   auto save(string location) -> bool override;
   auto analyze(string location) -> string;

--- a/mia/medium/pc-engine-ld.cpp
+++ b/mia/medium/pc-engine-ld.cpp
@@ -1,30 +1,23 @@
 struct PCEngineLD : LaserDisc {
-  auto name() -> string override { return "PC Engine LD"; }
-  auto extensions() -> std::vector<string> override {
-#if defined(ARES_ENABLE_CHD)
-    return {"cue", "chd", "mmi"};
-#else
-    return {"cue", "mmi"};
-#endif
-  }
+  auto name() -> string override { return "LaserActive (NEC PAC)"; }
   auto load(string location) -> LoadResult override;
   auto save(string location) -> bool override;
-  //auto analyze(string location) -> string;
 };
 
 auto PCEngineLD::load(string location) -> LoadResult {
   if(!inode::exists(location)) return romNotFound;
 
-  if (!mmiArchive.open(location)) return invalidROM;
-  if (!mmiArchive.media().size()) return invalidROM;
+  if(!mmiArchive.open(location)) return invalidROM;
+  if(!mmiArchive.media().size()) return invalidROM;
+  if(mmiArchive.system() != "LDROM2") return invalidROM;
 
   this->location = location;
   this->manifest = mmiArchive.manifest();
   auto document = BML::unserialize(manifest);
-  if (!document) return couldNotParseManifest;
+  if(!document) return couldNotParseManifest;
 
   string medium = "";
-  for (auto& media : mmiArchive.media()) {
+  for(auto& media : mmiArchive.media()) {
       if (medium) medium += ", ";
       medium += media.name;
   }
@@ -39,9 +32,9 @@ auto PCEngineLD::load(string location) -> LoadResult {
   pak->setAttribute("medium", medium);
   pak->append("manifest.bml", manifest);
 
-  for (auto& media : mmiArchive.media()) {
-    for (auto& stream : media.streams) {
-      if (stream.name == "DigitalAudio") {
+  for(auto& media : mmiArchive.media()) {
+    for(auto& stream : media.streams) {
+      if(stream.name == "DigitalAudio") {
         pak->append(stream.file, vfs::cdrom::open(location, stream.file));
       }
     }

--- a/mia/medium/playstation.cpp
+++ b/mia/medium/playstation.cpp
@@ -1,5 +1,12 @@
 struct PlayStation : CompactDisc {
   auto name() -> string override { return "PlayStation"; }
+  auto extensions() -> std::vector<string> override {
+#if defined(ARES_ENABLE_CHD)
+    return {"cue", "chd", "exe", "ps-exe"};
+#else
+    return {"cue", "exe"};
+#endif
+  }
   auto load(string location) -> LoadResult override;
   auto save(string location) -> bool override;
   auto analyze(string location) -> string;

--- a/mia/medium/playstation.cpp
+++ b/mia/medium/playstation.cpp
@@ -1,12 +1,5 @@
 struct PlayStation : CompactDisc {
   auto name() -> string override { return "PlayStation"; }
-  auto extensions() -> std::vector<string> override {
-#if defined(ARES_ENABLE_CHD)
-    return {"cue", "chd", "exe", "ps-exe"};
-#else
-    return {"cue", "exe"};
-#endif
-  }
   auto load(string location) -> LoadResult override;
   auto save(string location) -> bool override;
   auto analyze(string location) -> string;

--- a/mia/medium/saturn.cpp
+++ b/mia/medium/saturn.cpp
@@ -1,6 +1,5 @@
 struct Saturn : CompactDisc {
   auto name() -> string override { return "Saturn"; }
-  auto extensions() -> std::vector<string> override { return {"cue", "chd"}; }
   auto load(string location) -> LoadResult override;
   auto save(string location) -> bool override;
   auto analyze(string location) -> string;


### PR DESCRIPTION
MMI files were not properly detected/associated with their respective LaserActive cores, so loading via drag & drop or from the command line would fail (from the command line you would need to manual specify the system). Looks like this broke when it was decided to change the name of the emulator core to their PAC names at which point the medium name no longer matched. This will also check system as defined in MediaInfo.json in the MMI file and load into the correct LaserActive core. 
Note that the alternate core name strings are used in other places still, as well as struct & file names not matching the current emulator core name. Since it wasn't necessary to change these, I'm not changing anything else. 

Also cleanup extension definitions for all optical based systems. They are defined in CompactDisc & LaserDisc structs which all optical mediums derive from one or the other so specifying them in individual mediums is redundant. 

I'm including a small fix for an incorrect setting I spotted. I have no idea why the colorbleed setting was used here. 