### PR TITLE
Minor Qt6 on Linux cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,9 @@ desktop-ui/resource/resource.hpp
 mia/resource/resource.cpp
 mia/resource/resource.hpp
 
+# Exclude Qt generated MOC file
+hiro/qt/qt.moc
+
 # Exclude fetched third-party processor test binaries
 tests/arm7tdmi/tests
 tests/m68000/tests

--- a/desktop-ui/settings/emulators.cpp
+++ b/desktop-ui/settings/emulators.cpp
@@ -20,7 +20,7 @@ auto EmulatorSettings::construct() -> void {
     manufacturer.setText(emulator->manufacturer);
   }
   emulatorList.resizeColumns();
-  emulatorList.column(0).setWidth(24);
+  emulatorList.column(0).setWidth(32);
 }
 
 auto EmulatorSettings::eventToggle(TableViewCell cell) -> void {

--- a/desktop-ui/tools/cheats.cpp
+++ b/desktop-ui/tools/cheats.cpp
@@ -115,7 +115,7 @@ auto CheatEditor::refresh() -> void {
   }
 
   cheatList.resizeColumns();
-  cheatList.column(0).setWidth(24);
+  cheatList.column(0).setWidth(32);
 }
 
 auto CheatEditor::unload() -> void {

--- a/desktop-ui/tools/streams.cpp
+++ b/desktop-ui/tools/streams.cpp
@@ -28,7 +28,7 @@ auto StreamManager::reload() -> void {
     item.append(TableViewCell().setText({u32(stream->frequency() + 0.5), "hz"}));
   }
   streamList.resizeColumns();
-  streamList.column(0).setWidth(24);
+  streamList.column(0).setWidth(32);
 }
 
 auto StreamManager::unload() -> void {

--- a/hiro/qt/widget/table-view-cell.cpp
+++ b/hiro/qt/widget/table-view-cell.cpp
@@ -62,7 +62,7 @@ auto pTableViewCell::_setState() -> void {
       parent->qtItem->setForeground(self().offset(), CreateBrush(self().foregroundColor(true)));
       parent->qtItem->setIcon(self().offset(), CreateIcon(state().icon));
       parent->qtItem->setText(self().offset(), QString::fromUtf8(state().text));
-      parent->qtItem->setTextAlignment(self().offset(), CalculateAlignment(self().alignment(true)));
+      parent->qtItem->setTextAlignment(self().offset(), (Qt::Alignment)CalculateAlignment(self().alignment(true)));
     }
   }
 }

--- a/hiro/qt/widget/viewport.cpp
+++ b/hiro/qt/widget/viewport.cpp
@@ -5,7 +5,7 @@ namespace hiro {
 auto pViewport::construct() -> void {
   qtWidget = qtViewport = new QtViewport(*this);
   qtViewport->setMouseTracking(true);
-  qtViewport->setAttribute(Qt::WA_PaintOnScreen, true);
+  qtViewport->setAttribute(Qt::WA_PaintOnScreen, QT_VERSION < 0x050000 ? true : false);
   qtViewport->setStyleSheet("background: #000000");
 
   pWidget::construct();


### PR DESCRIPTION
Minor improvements to the Qt6 build on Linux:

- Exclude generated Qt6 MOC file from source control
- Cleanup build warning about deprecated function
- Width adjustment to prevent unnecessary scroll bar in a few tables
- Prevent the message "QWidget::paintEngine: Should no longer be called" from spamming the terminal