### PR TITLE
ruby: Add Direct3D 12 display backend

### DIFF
--- a/desktop-ui/settings/drivers.cpp
+++ b/desktop-ui/settings/drivers.cpp
@@ -40,7 +40,7 @@ auto DriverSettings::construct() -> void {
     settings.video.flush = videoFlushToggle.checked();
     ruby::video.setFlush(settings.video.flush);
   });
-#if defined(PLATFORM_MACOS)
+#if defined(PLATFORM_WINDOWS) || defined(PLATFORM_MACOS)
   videoColorSpaceToggle.setText("Force sRGB").onToggle([&] {
     settings.video.forceSRGB = videoColorSpaceToggle.checked();
     ruby::video.setForceSRGB(settings.video.forceSRGB);
@@ -164,10 +164,14 @@ auto DriverSettings::videoRefresh() -> void {
   videoExclusiveToggle.setChecked(ruby::video.exclusive()).setEnabled(ruby::video.hasExclusive());
 #endif
   videoBlockingToggle.setChecked(ruby::video.blocking()).setEnabled(ruby::video.hasBlocking());
-#if defined(PLATFORM_MACOS)
-  videoColorSpaceToggle.setChecked(ruby::video.forceSRGB()).setEnabled(ruby::video.hasForceSRGB());
-  videoThreadedRendererToggle.setChecked(ruby::video.threadedRenderer()).setEnabled(ruby::video.hasThreadedRenderer());
-  videoNativeFullScreenToggle.setChecked(ruby::video.nativeFullScreen()).setEnabled(ruby::video.hasNativeFullScreen());
+#if defined(PLATFORM_WINDOWS) || defined(PLATFORM_MACOS)
+  auto hasForceSRGB = ruby::video.hasForceSRGB();
+  auto hasThreadedRenderer = ruby::video.hasThreadedRenderer();
+  auto hasNativeFullScreen = ruby::video.hasNativeFullScreen();
+
+  videoColorSpaceToggle.setChecked(ruby::video.forceSRGB()).setEnabled(hasForceSRGB);
+  videoThreadedRendererToggle.setChecked(ruby::video.threadedRenderer()).setEnabled(hasThreadedRenderer);
+  videoNativeFullScreenToggle.setChecked(ruby::video.nativeFullScreen()).setEnabled(hasNativeFullScreen);
 #endif
   videoFlushToggle.setChecked(ruby::video.flush()).setEnabled(ruby::video.hasFlush());
   VerticalLayout::resize();

--- a/desktop-ui/settings/settings.hpp
+++ b/desktop-ui/settings/settings.hpp
@@ -379,7 +379,7 @@ struct DriverSettings : VerticalLayout {
 #endif
     CheckLabel videoBlockingToggle{&videoToggleLayout, Size{0, 0}};
     CheckLabel videoFlushToggle{&videoToggleLayout, Size{0, 0}};
-#if defined(PLATFORM_MACOS)
+#if defined(PLATFORM_WINDOWS) || defined(PLATFORM_MACOS)
     CheckLabel videoColorSpaceToggle{&videoToggleLayout, Size{0, 0}};
     CheckLabel videoThreadedRendererToggle{&videoToggleLayout, Size{0, 0}};
     CheckLabel videoNativeFullScreenToggle{&videoToggleLayout, Size{0, 0}};

--- a/desktop-ui/settings/settings.hpp
+++ b/desktop-ui/settings/settings.hpp
@@ -382,7 +382,7 @@ struct DriverSettings : VerticalLayout {
 #endif
     CheckLabel videoBlockingToggle{&videoToggleLayout, Size{0, 0}};
     CheckLabel videoFlushToggle{&videoToggleLayout, Size{0, 0}};
-#if defined(PLATFORM_MACOS)
+#if defined(PLATFORM_WINDOWS) || defined(PLATFORM_MACOS)
     CheckLabel videoColorSpaceToggle{&videoToggleLayout, Size{0, 0}};
     CheckLabel videoThreadedRendererToggle{&videoToggleLayout, Size{0, 0}};
     CheckLabel videoNativeFullScreenToggle{&videoToggleLayout, Size{0, 0}};

--- a/ruby/cmake/os-windows.cmake
+++ b/ruby/cmake/os-windows.cmake
@@ -2,6 +2,7 @@ target_sources(
   ruby
   PRIVATE #
     video/direct3d9.cpp
+    video/direct3d12/d3d12device.cpp
     video/wgl.cpp
 )
 
@@ -26,6 +27,7 @@ find_package(librashader)
 find_package(XAudio2)
 
 target_enable_feature(ruby "Direct3D 9 video driver" VIDEO_DIRECT3D9)
+target_enable_feature(ruby "Direct3D 12 video driver" VIDEO_DIRECT3D12)
 target_enable_feature(ruby "OpenGL video driver" VIDEO_WGL)
 target_enable_feature(ruby "WASAPI audio driver" AUDIO_WASAPI)
 target_enable_feature(ruby "DirectSound audio driver" AUDIO_DIRECTSOUND)
@@ -39,8 +41,9 @@ endif()
 
 if(librashader_FOUND AND ARES_ENABLE_LIBRASHADER)
   target_enable_feature(ruby "librashader OpenGL runtime" LIBRA_RUNTIME_OPENGL)
+  target_enable_feature(ruby "librashader Direct3D 12 runtime" LIBRA_RUNTIME_D3D12)
 else()
-  target_compile_definitions(ruby PRIVATE LIBRA_RUNTIME_OPENGL)
+  target_compile_definitions(ruby PRIVATE LIBRA_RUNTIME_OPENGL LIBRA_RUNTIME_D3D12)
 endif()
 
 if(XAudio2_FOUND)
@@ -54,6 +57,9 @@ target_link_libraries(
     $<$<BOOL:${SDL_FOUND}>:SDL::SDL>
     $<$<BOOL:${XAudio2_FOUND}>:XAudio2::XAudio2>
     d3d9
+    d3d12
+    dxgi
+    d3dcompiler
     opengl32
     dsound
     uuid

--- a/ruby/video/direct3d12/d3d12builders.cpp
+++ b/ruby/video/direct3d12/d3d12builders.cpp
@@ -1,0 +1,116 @@
+auto createFactory() -> bool {
+  HRESULT hr = CreateDXGIFactory2(0, IID_PPV_ARGS(&_factory));
+  if(FAILED(hr))
+    return false;
+
+  IDXGIFactory5 *factory5 = nullptr;
+  if(SUCCEEDED(_factory->QueryInterface(IID_PPV_ARGS(&factory5)))) {
+    BOOL allowTearing = FALSE;
+    if(SUCCEEDED(factory5->CheckFeatureSupport(
+            DXGI_FEATURE_PRESENT_ALLOW_TEARING, &allowTearing,
+            sizeof(allowTearing)))) {
+      _allowTearing = allowTearing;
+    }
+    d3d12device_release(factory5);
+  }
+
+  return true;
+}
+
+auto detectRootSignatureSupport() -> void {
+  D3D12_FEATURE_DATA_ROOT_SIGNATURE rootSignatureFeature{};
+  rootSignatureFeature.HighestVersion = D3D_ROOT_SIGNATURE_VERSION_1_1;
+  if(FAILED(_device->CheckFeatureSupport(D3D12_FEATURE_ROOT_SIGNATURE,
+                                         &rootSignatureFeature,
+                                         sizeof(rootSignatureFeature)))) {
+    _supportsRootSignature11 = false;
+  } else {
+    _supportsRootSignature11 =
+        rootSignatureFeature.HighestVersion >= D3D_ROOT_SIGNATURE_VERSION_1_1;
+  }
+}
+
+auto createDevice() -> bool {
+  if(SUCCEEDED(D3D12CreateDevice(nullptr, D3D_FEATURE_LEVEL_11_0,
+                                 IID_PPV_ARGS(&_device)))) {
+    detectRootSignatureSupport();
+    return true;
+  }
+
+  // nullptr picks the default adapter, fall back to enumeration if that fails
+  IDXGIAdapter1 *adapter = nullptr;
+  for(UINT index = 0;
+      _factory->EnumAdapters1(index, &adapter) != DXGI_ERROR_NOT_FOUND;
+      index++) {
+    DXGI_ADAPTER_DESC1 desc{};
+    adapter->GetDesc1(&desc);
+    if(desc.Flags & DXGI_ADAPTER_FLAG_SOFTWARE) {
+      d3d12device_release(adapter);
+      continue;
+    }
+
+    if(SUCCEEDED(D3D12CreateDevice(adapter, D3D_FEATURE_LEVEL_11_0,
+                                   IID_PPV_ARGS(&_device)))) {
+      d3d12device_release(adapter);
+      detectRootSignatureSupport();
+      return true;
+    }
+
+    d3d12device_release(adapter);
+  }
+
+  return false;
+}
+
+auto createQueueAndSwapChain() -> bool {
+  D3D12_COMMAND_QUEUE_DESC queueDesc{};
+  queueDesc.Type = D3D12_COMMAND_LIST_TYPE_DIRECT;
+
+  HRESULT hr = _device->CreateCommandQueue(&queueDesc, IID_PPV_ARGS(&_queue));
+  if(FAILED(hr))
+    return false;
+
+  DXGI_SWAP_CHAIN_DESC1 desc{};
+  desc.Width = _windowWidth;
+  desc.Height = _windowHeight;
+  desc.Format = DXGI_FORMAT_B8G8R8A8_UNORM;
+  desc.SampleDesc.Count = 1;
+  desc.BufferUsage = DXGI_USAGE_RENDER_TARGET_OUTPUT;
+  desc.BufferCount = FrameCount;
+  desc.Scaling = DXGI_SCALING_STRETCH;
+  desc.SwapEffect = DXGI_SWAP_EFFECT_FLIP_DISCARD;
+  desc.Flags = (_allowTearing ? DXGI_SWAP_CHAIN_FLAG_ALLOW_TEARING : 0) |
+               DXGI_SWAP_CHAIN_FLAG_FRAME_LATENCY_WAITABLE_OBJECT;
+
+  IDXGISwapChain1 *swapChain1 = nullptr;
+  hr = _factory->CreateSwapChainForHwnd(_queue, _context, &desc, nullptr,
+                                        nullptr, &swapChain1);
+  if(FAILED(hr))
+    return false;
+
+  _factory->MakeWindowAssociation(_context, DXGI_MWA_NO_ALT_ENTER);  // we handle fullscreen ourselves
+
+  hr = swapChain1->QueryInterface(IID_PPV_ARGS(&_swapChain));
+  if(FAILED(hr)) {
+    d3d12device_release(swapChain1);
+    return false;
+  }
+  d3d12device_release(swapChain1);
+
+  _swapChain->QueryInterface(IID_PPV_ARGS(&_swapChain2));
+  if(_swapChain2) {
+    _frameLatencyWaitableObject = _swapChain2->GetFrameLatencyWaitableObject();
+  }
+
+  applySwapChainColorSpace();
+
+  _frameIndex = _swapChain->GetCurrentBackBufferIndex();
+
+  if(_exclusive) {
+    if(FAILED(_swapChain->SetFullscreenState(TRUE, nullptr))) {
+      _exclusive = false;
+    }
+  }
+
+  return true;
+}

--- a/ruby/video/direct3d12/d3d12device.cpp
+++ b/ruby/video/direct3d12/d3d12device.cpp
@@ -1,0 +1,598 @@
+#include <d3d12.h>
+#include <d3dcompiler.h>
+#include <dxgi1_6.h>
+
+#include <librashader/librashader_ld.h>
+
+#include <array>
+#include <thread>
+
+static LRESULT CALLBACK d3d12device_windowprocedure(HWND hwnd, UINT msg,
+                                                    WPARAM wparam,
+                                                    LPARAM lparam) {
+  if(msg == WM_SYSKEYDOWN && wparam == VK_F4)
+    return false;
+  return DefWindowProc(hwnd, msg, wparam, lparam);
+}
+
+template <typename T> static auto d3d12device_release(T *&resource) -> void {
+  if(resource) {
+    resource->Release();
+    resource = nullptr;
+  }
+}
+
+struct d3d12device : VideoDriver {
+  d3d12device(Video &super) : VideoDriver(super) { construct(); }
+  ~d3d12device() { destruct(); }
+
+  auto create() -> bool override { return initialize(); }
+
+  auto driver() -> string override { return "Direct3D 12"; }
+  auto ready() -> bool override { return _ready; }
+
+  auto hasFullScreen() -> bool override { return true; }
+  auto hasMonitor() -> bool override { return true; }
+  auto hasExclusive() -> bool override { return true; }
+  auto hasContext() -> bool override { return true; }
+  auto hasBlocking() -> bool override { return true; }
+  auto hasForceSRGB() -> bool override { return true; }
+  auto hasThreadedRenderer() -> bool override { return true; }
+  auto hasNativeFullScreen() -> bool override { return true; }
+  auto hasFlush() -> bool override { return true; }
+  auto hasFormats() -> std::vector<string> override {
+    return {"ARGB24", "ARGB30"};
+  }
+  auto hasShader() -> bool override { return true; }
+
+  auto setFullScreen(bool fullScreen) -> bool override {
+    this->fullScreen = fullScreen;
+    return initialize();
+  }
+  auto setMonitor(string monitor) -> bool override {
+    if(!fullScreen)
+      return true;
+    return initialize();
+  }
+  auto setExclusive(bool exclusive) -> bool override {
+    if(!fullScreen)
+      return true;
+    return initialize();
+  }
+  auto setContext(uintptr context) -> bool override {
+    this->context = context;
+    return initialize();
+  }
+
+  auto setBlocking(bool blocking) -> bool override {
+    _blockingEnabled.store(blocking, std::memory_order_relaxed);
+    updatePresentMode();
+    return true;
+  }
+
+  auto setForceSRGB(bool forceSRGB) -> bool override {
+    if(_forceSRGB == forceSRGB)
+      return true;
+
+    _forceSRGB = forceSRGB;
+
+    lock_guard<std::mutex> lock(_renderMutex);
+    applySwapChainColorSpace();
+    return true;
+  }
+
+  auto setThreadedRenderer(bool threadedRenderer) -> bool override {
+    if(_threaded.load(std::memory_order_relaxed) == threadedRenderer)
+      return true;
+    _threaded.store(threadedRenderer, std::memory_order_relaxed);
+    if(!_ready)
+      return true;
+
+    if(_threaded.load(std::memory_order_relaxed)) {
+      startRenderThread();
+    } else {
+      stopRenderThread(true);
+    }
+    updatePresentMode();
+
+    return true;
+  }
+
+  auto setNativeFullScreen(bool nativeFullScreen) -> bool override {
+    if(fullScreen)
+      return initialize();
+    return true;
+  }
+
+  auto setFlush(bool flush) -> bool override {
+    this->flush = flush;
+    return true;
+  }
+
+  auto setFormat(string format) -> bool override {
+    if(!updateSourceFormat(format))
+      return false;
+
+    lock_guard<std::mutex> lock(_renderMutex);
+    if(_ready && _sourceWidth && _sourceHeight) {
+      return resizeSource(_sourceWidth, _sourceHeight);
+    }
+
+    return true;
+  }
+
+  auto setShader(string shader) -> bool override {
+    this->shader = shader;
+    return updateShader();
+  }
+
+  auto refreshRateHint(double refreshRate) -> void override {
+    if(_refreshRateHint == refreshRate)
+      return;
+    _refreshRateHint = refreshRate;
+    updatePresentMode();
+  }
+
+  auto focused() -> bool override {
+    if(fullScreen && _exclusive)
+      return true;
+    auto focused = GetFocus();
+    return _context == focused || IsChild(_context, focused);
+  }
+
+  auto clear() -> void override {
+    if(_buffer.size())
+      memory::fill(_buffer.data(), _buffer.size() * sizeof(u32));
+    if(!_ready)
+      return;
+
+    u32 width = 0;
+    u32 height = 0;
+    size(width, height);
+    if(!(width && height))
+      return;
+
+    if(_sourceWidth && _sourceHeight) {
+      output(width, height);
+      return;
+    }
+
+    renderFrame(width, height, 0, 0, nullptr);
+  }
+
+  auto size(u32& width, u32& height) -> void override {
+    if(!_context) {
+      width = 0;
+      height = 0;
+      return;
+    }
+
+    RECT rectangle{};
+    GetClientRect(_context, &rectangle);
+
+    width = rectangle.right - rectangle.left;
+    height = rectangle.bottom - rectangle.top;
+  }
+
+  auto acquire(u32*& data, u32& pitch, u32 width, u32 height) -> bool override {
+    if(!_ready)
+      return false;
+    if(!width || !height)
+      return false;
+
+    if(width != _sourceWidth || height != _sourceHeight) {
+      _buffer.resize(width * height);
+      if(_buffer.size())
+        memory::fill(_buffer.data(), _buffer.size() * sizeof(u32));
+
+      lock_guard<std::mutex> lock(_renderMutex);
+      if(!resizeSource(width, height))
+        return false;
+    }
+
+    pitch = _sourceWidth * sizeof(u32);
+    data = _buffer.data();
+    return true;
+  }
+
+  auto release() -> void override {}
+
+  auto output(u32 width, u32 height) -> void override {
+    if(_lost.exchange(false)) {
+      if(!initialize()) {
+        _lost.store(true);
+        return;
+      }
+    }
+
+    if(_threaded.load(std::memory_order_relaxed)) {
+      submitThreadedFrame(width, height);
+      return;
+    }
+
+    renderFrame(width, height, _sourceWidth, _sourceHeight, _buffer.data());
+  }
+
+private:
+  static constexpr u32 FrameCount = 2;
+
+  struct Vertex {
+    float position[4];
+    float uv[2];
+  };
+
+  auto construct() -> void {
+    WNDCLASS windowClass{};
+    windowClass.hbrBackground = (HBRUSH)GetStockObject(BLACK_BRUSH);
+    windowClass.hCursor = LoadCursor(0, IDC_ARROW);
+    windowClass.hIcon = LoadIcon(nullptr, IDI_APPLICATION);
+    windowClass.hInstance = GetModuleHandle(0);
+    windowClass.lpfnWndProc = d3d12device_windowprocedure;
+    windowClass.lpszClassName = L"d3d12device_window";
+    windowClass.style = CS_HREDRAW | CS_VREDRAW;
+    RegisterClass(&windowClass);
+
+    _threaded.store(threadedRenderer, std::memory_order_relaxed);
+    _blockingEnabled.store(blocking, std::memory_order_relaxed);
+    _presentSyncInterval.store(blocking ? 1 : 0, std::memory_order_relaxed);
+  }
+
+  auto queryCurrentRefreshRateHz() -> double {
+    if(!_context)
+      return 0.0;
+
+    auto monitor = MonitorFromWindow(_context, MONITOR_DEFAULTTONEAREST);
+    if(!monitor)
+      return 0.0;
+
+    MONITORINFOEX monitorInfo{};
+    monitorInfo.cbSize = sizeof(monitorInfo);
+    if(!GetMonitorInfo(monitor, &monitorInfo))
+      return 0.0;
+
+    DEVMODE displayMode{};
+    displayMode.dmSize = sizeof(displayMode);
+    if(!EnumDisplaySettings(monitorInfo.szDevice, ENUM_CURRENT_SETTINGS,
+                             &displayMode)) {
+      return 0.0;
+    }
+
+    if(displayMode.dmDisplayFrequency <= 1)
+      return 0.0;
+
+    return (double)displayMode.dmDisplayFrequency;
+  }
+
+  auto computePresentSyncInterval() -> UINT {
+    if(!_blockingEnabled.load(std::memory_order_relaxed))
+      return 0;
+
+    if(_refreshRateHint > 0.0) {
+      auto refreshRate = queryCurrentRefreshRateHz();
+      if(refreshRate > 0.0) {
+        auto ratio = refreshRate / _refreshRateHint;
+        if(ratio < 1.0)
+          ratio = 1.0;
+
+        auto syncInterval = (UINT)(ratio + 0.5);
+        if(syncInterval > 4)
+          syncInterval = 4;
+        return syncInterval;
+      }
+    }
+
+    return 1;
+  }
+
+  auto applySwapChainColorSpace() -> void {
+    if(!_swapChain)
+      return;
+
+    DXGI_COLOR_SPACE_TYPE targetColorSpace =
+        DXGI_COLOR_SPACE_RGB_FULL_G22_NONE_P709;
+
+    if(!_forceSRGB) {
+      IDXGIOutput *output = nullptr;
+      if(SUCCEEDED(_swapChain->GetContainingOutput(&output)) && output) {
+        IDXGIOutput6 *output6 = nullptr;
+        if(SUCCEEDED(output->QueryInterface(IID_PPV_ARGS(&output6))) &&
+            output6) {
+          DXGI_OUTPUT_DESC1 outputDesc{};
+          if(SUCCEEDED(output6->GetDesc1(&outputDesc))) {
+            targetColorSpace = outputDesc.ColorSpace;
+          }
+          d3d12device_release(output6);
+        }
+        d3d12device_release(output);
+      }
+    }
+
+    UINT support = 0;
+    if(FAILED(
+            _swapChain->CheckColorSpaceSupport(targetColorSpace, &support)) ||
+        !(support & DXGI_SWAP_CHAIN_COLOR_SPACE_SUPPORT_FLAG_PRESENT)) {
+      targetColorSpace = DXGI_COLOR_SPACE_RGB_FULL_G22_NONE_P709;
+      if(FAILED(
+              _swapChain->CheckColorSpaceSupport(targetColorSpace, &support)) ||
+          !(support & DXGI_SWAP_CHAIN_COLOR_SPACE_SUPPORT_FLAG_PRESENT)) {
+        return;
+      }
+    }
+
+    _swapChain->SetColorSpace1(targetColorSpace);
+  }
+
+  auto destruct() -> void { terminate(); }
+
+  auto initialize() -> bool {
+    auto fail = [&]() -> bool {
+      terminate();
+      return false;
+    };
+
+    terminate();
+    _lost.store(false);
+    _threaded.store(threadedRenderer, std::memory_order_relaxed);
+    _blockingEnabled.store(blocking, std::memory_order_relaxed);
+    _forceSRGB = forceSRGB;
+    if(!updateSourceFormat(format)) {
+      updateSourceFormat("ARGB24");
+    }
+    if(!fullScreen && !context)
+      return fail();
+
+    auto monitor = Video::monitor(this->monitor);
+    _monitorX = monitor.x;
+    _monitorY = monitor.y;
+    _monitorWidth = monitor.width;
+    _monitorHeight = monitor.height;
+
+    _exclusive = fullScreen && exclusive && !nativeFullScreen;
+
+    if(fullScreen) {
+      _context = _window = CreateWindowEx(
+          WS_EX_TOPMOST, L"d3d12device_window", L"", WS_VISIBLE | WS_POPUP,
+          _monitorX, _monitorY, _monitorWidth, _monitorHeight, nullptr, nullptr,
+          GetModuleHandle(0), nullptr);
+    } else {
+      _context = (HWND)context;
+    }
+
+    if(!_context)
+      return fail();
+
+    RECT rectangle{};
+    GetClientRect(_context, &rectangle);
+    _windowWidth = rectangle.right - rectangle.left;
+    _windowHeight = rectangle.bottom - rectangle.top;
+    if(!_windowWidth)
+      _windowWidth = 1;
+    if(!_windowHeight)
+      _windowHeight = 1;
+
+    if(!createFactory())
+      return fail();
+    if(!createDevice())
+      return fail();
+    if(!createQueueAndSwapChain())
+      return fail();
+    if(!createRenderTargets())
+      return fail();
+    if(!createCommandObjects())
+      return fail();
+    if(!createDescriptorHeaps())
+      return fail();
+    if(!createPipeline())
+      return fail();
+    if(!createVertexBuffer())
+      return fail();
+
+    _libra = librashader_load_instance();
+    if(!_libra.instance_loaded) {
+      print("Direct3D 12: Failed to load librashader: shaders will be "
+            "disabled\n");
+    }
+
+    updateShader();
+
+    _ready = true;
+    updatePresentMode();
+    if(_threaded.load(std::memory_order_relaxed))
+      startRenderThread();
+    return true;
+  }
+
+  auto terminate() -> void {
+    _ready = false;
+    _lost.store(false);
+    stopRenderThread(true);
+    lock_guard<std::mutex> renderLock(_renderMutex);
+
+    if(_swapChain) {
+      _swapChain->SetFullscreenState(FALSE, nullptr);
+    }
+
+    waitForGpu();
+
+    if(_filterChain) {
+      _libra.d3d12_filter_chain_free(&_filterChain);
+      _filterChain = nullptr;
+    }
+    if(_preset) {
+      _libra.preset_free(&_preset);
+      _preset = nullptr;
+    }
+
+    _buffer.clear();
+    _buffer.shrink_to_fit();
+
+    d3d12device_release(_shaderTarget);
+    _shaderTargetState = D3D12_RESOURCE_STATE_COMMON;
+    _shaderTargetRtvValid = false;
+    _shaderWidth = 0;
+    _shaderHeight = 0;
+
+    d3d12device_release(_sourceUpload);
+    d3d12device_release(_sourceTexture);
+    _sourceWidth = 0;
+    _sourceHeight = 0;
+    resetSrvDescriptorCache();
+
+    d3d12device_release(_vertexBuffer);
+    d3d12device_release(_pipelineState);
+    d3d12device_release(_rootSignature);
+
+    d3d12device_release(_srvHeap);
+
+    for(auto &target : _renderTargets) {
+      d3d12device_release(target);
+    }
+    d3d12device_release(_rtvHeap);
+
+    d3d12device_release(_commandList);
+    for(auto &allocator : _commandAllocators) {
+      d3d12device_release(allocator);
+    }
+
+    d3d12device_release(_fence);
+    if(_fenceEvent) {
+      CloseHandle(_fenceEvent);
+      _fenceEvent = nullptr;
+    }
+
+    d3d12device_release(_swapChain);
+    d3d12device_release(_swapChain2);
+    d3d12device_release(_queue);
+    d3d12device_release(_device);
+    d3d12device_release(_factory);
+
+    if(_window) {
+      DestroyWindow(_window);
+      _window = nullptr;
+    }
+
+    _context = nullptr;
+    _frameLatencyWaitableObject = nullptr;
+    _frameIndex = 0;
+    _fenceValue = 0;
+    _fenceValues = {};
+  }
+
+  auto resetSrvDescriptorCache() -> void {
+    _srvCacheFilterSrcRes = nullptr;
+    _srvCacheFilterSrcFmt = DXGI_FORMAT_UNKNOWN;
+    _srvCacheBlitRes = nullptr;
+    _srvCacheBlitFmt = DXGI_FORMAT_UNKNOWN;
+  }
+
+#include <ruby/video/direct3d12/d3d12builders.cpp>
+#include <ruby/video/direct3d12/d3d12resources.cpp>
+#include <ruby/video/direct3d12/d3d12thread.cpp>
+#include <ruby/video/direct3d12/d3d12present.cpp>
+
+  auto updatePresentMode() -> void {
+    auto syncInterval = computePresentSyncInterval();
+    _presentSyncInterval.store(syncInterval, std::memory_order_relaxed);
+
+    lock_guard<std::mutex> lock(_renderMutex);
+    if(!_swapChain2)
+      return;
+    bool blockingEnabled = _blockingEnabled.load(std::memory_order_relaxed);
+    bool threadedEnabled = _threaded.load(std::memory_order_relaxed);
+    u32 maxLatency = blockingEnabled ? 1 : (threadedEnabled ? 2 : 1);
+    _swapChain2->SetMaximumFrameLatency(maxLatency);
+  }
+
+  bool _ready = false;
+
+  HWND _window = nullptr;
+  HWND _context = nullptr;
+
+  s32 _monitorX = 0;
+  s32 _monitorY = 0;
+  s32 _monitorWidth = 0;
+  s32 _monitorHeight = 0;
+  bool _exclusive = false;
+
+  u32 _windowWidth = 1;
+  u32 _windowHeight = 1;
+
+  IDXGIFactory4 *_factory = nullptr;
+  ID3D12Device *_device = nullptr;
+  ID3D12CommandQueue *_queue = nullptr;
+  IDXGISwapChain3 *_swapChain = nullptr;
+  IDXGISwapChain2 *_swapChain2 = nullptr;
+  HANDLE _frameLatencyWaitableObject = nullptr;
+
+  ID3D12DescriptorHeap *_rtvHeap = nullptr;
+  UINT _rtvDescriptorSize = 0;
+  std::array<ID3D12Resource *, FrameCount> _renderTargets = {nullptr, nullptr};
+
+  std::array<ID3D12CommandAllocator *, FrameCount> _commandAllocators = {
+      nullptr, nullptr};
+  ID3D12GraphicsCommandList *_commandList = nullptr;
+
+  ID3D12Fence *_fence = nullptr;
+  HANDLE _fenceEvent = nullptr;
+  std::array<u64, FrameCount> _fenceValues = {};
+  u64 _fenceValue = 0;
+  u32 _frameIndex = 0;
+
+  bool _allowTearing = false;
+  bool _supportsRootSignature11 = false;
+  std::atomic<bool> _lost{false};
+  std::atomic<bool> _threaded{true};
+  std::atomic<bool> _blockingEnabled{true};
+  std::atomic<UINT> _presentSyncInterval{1};
+  bool _forceSRGB = false;
+  double _refreshRateHint = 0.0;
+
+  std::thread _renderThread;
+  std::mutex _threadMutex;
+  std::condition_variable _threadCV;
+  std::condition_variable _threadDoneCV;
+  bool _threadExit = false;
+  bool _threadPending = false;
+  bool _threadBusy = false;
+  std::vector<u32> _threadFrameBuffer;
+  u32 _threadSourceWidth = 0;
+  u32 _threadSourceHeight = 0;
+  u32 _threadOutputWidth = 0;
+  u32 _threadOutputHeight = 0;
+
+  std::mutex _renderMutex;
+
+  ID3D12DescriptorHeap *_srvHeap = nullptr;
+  UINT _srvDescriptorSize = 0;
+  ID3D12Resource *_srvCacheFilterSrcRes = nullptr;
+  DXGI_FORMAT _srvCacheFilterSrcFmt = DXGI_FORMAT_UNKNOWN;
+  ID3D12Resource *_srvCacheBlitRes = nullptr;
+  DXGI_FORMAT _srvCacheBlitFmt = DXGI_FORMAT_UNKNOWN;
+
+  ID3D12RootSignature *_rootSignature = nullptr;
+  ID3D12PipelineState *_pipelineState = nullptr;
+
+  ID3D12Resource *_vertexBuffer = nullptr;
+  D3D12_VERTEX_BUFFER_VIEW _vertexBufferView = {};
+
+  ID3D12Resource *_sourceTexture = nullptr;
+  ID3D12Resource *_sourceUpload = nullptr;
+  D3D12_PLACED_SUBRESOURCE_FOOTPRINT _sourceFootprint = {};
+  D3D12_RESOURCE_STATES _sourceState = D3D12_RESOURCE_STATE_COPY_DEST;
+  DXGI_FORMAT _sourceFormat = DXGI_FORMAT_B8G8R8A8_UNORM;
+  u32 _sourceWidth = 0;
+  u32 _sourceHeight = 0;
+  std::vector<u32> _buffer;
+
+  ID3D12Resource *_shaderTarget = nullptr;
+  D3D12_RESOURCE_STATES _shaderTargetState = D3D12_RESOURCE_STATE_COMMON;
+  bool _shaderTargetRtvValid = false;
+  DXGI_FORMAT _shaderTargetFormat = DXGI_FORMAT_B8G8R8A8_UNORM;
+  u32 _shaderWidth = 0;
+  u32 _shaderHeight = 0;
+
+  libra_instance_t _libra = {};
+  libra_shader_preset_t _preset = nullptr;
+  libra_d3d12_filter_chain_t _filterChain = nullptr;
+  u32 _frameCount = 0;
+};

--- a/ruby/video/direct3d12/d3d12present.cpp
+++ b/ruby/video/direct3d12/d3d12present.cpp
@@ -1,0 +1,335 @@
+auto renderFrame(u32 width, u32 height, u32 sourceWidth, u32 sourceHeight,
+                 const u32 *sourceData) -> void {
+  if(!_ready || !_swapChain || !_context)
+    return;
+  bool hasSource = sourceData && sourceWidth && sourceHeight;
+
+  lock_guard<std::mutex> renderLock(_renderMutex);
+
+  u32 windowWidth = 0;
+  u32 windowHeight = 0;
+  size(windowWidth, windowHeight);
+  if(!windowWidth || !windowHeight)
+    return;
+
+  if(windowWidth != _windowWidth || windowHeight != _windowHeight) {
+    _windowWidth = windowWidth;
+    _windowHeight = windowHeight;
+    if(!resizeSwapChain())
+      return;
+  }
+
+  if(!width)
+    width = windowWidth;
+  if(!height)
+    height = windowHeight;
+
+  if(width > windowWidth)
+    width = windowWidth;
+  if(height > windowHeight)
+    height = windowHeight;
+
+  if(hasSource) {
+    if(sourceWidth != _sourceWidth || sourceHeight != _sourceHeight ||
+        !_sourceTexture || !_sourceUpload) {
+      if(!resizeSource(sourceWidth, sourceHeight))
+        return;
+    }
+  }
+
+  if(!beginFrame())
+    return;
+  ID3D12Resource *sampledResource = nullptr;
+  if(hasSource) {
+    if(!uploadSourceTexture(sourceData, sourceWidth, sourceHeight)) {
+      endFrame(false);
+      return;
+    }
+    sampledResource = _sourceTexture;
+
+    if(_filterChain) {
+      if(!ensureShaderTarget(width, height)) {
+        endFrame(false);
+        return;
+      }
+
+      D3D12_SHADER_RESOURCE_VIEW_DESC filterInputSrvDesc{};
+      filterInputSrvDesc.Format = _sourceFormat;
+      filterInputSrvDesc.Shader4ComponentMapping =
+          D3D12_DEFAULT_SHADER_4_COMPONENT_MAPPING;
+      filterInputSrvDesc.ViewDimension = D3D12_SRV_DIMENSION_TEXTURE2D;
+      filterInputSrvDesc.Texture2D.MostDetailedMip = 0;
+      filterInputSrvDesc.Texture2D.MipLevels = 1;
+
+      auto filterInputSrvHandle =
+          _srvHeap->GetCPUDescriptorHandleForHeapStart();
+      if(_sourceTexture != _srvCacheFilterSrcRes ||
+          _sourceFormat != _srvCacheFilterSrcFmt) {
+        _device->CreateShaderResourceView(_sourceTexture, &filterInputSrvDesc,
+                                          filterInputSrvHandle);
+        _srvCacheFilterSrcRes = _sourceTexture;
+        _srvCacheFilterSrcFmt = _sourceFormat;
+      }
+
+      transitionResource(_shaderTarget, _shaderTargetState,
+                         D3D12_RESOURCE_STATE_RENDER_TARGET);
+      _shaderTargetState = D3D12_RESOURCE_STATE_RENDER_TARGET;
+
+      libra_image_d3d12_t input{};
+      input.image_type = LIBRA_D3D12_IMAGE_TYPE_SOURCE_IMAGE;
+      input.handle.source.descriptor = filterInputSrvHandle;
+      input.handle.source.resource = _sourceTexture;
+
+      libra_image_d3d12_t output{};
+      output.image_type = LIBRA_D3D12_IMAGE_TYPE_RESOURCE;
+      output.handle.resource = _shaderTarget;
+
+      if(auto error = _libra.d3d12_filter_chain_frame(
+              &_filterChain, _commandList, _frameCount++, input, output,
+              nullptr, nullptr, nullptr)) {
+        _libra.error_print(error);
+        sampledResource = _sourceTexture;
+      } else {
+        sampledResource = _shaderTarget;
+      }
+
+      transitionResource(_shaderTarget, _shaderTargetState,
+                         D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE);
+      _shaderTargetState = D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE;
+    }
+  }
+
+  transitionResource(_renderTargets[_frameIndex], D3D12_RESOURCE_STATE_PRESENT,
+                     D3D12_RESOURCE_STATE_RENDER_TARGET);
+
+  auto rtvStart = _rtvHeap->GetCPUDescriptorHandleForHeapStart();
+  D3D12_CPU_DESCRIPTOR_HANDLE rtv = rtvStart;
+  rtv.ptr += _frameIndex * _rtvDescriptorSize;
+
+  _commandList->OMSetRenderTargets(1, &rtv, FALSE, nullptr);
+
+  float clearColor[4] = {0.0f, 0.0f, 0.0f, 1.0f};
+  _commandList->ClearRenderTargetView(rtv, clearColor, 0, nullptr);
+
+  D3D12_VIEWPORT viewport{};
+  viewport.TopLeftX = (float)((windowWidth - width) / 2);
+  viewport.TopLeftY = (float)((windowHeight - height) / 2);
+  viewport.Width = (float)width;
+  viewport.Height = (float)height;
+  viewport.MinDepth = 0.0f;
+  viewport.MaxDepth = 1.0f;
+
+  D3D12_RECT scissor{};
+  scissor.left = (LONG)viewport.TopLeftX;
+  scissor.top = (LONG)viewport.TopLeftY;
+  scissor.right = scissor.left + (LONG)width;
+  scissor.bottom = scissor.top + (LONG)height;
+
+  _commandList->RSSetViewports(1, &viewport);
+  _commandList->RSSetScissorRects(1, &scissor);
+
+  if(hasSource) {
+    const DXGI_FORMAT blitFmt =
+        sampledResource == _shaderTarget ? _shaderTargetFormat : _sourceFormat;
+    D3D12_SHADER_RESOURCE_VIEW_DESC srvDesc{};
+    srvDesc.Format = blitFmt;
+    srvDesc.Shader4ComponentMapping = D3D12_DEFAULT_SHADER_4_COMPONENT_MAPPING;
+    srvDesc.ViewDimension = D3D12_SRV_DIMENSION_TEXTURE2D;
+    srvDesc.Texture2D.MostDetailedMip = 0;
+    srvDesc.Texture2D.MipLevels = 1;
+
+    auto blitSrvCpu = _srvHeap->GetCPUDescriptorHandleForHeapStart();
+    blitSrvCpu.ptr += _srvDescriptorSize;
+    if(sampledResource != _srvCacheBlitRes || blitFmt != _srvCacheBlitFmt) {
+      _device->CreateShaderResourceView(sampledResource, &srvDesc, blitSrvCpu);
+      _srvCacheBlitRes = sampledResource;
+      _srvCacheBlitFmt = blitFmt;
+    }
+
+    auto blitSrvGpu = _srvHeap->GetGPUDescriptorHandleForHeapStart();
+    blitSrvGpu.ptr += _srvDescriptorSize;
+
+    ID3D12DescriptorHeap *descriptorHeaps[] = {_srvHeap};
+    _commandList->SetDescriptorHeaps(1, descriptorHeaps);
+    _commandList->SetGraphicsRootSignature(_rootSignature);
+    _commandList->SetPipelineState(_pipelineState);
+    _commandList->SetGraphicsRootDescriptorTable(0, blitSrvGpu);
+
+    _commandList->IASetPrimitiveTopology(D3D_PRIMITIVE_TOPOLOGY_TRIANGLESTRIP);
+    _commandList->IASetVertexBuffers(0, 1, &_vertexBufferView);
+    _commandList->DrawInstanced(4, 1, 0, 0);
+  }
+
+  transitionResource(_renderTargets[_frameIndex],
+                     D3D12_RESOURCE_STATE_RENDER_TARGET,
+                     D3D12_RESOURCE_STATE_PRESENT);
+  endFrame(true);
+}
+
+auto beginFrame() -> bool {
+  bool blockingEnabled = _blockingEnabled.load(std::memory_order_relaxed);
+  if(blockingEnabled && _frameLatencyWaitableObject) {
+    DWORD waitResult = WaitForSingleObject(_frameLatencyWaitableObject, 100);
+    if(waitResult == WAIT_FAILED) {
+      markLost();
+      return false;
+    }
+    if(waitResult == WAIT_TIMEOUT)
+      return false;
+    if(waitResult != WAIT_OBJECT_0 && waitResult != WAIT_ABANDONED) {
+      markLost();
+      return false;
+    }
+  }
+
+  if(_fence->GetCompletedValue() < _fenceValues[_frameIndex]) {
+    auto signalResult =
+        _fence->SetEventOnCompletion(_fenceValues[_frameIndex], _fenceEvent);
+    if(FAILED(signalResult)) {
+      markLost();
+      return false;
+    }
+    DWORD waitResult = WaitForSingleObject(_fenceEvent, INFINITE);
+    if(waitResult != WAIT_OBJECT_0 && waitResult != WAIT_ABANDONED) {
+      markLost();
+      return false;
+    }
+  }
+
+  HRESULT hr = _commandAllocators[_frameIndex]->Reset();
+  if(FAILED(hr)) {
+    markLost();
+    return false;
+  }
+
+  hr = _commandList->Reset(_commandAllocators[_frameIndex], nullptr);
+  if(FAILED(hr)) {
+    markLost();
+    return false;
+  }
+
+  return true;
+}
+
+auto endFrame(bool present) -> bool {
+  HRESULT hr = _commandList->Close();
+  if(FAILED(hr)) {
+    markLost();
+    return false;
+  }
+
+  ID3D12CommandList *lists[] = {_commandList};
+  _queue->ExecuteCommandLists(1, lists);
+
+  UINT presentFlags = 0;
+  if(present) {
+    bool blockingEnabled = _blockingEnabled.load(std::memory_order_relaxed);
+    bool threadedEnabled = _threaded.load(std::memory_order_relaxed);
+    if(!blockingEnabled && _allowTearing && !_exclusive) {
+      presentFlags = DXGI_PRESENT_ALLOW_TEARING;
+    }
+    if(!blockingEnabled && threadedEnabled) {
+      presentFlags |= DXGI_PRESENT_DO_NOT_WAIT;
+    }
+
+    auto syncInterval = _presentSyncInterval.load(std::memory_order_relaxed);
+    auto status = _swapChain->Present(syncInterval, presentFlags);
+    if(status != DXGI_ERROR_WAS_STILL_DRAWING &&
+        status != DXGI_STATUS_OCCLUDED && FAILED(status)) {
+      markLost();
+      return false;
+    }
+  }
+
+  auto signalValue = ++_fenceValue;
+  hr = _queue->Signal(_fence, signalValue);
+  if(FAILED(hr)) {
+    markLost();
+    return false;
+  }
+
+  _fenceValues[_frameIndex] = signalValue;
+  _frameIndex = _swapChain->GetCurrentBackBufferIndex();
+
+  if(flush)
+    waitForGpu();
+  return true;
+}
+
+auto waitForGpu() -> void {
+  if(!_queue || !_fence || !_fenceEvent)
+    return;
+
+  auto signalValue = ++_fenceValue;
+  HRESULT hr = _queue->Signal(_fence, signalValue);
+  if(FAILED(hr)) {
+    markLost();
+    return;
+  }
+  hr = _fence->SetEventOnCompletion(signalValue, _fenceEvent);
+  if(FAILED(hr)) {
+    markLost();
+    return;
+  }
+  DWORD waitResult = WaitForSingleObject(_fenceEvent, INFINITE);
+  if(waitResult != WAIT_OBJECT_0 && waitResult != WAIT_ABANDONED) {
+    markLost();
+    return;
+  }
+
+  for(u32 index = 0; index < FrameCount; index++) {
+    _fenceValues[index] = signalValue;
+  }
+}
+
+auto resizeSwapChain() -> bool {
+  if(!_swapChain || !_device)
+    return false;
+
+  waitForGpu();
+
+  for(auto& target : _renderTargets) {
+    d3d12device_release(target);
+  }
+
+  DXGI_SWAP_CHAIN_DESC desc{};
+  HRESULT hr = _swapChain->GetDesc(&desc);
+  if(FAILED(hr)) {
+    markLost();
+    return false;
+  }
+
+  auto width = _windowWidth ? _windowWidth : 1;
+  auto height = _windowHeight ? _windowHeight : 1;
+
+  hr = _swapChain->ResizeBuffers(FrameCount, width, height,
+                                 desc.BufferDesc.Format, desc.Flags);
+  if(FAILED(hr)) {
+    markLost();
+    return false;
+  }
+
+  applySwapChainColorSpace();
+
+  _frameIndex = _swapChain->GetCurrentBackBufferIndex();
+
+  d3d12device_release(_rtvHeap);
+  return createRenderTargets();
+}
+
+auto markLost() -> void { _lost.store(true); }
+
+auto transitionResource(ID3D12Resource *resource, D3D12_RESOURCE_STATES before,
+                        D3D12_RESOURCE_STATES after) -> void {
+  if(!resource || before == after)
+    return;
+
+  D3D12_RESOURCE_BARRIER barrier{};
+  barrier.Type = D3D12_RESOURCE_BARRIER_TYPE_TRANSITION;
+  barrier.Transition.pResource = resource;
+  barrier.Transition.StateBefore = before;
+  barrier.Transition.StateAfter = after;
+  barrier.Transition.Subresource = D3D12_RESOURCE_BARRIER_ALL_SUBRESOURCES;
+
+  _commandList->ResourceBarrier(1, &barrier);
+}

--- a/ruby/video/direct3d12/d3d12resources.cpp
+++ b/ruby/video/direct3d12/d3d12resources.cpp
@@ -1,0 +1,524 @@
+auto createRenderTargets() -> bool {
+  D3D12_DESCRIPTOR_HEAP_DESC heapDesc{};
+  heapDesc.NumDescriptors = FrameCount + 1;  // +1 for the shader target when a filter chain is active
+  heapDesc.Type = D3D12_DESCRIPTOR_HEAP_TYPE_RTV;
+
+  HRESULT hr =
+      _device->CreateDescriptorHeap(&heapDesc, IID_PPV_ARGS(&_rtvHeap));
+  if(FAILED(hr))
+    return false;
+
+  _rtvDescriptorSize =
+      _device->GetDescriptorHandleIncrementSize(D3D12_DESCRIPTOR_HEAP_TYPE_RTV);
+
+  auto handle = _rtvHeap->GetCPUDescriptorHandleForHeapStart();
+  for(u32 index = 0; index < FrameCount; index++) {
+    hr = _swapChain->GetBuffer(index, IID_PPV_ARGS(&_renderTargets[index]));
+    if(FAILED(hr))
+      return false;
+    _device->CreateRenderTargetView(_renderTargets[index], nullptr, handle);
+    handle.ptr += _rtvDescriptorSize;
+  }
+
+  _shaderTargetRtvValid = false;
+
+  return true;
+}
+
+auto createCommandObjects() -> bool {
+  HRESULT hr;
+  for(u32 index = 0; index < FrameCount; index++) {
+    hr = _device->CreateCommandAllocator(
+        D3D12_COMMAND_LIST_TYPE_DIRECT,
+        IID_PPV_ARGS(&_commandAllocators[index]));
+    if(FAILED(hr))
+      return false;
+  }
+
+  hr = _device->CreateCommandList(0, D3D12_COMMAND_LIST_TYPE_DIRECT,
+                                  _commandAllocators[_frameIndex], nullptr,
+                                  IID_PPV_ARGS(&_commandList));
+  if(FAILED(hr))
+    return false;
+  // command lists start in the recording state, close immediately so beginFrame can reset it
+  hr = _commandList->Close();
+  if(FAILED(hr))
+    return false;
+
+  hr = _device->CreateFence(0, D3D12_FENCE_FLAG_NONE, IID_PPV_ARGS(&_fence));
+  if(FAILED(hr))
+    return false;
+
+  _fenceEvent = CreateEvent(nullptr, FALSE, FALSE, nullptr);
+  if(!_fenceEvent)
+    return false;
+
+  return true;
+}
+
+auto createDescriptorHeaps() -> bool {
+  D3D12_DESCRIPTOR_HEAP_DESC heapDesc{};
+  heapDesc.NumDescriptors = 2;
+  heapDesc.Type = D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV;
+  heapDesc.Flags = D3D12_DESCRIPTOR_HEAP_FLAG_SHADER_VISIBLE;
+
+  HRESULT hr =
+      _device->CreateDescriptorHeap(&heapDesc, IID_PPV_ARGS(&_srvHeap));
+  if(FAILED(hr))
+    return false;
+
+  _srvDescriptorSize = _device->GetDescriptorHandleIncrementSize(
+      D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV);
+  return true;
+}
+
+auto createPipeline() -> bool {
+  struct CompiledShader {
+    IUnknown *blob = nullptr;
+    const void *bytecode = nullptr;
+    SIZE_T length = 0;
+  };
+
+  auto releaseCompiledShader = [&](CompiledShader &shader) -> void {
+    d3d12device_release(shader.blob);
+    shader.bytecode = nullptr;
+    shader.length = 0;
+  };
+
+  auto compileWithFxc = [&](const char *source, const char *profile,
+                            CompiledShader &output) -> bool {
+    ID3DBlob *shader = nullptr;
+    ID3DBlob *errors = nullptr;
+    UINT compileFlags = D3DCOMPILE_ENABLE_STRICTNESS;
+    auto sourceLength = string{source}.size();
+    auto result =
+        D3DCompile(source, sourceLength, nullptr, nullptr, nullptr, "main",
+                   profile, compileFlags, 0, &shader, &errors);
+    if(FAILED(result)) {
+      if(errors) {
+        print(string{"Direct3D 12: FXC compile failed for ", profile, ":\n"});
+        print((const char *)errors->GetBufferPointer());
+        print("\n");
+        d3d12device_release(errors);
+      }
+      return false;
+    }
+
+    if(errors)
+      d3d12device_release(errors);
+
+    output.blob = shader;
+    output.bytecode = shader->GetBufferPointer();
+    output.length = shader->GetBufferSize();
+    return true;
+  };
+
+  static const char *vertexShaderSource = R"(
+struct VSInput {
+  float4 position : POSITION;
+  float2 uv : TEXCOORD;
+};
+
+struct VSOutput {
+  float4 position : SV_POSITION;
+  float2 uv : TEXCOORD;
+};
+
+VSOutput main(VSInput input) {
+  VSOutput output;
+  output.position = input.position;
+  output.uv = input.uv;
+  return output;
+}
+)";
+
+  static const char *pixelShaderSource = R"(
+Texture2D sourceTexture : register(t0);
+SamplerState sourceSampler : register(s0);
+
+float4 main(float4 position : SV_POSITION, float2 uv : TEXCOORD) : SV_TARGET {
+  return sourceTexture.Sample(sourceSampler, uv);
+}
+)";
+
+  CompiledShader vertexShader{};
+  CompiledShader pixelShader{};
+
+  if(!compileWithFxc(vertexShaderSource, "vs_5_0", vertexShader)) {
+    releaseCompiledShader(vertexShader);
+    return false;
+  }
+
+  if(!compileWithFxc(pixelShaderSource, "ps_5_0", pixelShader)) {
+    releaseCompiledShader(vertexShader);
+    releaseCompiledShader(pixelShader);
+    return false;
+  }
+
+  D3D12_STATIC_SAMPLER_DESC sampler{};
+  sampler.Filter = D3D12_FILTER_MIN_MAG_MIP_POINT;
+  sampler.AddressU = D3D12_TEXTURE_ADDRESS_MODE_CLAMP;
+  sampler.AddressV = D3D12_TEXTURE_ADDRESS_MODE_CLAMP;
+  sampler.AddressW = D3D12_TEXTURE_ADDRESS_MODE_CLAMP;
+  sampler.ShaderRegister = 0;
+  sampler.RegisterSpace = 0;
+  sampler.ShaderVisibility = D3D12_SHADER_VISIBILITY_PIXEL;
+  sampler.MaxLOD = D3D12_FLOAT32_MAX;
+
+  ID3DBlob *serializedRootSignature = nullptr;
+  ID3DBlob *rootSignatureErrors = nullptr;
+  HRESULT rootSignatureStatus = E_FAIL;
+
+  if(_supportsRootSignature11) {
+    D3D12_DESCRIPTOR_RANGE1 range1{};
+    range1.RangeType = D3D12_DESCRIPTOR_RANGE_TYPE_SRV;
+    range1.NumDescriptors = 1;
+    range1.BaseShaderRegister = 0;
+    range1.RegisterSpace = 0;
+    range1.Flags = D3D12_DESCRIPTOR_RANGE_FLAG_DATA_STATIC;
+    range1.OffsetInDescriptorsFromTableStart =
+        D3D12_DESCRIPTOR_RANGE_OFFSET_APPEND;
+
+    D3D12_ROOT_PARAMETER1 parameter1{};
+    parameter1.ParameterType = D3D12_ROOT_PARAMETER_TYPE_DESCRIPTOR_TABLE;
+    parameter1.DescriptorTable.NumDescriptorRanges = 1;
+    parameter1.DescriptorTable.pDescriptorRanges = &range1;
+    parameter1.ShaderVisibility = D3D12_SHADER_VISIBILITY_PIXEL;
+
+    D3D12_ROOT_SIGNATURE_DESC1 rootSignatureDesc1{};
+    rootSignatureDesc1.NumParameters = 1;
+    rootSignatureDesc1.pParameters = &parameter1;
+    rootSignatureDesc1.NumStaticSamplers = 1;
+    rootSignatureDesc1.pStaticSamplers = &sampler;
+    rootSignatureDesc1.Flags =
+        D3D12_ROOT_SIGNATURE_FLAG_ALLOW_INPUT_ASSEMBLER_INPUT_LAYOUT;
+
+    D3D12_VERSIONED_ROOT_SIGNATURE_DESC versionedDesc{};
+    versionedDesc.Version = D3D_ROOT_SIGNATURE_VERSION_1_1;
+    versionedDesc.Desc_1_1 = rootSignatureDesc1;
+
+    rootSignatureStatus = D3D12SerializeVersionedRootSignature(
+        &versionedDesc, &serializedRootSignature, &rootSignatureErrors);
+  } else {
+    D3D12_DESCRIPTOR_RANGE range{};
+    range.RangeType = D3D12_DESCRIPTOR_RANGE_TYPE_SRV;
+    range.NumDescriptors = 1;
+    range.BaseShaderRegister = 0;
+    range.RegisterSpace = 0;
+    range.OffsetInDescriptorsFromTableStart =
+        D3D12_DESCRIPTOR_RANGE_OFFSET_APPEND;
+
+    D3D12_ROOT_PARAMETER parameter{};
+    parameter.ParameterType = D3D12_ROOT_PARAMETER_TYPE_DESCRIPTOR_TABLE;
+    parameter.DescriptorTable.NumDescriptorRanges = 1;
+    parameter.DescriptorTable.pDescriptorRanges = &range;
+    parameter.ShaderVisibility = D3D12_SHADER_VISIBILITY_PIXEL;
+
+    D3D12_ROOT_SIGNATURE_DESC rootSignatureDesc{};
+    rootSignatureDesc.NumParameters = 1;
+    rootSignatureDesc.pParameters = &parameter;
+    rootSignatureDesc.NumStaticSamplers = 1;
+    rootSignatureDesc.pStaticSamplers = &sampler;
+    rootSignatureDesc.Flags =
+        D3D12_ROOT_SIGNATURE_FLAG_ALLOW_INPUT_ASSEMBLER_INPUT_LAYOUT;
+
+    D3D12_VERSIONED_ROOT_SIGNATURE_DESC versionedDesc{};
+    versionedDesc.Version = D3D_ROOT_SIGNATURE_VERSION_1_0;
+    versionedDesc.Desc_1_0 = rootSignatureDesc;
+
+    rootSignatureStatus = D3D12SerializeVersionedRootSignature(
+        &versionedDesc, &serializedRootSignature, &rootSignatureErrors);
+  }
+
+  if(FAILED(rootSignatureStatus)) {
+    if(rootSignatureErrors)
+      d3d12device_release(rootSignatureErrors);
+    releaseCompiledShader(vertexShader);
+    releaseCompiledShader(pixelShader);
+    return false;
+  }
+
+  if(rootSignatureErrors)
+    d3d12device_release(rootSignatureErrors);
+
+  HRESULT hr = _device->CreateRootSignature(
+      0, serializedRootSignature->GetBufferPointer(),
+      serializedRootSignature->GetBufferSize(), IID_PPV_ARGS(&_rootSignature));
+  if(FAILED(hr)) {
+    d3d12device_release(serializedRootSignature);
+    releaseCompiledShader(vertexShader);
+    releaseCompiledShader(pixelShader);
+    return false;
+  }
+
+  d3d12device_release(serializedRootSignature);
+
+  D3D12_INPUT_ELEMENT_DESC inputLayout[] = {
+      {"POSITION", 0, DXGI_FORMAT_R32G32B32A32_FLOAT, 0, 0,
+       D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0},
+      {"TEXCOORD", 0, DXGI_FORMAT_R32G32_FLOAT, 0, 16,
+       D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0},
+  };
+
+  D3D12_BLEND_DESC blendDesc{};
+  auto &targetBlend = blendDesc.RenderTarget[0];
+  targetBlend.SrcBlend = D3D12_BLEND_ONE;
+  targetBlend.DestBlend = D3D12_BLEND_ZERO;
+  targetBlend.BlendOp = D3D12_BLEND_OP_ADD;
+  targetBlend.SrcBlendAlpha = D3D12_BLEND_ONE;
+  targetBlend.DestBlendAlpha = D3D12_BLEND_ZERO;
+  targetBlend.BlendOpAlpha = D3D12_BLEND_OP_ADD;
+  targetBlend.LogicOp = D3D12_LOGIC_OP_NOOP;
+  targetBlend.RenderTargetWriteMask = D3D12_COLOR_WRITE_ENABLE_ALL;
+
+  D3D12_RASTERIZER_DESC rasterizerDesc{};
+  rasterizerDesc.FillMode = D3D12_FILL_MODE_SOLID;
+  rasterizerDesc.CullMode = D3D12_CULL_MODE_NONE;
+  rasterizerDesc.DepthClipEnable = TRUE;
+
+  D3D12_GRAPHICS_PIPELINE_STATE_DESC pipelineDesc{};
+  pipelineDesc.pRootSignature = _rootSignature;
+  pipelineDesc.VS = {vertexShader.bytecode, vertexShader.length};
+  pipelineDesc.PS = {pixelShader.bytecode, pixelShader.length};
+  pipelineDesc.BlendState = blendDesc;
+  pipelineDesc.SampleMask = UINT_MAX;
+  pipelineDesc.RasterizerState = rasterizerDesc;
+  pipelineDesc.InputLayout = {
+      inputLayout,
+      (UINT)(sizeof(inputLayout) / sizeof(D3D12_INPUT_ELEMENT_DESC))};
+  pipelineDesc.PrimitiveTopologyType = D3D12_PRIMITIVE_TOPOLOGY_TYPE_TRIANGLE;
+  pipelineDesc.NumRenderTargets = 1;
+  pipelineDesc.RTVFormats[0] = DXGI_FORMAT_B8G8R8A8_UNORM;
+  pipelineDesc.SampleDesc.Count = 1;
+
+  hr = _device->CreateGraphicsPipelineState(&pipelineDesc,
+                                            IID_PPV_ARGS(&_pipelineState));
+
+  releaseCompiledShader(vertexShader);
+  releaseCompiledShader(pixelShader);
+
+  return SUCCEEDED(hr);
+}
+
+auto createVertexBuffer() -> bool {
+  Vertex vertices[] = {
+      {{-1.0f, 1.0f, 0.0f, 1.0f}, {0.0f, 0.0f}},
+      {{1.0f, 1.0f, 0.0f, 1.0f}, {1.0f, 0.0f}},
+      {{-1.0f, -1.0f, 0.0f, 1.0f}, {0.0f, 1.0f}},
+      {{1.0f, -1.0f, 0.0f, 1.0f}, {1.0f, 1.0f}},
+  };
+
+  auto bufferSize = sizeof(vertices);
+
+  D3D12_HEAP_PROPERTIES heapProps{};
+  heapProps.Type = D3D12_HEAP_TYPE_UPLOAD;
+
+  D3D12_RESOURCE_DESC resourceDesc{};
+  resourceDesc.Dimension = D3D12_RESOURCE_DIMENSION_BUFFER;
+  resourceDesc.Width = bufferSize;
+  resourceDesc.Height = 1;
+  resourceDesc.DepthOrArraySize = 1;
+  resourceDesc.MipLevels = 1;
+  resourceDesc.SampleDesc.Count = 1;
+  resourceDesc.Layout = D3D12_TEXTURE_LAYOUT_ROW_MAJOR;
+
+  HRESULT hr = _device->CreateCommittedResource(
+      &heapProps, D3D12_HEAP_FLAG_NONE, &resourceDesc,
+      D3D12_RESOURCE_STATE_GENERIC_READ, nullptr, IID_PPV_ARGS(&_vertexBuffer));
+  if(FAILED(hr))
+    return false;
+
+  void *mappedData = nullptr;
+  D3D12_RANGE readRange{0, 0};
+  hr = _vertexBuffer->Map(0, &readRange, &mappedData);
+  if(FAILED(hr))
+    return false;
+
+  memory::copy(mappedData, vertices, bufferSize);
+  _vertexBuffer->Unmap(0, nullptr);
+
+  _vertexBufferView.BufferLocation = _vertexBuffer->GetGPUVirtualAddress();
+  _vertexBufferView.StrideInBytes = sizeof(Vertex);
+  _vertexBufferView.SizeInBytes = (UINT)bufferSize;
+
+  return true;
+}
+
+auto resizeSource(u32 width, u32 height) -> bool {
+  _sourceWidth = width;
+  _sourceHeight = height;
+
+  resetSrvDescriptorCache();
+
+  d3d12device_release(_sourceTexture);
+  d3d12device_release(_sourceUpload);
+
+  D3D12_RESOURCE_DESC textureDesc{};
+  textureDesc.Dimension = D3D12_RESOURCE_DIMENSION_TEXTURE2D;
+  textureDesc.Alignment = 0;
+  textureDesc.Width = width;
+  textureDesc.Height = height;
+  textureDesc.DepthOrArraySize = 1;
+  textureDesc.MipLevels = 1;
+  textureDesc.Format = _sourceFormat;
+  textureDesc.SampleDesc.Count = 1;
+  textureDesc.Layout = D3D12_TEXTURE_LAYOUT_UNKNOWN;
+  textureDesc.Flags = D3D12_RESOURCE_FLAG_NONE;
+
+  D3D12_HEAP_PROPERTIES textureHeap{};
+  textureHeap.Type = D3D12_HEAP_TYPE_DEFAULT;
+
+  HRESULT hr = _device->CreateCommittedResource(
+      &textureHeap, D3D12_HEAP_FLAG_NONE, &textureDesc,
+      D3D12_RESOURCE_STATE_COPY_DEST, nullptr, IID_PPV_ARGS(&_sourceTexture));
+  if(FAILED(hr))
+    return false;
+
+  _sourceState = D3D12_RESOURCE_STATE_COPY_DEST;
+
+  UINT64 uploadSize = 0;
+  _device->GetCopyableFootprints(&textureDesc, 0, 1, 0, &_sourceFootprint,
+                                 nullptr, nullptr, &uploadSize);
+
+  D3D12_RESOURCE_DESC uploadDesc{};
+  uploadDesc.Dimension = D3D12_RESOURCE_DIMENSION_BUFFER;
+  uploadDesc.Width = uploadSize;
+  uploadDesc.Height = 1;
+  uploadDesc.DepthOrArraySize = 1;
+  uploadDesc.MipLevels = 1;
+  uploadDesc.SampleDesc.Count = 1;
+  uploadDesc.Layout = D3D12_TEXTURE_LAYOUT_ROW_MAJOR;
+
+  D3D12_HEAP_PROPERTIES uploadHeap{};
+  uploadHeap.Type = D3D12_HEAP_TYPE_UPLOAD;
+
+  hr = _device->CreateCommittedResource(
+      &uploadHeap, D3D12_HEAP_FLAG_NONE, &uploadDesc,
+      D3D12_RESOURCE_STATE_GENERIC_READ, nullptr, IID_PPV_ARGS(&_sourceUpload));
+  if(FAILED(hr))
+    return false;
+
+  return true;
+}
+
+auto uploadSourceTexture(const u32 *sourceData, u32 sourceWidth,
+                         u32 sourceHeight) -> bool {
+  if(!_sourceTexture || !_sourceUpload || !sourceData)
+    return false;
+
+  transitionResource(_sourceTexture, _sourceState,
+                     D3D12_RESOURCE_STATE_COPY_DEST);
+  _sourceState = D3D12_RESOURCE_STATE_COPY_DEST;
+
+  void *mapped = nullptr;
+  D3D12_RANGE readRange{0, 0};
+  HRESULT hr = _sourceUpload->Map(0, &readRange, &mapped);
+  if(FAILED(hr))
+    return false;
+
+  auto destination = (u8 *)mapped + _sourceFootprint.Offset;
+  auto source = (const u8 *)sourceData;
+  u32 sourcePitch = sourceWidth * sizeof(u32);
+
+  // GPU row pitch may be wider than source due to alignment, copy row by row
+  for(u32 y : range(sourceHeight)) {
+    memory::copy(destination + y * _sourceFootprint.Footprint.RowPitch,
+                 source + y * sourcePitch, sourcePitch);
+  }
+
+  _sourceUpload->Unmap(0, nullptr);
+
+  D3D12_TEXTURE_COPY_LOCATION destinationLocation{};
+  destinationLocation.pResource = _sourceTexture;
+  destinationLocation.Type = D3D12_TEXTURE_COPY_TYPE_SUBRESOURCE_INDEX;
+  destinationLocation.SubresourceIndex = 0;
+
+  D3D12_TEXTURE_COPY_LOCATION sourceLocation{};
+  sourceLocation.pResource = _sourceUpload;
+  sourceLocation.Type = D3D12_TEXTURE_COPY_TYPE_PLACED_FOOTPRINT;
+  sourceLocation.PlacedFootprint = _sourceFootprint;
+
+  _commandList->CopyTextureRegion(&destinationLocation, 0, 0, 0,
+                                  &sourceLocation, nullptr);
+
+  transitionResource(_sourceTexture, _sourceState,
+                     D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE);
+  _sourceState = D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE;
+
+  return true;
+}
+
+auto ensureShaderTarget(u32 width, u32 height) -> bool {
+  if(!_filterChain)
+    return true;
+
+  if(_shaderTarget && _shaderWidth == width && _shaderHeight == height &&
+      _shaderTargetRtvValid)
+    return true;
+
+  auto recreateResource =
+      !_shaderTarget || _shaderWidth != width || _shaderHeight != height;
+  if(recreateResource) {
+    resetSrvDescriptorCache();
+    d3d12device_release(_shaderTarget);
+    _shaderWidth = width;
+    _shaderHeight = height;
+  }
+
+  D3D12_RESOURCE_DESC textureDesc{};
+  textureDesc.Dimension = D3D12_RESOURCE_DIMENSION_TEXTURE2D;
+  textureDesc.Alignment = 0;
+  textureDesc.Width = width;
+  textureDesc.Height = height;
+  textureDesc.DepthOrArraySize = 1;
+  textureDesc.MipLevels = 1;
+  textureDesc.Format = _shaderTargetFormat;
+  textureDesc.SampleDesc.Count = 1;
+  textureDesc.Layout = D3D12_TEXTURE_LAYOUT_UNKNOWN;
+  textureDesc.Flags = D3D12_RESOURCE_FLAG_ALLOW_RENDER_TARGET;
+
+  D3D12_HEAP_PROPERTIES heapProps{};
+  heapProps.Type = D3D12_HEAP_TYPE_DEFAULT;
+
+  D3D12_CLEAR_VALUE clearValue{};
+  clearValue.Format = _shaderTargetFormat;
+  clearValue.Color[0] = 0.0f;
+  clearValue.Color[1] = 0.0f;
+  clearValue.Color[2] = 0.0f;
+  clearValue.Color[3] = 1.0f;
+
+  if(recreateResource) {
+    HRESULT hr = _device->CreateCommittedResource(
+        &heapProps, D3D12_HEAP_FLAG_NONE, &textureDesc,
+        D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE, &clearValue,
+        IID_PPV_ARGS(&_shaderTarget));
+    if(FAILED(hr))
+      return false;
+
+    _shaderTargetState = D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE;
+  }
+
+  auto shaderTargetRtvHandle = _rtvHeap->GetCPUDescriptorHandleForHeapStart();
+  shaderTargetRtvHandle.ptr += FrameCount * _rtvDescriptorSize;
+  _device->CreateRenderTargetView(_shaderTarget, nullptr,
+                                  shaderTargetRtvHandle);
+  _shaderTargetRtvValid = true;
+
+  return true;
+}
+
+auto updateSourceFormat(const string &format) -> bool {
+  if(format == "ARGB24") {
+    _sourceFormat = DXGI_FORMAT_B8G8R8A8_UNORM;
+    _shaderTargetFormat = DXGI_FORMAT_B8G8R8A8_UNORM;
+    resetSrvDescriptorCache();
+    return true;
+  }
+  if(format == "ARGB30") {
+    _sourceFormat = DXGI_FORMAT_R10G10B10A2_UNORM;
+    _shaderTargetFormat = DXGI_FORMAT_B8G8R8A8_UNORM;
+    resetSrvDescriptorCache();
+    return true;
+  }
+  return false;
+}

--- a/ruby/video/direct3d12/d3d12thread.cpp
+++ b/ruby/video/direct3d12/d3d12thread.cpp
@@ -1,0 +1,154 @@
+auto updateShader() -> bool {
+  lock_guard<std::mutex> renderLock(_renderMutex);
+
+  if(!_device)
+    return true;
+
+  if(_filterChain) {
+    _libra.d3d12_filter_chain_free(&_filterChain);
+    _filterChain = nullptr;
+  }
+  if(_preset) {
+    _libra.preset_free(&_preset);
+    _preset = nullptr;
+  }
+  _frameCount = 0;
+  resetSrvDescriptorCache();
+
+  if(!_libra.instance_loaded)
+    return true;
+
+  if(shader.imatch("None"))
+    return true;
+
+  if(!file::exists(shader))
+    return true;
+
+  if(auto error = _libra.preset_create(shader.data(), &_preset)) {
+    print("Direct3D 12: Failed to load shader: ", shader, "\n");
+    _libra.error_print(error);
+    return false;
+  }
+
+  filter_chain_d3d12_opt_t options{};
+  options.version = LIBRASHADER_CURRENT_VERSION;
+
+  if(auto error = _libra.d3d12_filter_chain_create(&_preset, _device, &options,
+                                                    &_filterChain)) {
+    print("Direct3D 12: Failed to create filter chain for: ", shader, "\n");
+    _libra.error_print(error);
+    _libra.preset_free(&_preset);
+    return false;
+  }
+
+  _preset = nullptr;
+  return true;
+}
+
+auto submitThreadedFrame(u32 width, u32 height) -> void {
+  if(!_ready || !_swapChain || !_context || !_buffer.size())
+    return;
+
+  if(!_renderThread.joinable())
+    startRenderThread();
+  if(!_renderThread.joinable()) {
+    renderFrame(width, height, _sourceWidth, _sourceHeight, _buffer.data());
+    return;
+  }
+
+  {
+    lock_guard<std::mutex> lock(_threadMutex);
+    _threadSourceWidth = _sourceWidth;
+    _threadSourceHeight = _sourceHeight;
+    _threadOutputWidth = width;
+    _threadOutputHeight = height;
+    _threadFrameBuffer.swap(_buffer);
+    const size_t needed = (size_t)_threadSourceWidth * _threadSourceHeight;
+    if(_buffer.size() != needed)
+      _buffer.resize(needed);
+    _threadPending = true;
+  }
+
+  _threadCV.notify_one();
+
+  if(_blockingEnabled.load(std::memory_order_relaxed)) {
+    unique_lock<std::mutex> lock(_threadMutex);
+    _threadDoneCV.wait(lock, [&] { return !_threadPending && !_threadBusy; });
+  }
+}
+
+auto renderThreadLoop() -> void {
+  std::vector<u32> frameBuffer;
+
+  while(true) {
+    u32 sourceWidth = 0;
+    u32 sourceHeight = 0;
+    u32 outputWidth = 0;
+    u32 outputHeight = 0;
+
+    {
+      unique_lock<std::mutex> lock(_threadMutex);
+      _threadCV.wait(lock, [&] { return _threadExit || _threadPending; });
+      if(_threadExit)
+        break;
+
+      frameBuffer.swap(_threadFrameBuffer);
+      sourceWidth = _threadSourceWidth;
+      sourceHeight = _threadSourceHeight;
+      outputWidth = _threadOutputWidth;
+      outputHeight = _threadOutputHeight;
+      _threadPending = false;
+      _threadBusy = true;
+    }
+
+    renderFrame(outputWidth, outputHeight, sourceWidth, sourceHeight,
+                frameBuffer.data());
+
+    frameBuffer.clear();
+
+    {
+      lock_guard<std::mutex> lock(_threadMutex);
+      _threadBusy = false;
+    }
+    _threadDoneCV.notify_all();
+  }
+}
+
+auto startRenderThread() -> void {
+  if(_renderThread.joinable())
+    return;
+
+  {
+    lock_guard<std::mutex> lock(_threadMutex);
+    _threadExit = false;
+    _threadPending = false;
+    _threadBusy = false;
+    _threadFrameBuffer.clear();
+  }
+
+  _renderThread = std::thread([this] { renderThreadLoop(); });
+}
+
+auto stopRenderThread(bool drain) -> void {
+  if(!_renderThread.joinable())
+    return;
+
+  {
+    unique_lock<std::mutex> lock(_threadMutex);
+    if(drain) {
+      _threadDoneCV.wait(lock, [&] { return !_threadPending && !_threadBusy; });
+    }
+    _threadExit = true;
+  }
+
+  _threadCV.notify_one();
+  _renderThread.join();
+
+  {
+    lock_guard<std::mutex> lock(_threadMutex);
+    _threadExit = false;
+    _threadPending = false;
+    _threadBusy = false;
+    _threadFrameBuffer.clear();
+  }
+}

--- a/ruby/video/video.cpp
+++ b/ruby/video/video.cpp
@@ -2,6 +2,10 @@
   #include <ruby/video/direct3d9.cpp>
 #endif
 
+#if defined(VIDEO_DIRECT3D12)
+  #include <ruby/video/direct3d12/d3d12device.cpp>
+#endif
+
 #if defined(VIDEO_GLX)
   #include <ruby/video/glx.cpp>
 #endif
@@ -175,6 +179,10 @@ auto Video::create(string driver) -> bool {
   if(driver == "Direct3D 9.0") self.instance = std::make_unique<VideoDirect3D9>(*this);
   #endif
 
+  #if defined(VIDEO_DIRECT3D12)
+  if(driver == "Direct3D 12") self.instance = std::make_unique<d3d12device>(*this);
+  #endif
+
   #if defined(VIDEO_GLX)
   if(driver == "OpenGL 3.2") self.instance = std::make_unique<VideoGLX>(*this);
   #endif
@@ -204,6 +212,10 @@ auto Video::hasDrivers() -> std::vector<string> {
   "Direct3D 9.0",
   #endif
 
+  #if defined(VIDEO_DIRECT3D12)
+  "Direct3D 12",
+  #endif
+
   #if defined(VIDEO_GLX)
   "OpenGL 3.2",
   #endif
@@ -224,6 +236,8 @@ auto Video::optimalDriver() -> string {
   return "OpenGL 3.2";
   #elif defined(VIDEO_DIRECT3D9)
   return "Direct3D 9.0";
+  #elif defined(VIDEO_DIRECT3D12)
+  return "Direct3D 12";
   #else
   return "None";
   #endif
@@ -234,6 +248,8 @@ auto Video::safestDriver() -> string {
   return "Metal";
   #elif defined(VIDEO_DIRECT3D9)
   return "Direct3D 9.0";
+  #elif defined(VIDEO_DIRECT3D12)
+  return "Direct3D 12";
   #elif defined(VIDEO_WGL)
   return "OpenGL 3.2";
   #elif defined(VIDEO_GLX)


### PR DESCRIPTION
### Description of Changes
Added a new Direct3D 12 video backend. And allowed previously Metal only settings in desktop-ui on Windows as I added support for them in Direct3D 12 (they are greyed out in renderers they aren't supported in).

### Suggested Testing Steps
- Open the build from this PR, and make sure `Direct3D 12` appears as a selectable video driver.
- Switch to `Direct3D 12` and make sure there isn't any problems with rendering.
- Check that there are no issues with these settings:
  - Synchronize on/off
  - Windowed/fullscreen transitions (including native fullscreen toggle)
  - Window resize and resolution changes
  - Aspect ratio modes and scaling behavior
  - Run-ahead on/off
  - Shader enable/disable and preset switching (**shaders won't work until `runtime-d3d12` is added to the cargo run of deps**)
  - Monitor switching and exclusive mode behavior (where applicable)
- Toggle D3D12 specific settings (`Force sRGB`, `Threaded renderer`, `Native fullscreen`) and make sure there's no regressions (no crashes/hangs, rendering remains correct).
- Restart app and make sure all selected video settings stay and reapply correctly.