### PR TITLE
Super Game Boy accuracy fixes (multiplayer, packet acknowledgement, register mirroring)

### DIFF
--- a/ares/sfc/coprocessor/icd/icd.cpp
+++ b/ares/sfc/coprocessor/icd/icd.cpp
@@ -55,7 +55,6 @@ auto ICD::power(bool reset) -> void {
   cpu.coprocessors.push_back(this);
 
   joypID = 3;
-  joypLock = 1;
   pulseLock = 1;
   strobeLock = 0;
   packetLock = 0;
@@ -63,6 +62,7 @@ auto ICD::power(bool reset) -> void {
   packetReady = 0;
   bitData = 0;
   bitOffset = 0;
+  previousP15 = 0;
 
   for(auto& n : output) n = 0xff;
   readBank = 0;

--- a/ares/sfc/coprocessor/icd/icd.cpp
+++ b/ares/sfc/coprocessor/icd/icd.cpp
@@ -54,16 +54,13 @@ auto ICD::power(bool reset) -> void {
   });
   cpu.coprocessors.push_back(this);
 
-  for(auto& packet : this->packet) packet = {};
-  packetSize = 0;
-
   joypID = 3;
   joypLock = 1;
   pulseLock = 1;
   strobeLock = 0;
   packetLock = 0;
-  joypPacket = {};
   packetOffset = 0;
+  packetReady = 0;
   bitData = 0;
   bitOffset = 0;
 

--- a/ares/sfc/coprocessor/icd/icd.hpp
+++ b/ares/sfc/coprocessor/icd/icd.hpp
@@ -30,20 +30,13 @@ struct ICD : Platform, GameBoy::SuperGameBoyInterface, Thread {
   n32 Frequency = 0;
 
 private:
-  struct Packet {
-    auto operator[](n4 address) -> n8& { return data[address]; }
-    n8 data[16];
-  };
-  Packet packet[64];
-  n7 packetSize;
-
   n2 joypID;
   n1 joypLock;
   n1 pulseLock;
   n1 strobeLock;
   n1 packetLock;
-  Packet joypPacket;
   n4 packetOffset;
+  n1 packetReady;
   n8 bitData;
   n3 bitOffset;
 

--- a/ares/sfc/coprocessor/icd/icd.hpp
+++ b/ares/sfc/coprocessor/icd/icd.hpp
@@ -31,7 +31,6 @@ struct ICD : Platform, GameBoy::SuperGameBoyInterface, Thread {
 
 private:
   n2 joypID;
-  n1 joypLock;
   n1 pulseLock;
   n1 strobeLock;
   n1 packetLock;
@@ -39,6 +38,7 @@ private:
   n1 packetReady;
   n8 bitData;
   n3 bitOffset;
+  n1 previousP15;
 
   n8 output[4 * 512];
   n2 readBank;

--- a/ares/sfc/coprocessor/icd/interface.cpp
+++ b/ares/sfc/coprocessor/icd/interface.cpp
@@ -83,7 +83,7 @@ auto ICD::joypWrite(n1 p14, n1 p15) -> void {
 
   if(packetLock == 1) {
     if(p14 == 0 && p15 == 1) {
-      if(packetSize < 64) packet[packetSize++] = joypPacket;
+      packetReady = 1;
       packetLock = 0;
       pulseLock = 1;
     }
@@ -93,7 +93,7 @@ auto ICD::joypWrite(n1 p14, n1 p15) -> void {
   bitData = bit << 7 | bitData >> 1;
   if(++bitOffset) return;
 
-  joypPacket[packetOffset] = bitData;
+  r7000[packetOffset] = bitData;
   if(++packetOffset) return;
 
   packetLock = 1;

--- a/ares/sfc/coprocessor/icd/interface.cpp
+++ b/ares/sfc/coprocessor/icd/interface.cpp
@@ -21,16 +21,14 @@ auto ICD::ppuWrite(n2 color) -> void {
 
 auto ICD::joypWrite(n1 p14, n1 p15) -> void {
   //joypad handling
-  if(p14 == 1 && p15 == 1) {
-    if(joypLock == 0) {
-      joypLock = 1;
-      joypID++;
-      if(mltReq == 0) joypID &= 0;  //1-player mode
-      if(mltReq == 1) joypID &= 1;  //2-player mode
-      if(mltReq == 2) joypID &= 3;  //4-player mode (unverified; but the most likely behavior)
-      if(mltReq == 3) joypID &= 3;  //4-player mode
-    }
+  if (p15 && !previousP15) {
+    joypID++;
+    if (mltReq == 0) joypID &= 0;  //1-player mode
+    if (mltReq == 1) joypID &= 1;  //2-player mode
+    if (mltReq == 2) joypID &= 3;  //4-player mode (unverified; but the most likely behavior)
+    if (mltReq == 3) joypID &= 3;  //4-player mode
   }
+  previousP15 = p15;
 
   n8 joypad;
   if(joypID == 0) joypad = r6004;
@@ -44,9 +42,6 @@ auto ICD::joypWrite(n1 p14, n1 p15) -> void {
   if(p15 == 0) input &= joypad.bit(4,7);  //buttons
 
   GameBoy::cpu.input(input);
-
-  if(p14 == 0 && p15 == 1);
-  if(p14 == 1 && p15 == 0) joypLock ^= 1;
 
   //packet handling
   if(p14 == 0 && p15 == 0) {  //pulse

--- a/ares/sfc/coprocessor/icd/io.cpp
+++ b/ares/sfc/coprocessor/icd/io.cpp
@@ -1,5 +1,5 @@
 auto ICD::readIO(n24 address, n8 data) -> n8 {
-  address &= 0x40ffff;
+  address &= 0x40f80f;
 
   //LY counter
   if(address == 0x6000) {
@@ -17,7 +17,7 @@ auto ICD::readIO(n24 address, n8 data) -> n8 {
   }
 
   //command port
-  if((address & 0x40fff0) == 0x7000) {
+  if(address >= 0x7000 && address <= 0x700f) {
     if ((address & 15) == 0) {
       packetReady = false;
     }
@@ -25,7 +25,7 @@ auto ICD::readIO(n24 address, n8 data) -> n8 {
   }
 
   //VRAM port
-  if(address == 0x7800) {
+  if(address >= 0x7800 && address <= 0x780f) {
     data = output[readBank * 512 + readAddress++];
     return data;
   }

--- a/ares/sfc/coprocessor/icd/io.cpp
+++ b/ares/sfc/coprocessor/icd/io.cpp
@@ -8,13 +8,7 @@ auto ICD::readIO(n24 address, n8 data) -> n8 {
 
   //command ready port
   if(address == 0x6002) {
-    data = packetSize > 0;
-    if(data) {
-      for(auto n : range(16)) r7000[n] = packet[0][n];
-      packetSize--;
-      for(auto n : range(packetSize)) packet[n] = packet[n + 1];
-    }
-    return data;
+    return packetReady;
   }
 
   //ICD2 revision
@@ -24,6 +18,9 @@ auto ICD::readIO(n24 address, n8 data) -> n8 {
 
   //command port
   if((address & 0x40fff0) == 0x7000) {
+    if ((address & 15) == 0) {
+      packetReady = false;
+    }
     return r7000[address & 15];
   }
 

--- a/ares/sfc/coprocessor/icd/serialization.cpp
+++ b/ares/sfc/coprocessor/icd/serialization.cpp
@@ -3,7 +3,6 @@ auto ICD::serialize(serializer& s) -> void {
   GameBoy::system.serialize(s, scheduler.getSynchronize());
 
   s(joypID);
-  s(joypLock);
   s(pulseLock);
   s(strobeLock);
   s(packetLock);
@@ -11,6 +10,7 @@ auto ICD::serialize(serializer& s) -> void {
   s(packetReady);
   s(bitData);
   s(bitOffset);
+  s(previousP15);
 
   s(output);
   s(readBank);

--- a/ares/sfc/coprocessor/icd/serialization.cpp
+++ b/ares/sfc/coprocessor/icd/serialization.cpp
@@ -2,16 +2,13 @@ auto ICD::serialize(serializer& s) -> void {
   Thread::serialize(s);
   GameBoy::system.serialize(s, scheduler.getSynchronize());
 
-  for(u32 n : range(64)) s(packet[n].data);
-  s(packetSize);
-
   s(joypID);
   s(joypLock);
   s(pulseLock);
   s(strobeLock);
   s(packetLock);
-  s(joypPacket.data);
   s(packetOffset);
+  s(packetReady);
   s(bitData);
   s(bitOffset);
 

--- a/ares/sfc/system/serialization.cpp
+++ b/ares/sfc/system/serialization.cpp
@@ -1,4 +1,4 @@
-static const string SerializerVersion = "v144";
+static const string SerializerVersion = "v145";
 
 auto System::serialize(bool synchronize) -> serializer {
   if(synchronize) scheduler.enter(Scheduler::Mode::Synchronize);


### PR DESCRIPTION
Should fix #2493 and #1205 and #2500. There are still things to fix SGB-side, because `sgb-ext-test` does not pass.