### PR TITLE
emux v1.1: remove dashes from instruction names

### DIFF
--- a/ares/n64/rsp/disassembler.cpp
+++ b/ares/n64/rsp/disassembler.cpp
@@ -300,9 +300,9 @@ auto RSP::Disassembler::SCC() -> std::vector<string> {
     if(xcode() == 1) return {"xdetect", xrdValue()};
     return {"xdetect", xrdValue(), xcodeImm()};
   case 0x23:
-    if(xcode() == 0) return {"xtrace-start"};
-    return {"xtrace-start", xcodeImm()};
-  case 0x24: return {"xtrace-stop"};
+    if(xcode() == 0) return {"xtracestart"};
+    return {"xtracestart", xcodeImm()};
+  case 0x24: return {"xtracestop"};
   case 0x25:
     if(xcode() == 0) return {"xlog", xrdValue()};
     return {"xlog", xrdValue(), xrtValue(), xcodeImm()};
@@ -311,7 +311,7 @@ auto RSP::Disassembler::SCC() -> std::vector<string> {
     return {"xlogregs", xrdValue(), xcodeImm()};
   case 0x27: return {"xhexdump", xrdValue(), xrtValue(), xcodeImm()};
   case 0x28: return {"xprof", xrdValue(), xcodeImm()};
-  case 0x29: return {"xprof-read", xrdValue(), xrtName()};
+  case 0x29: return {"xprofread", xrdValue(), xrtName()};
   case 0x2a: return {"xexception", xrtValue()};
   case 0x2c:
     if(xcode() == 1) return {"xioctl", "exit"};

--- a/ares/n64/rsp/emux.cpp
+++ b/ares/n64/rsp/emux.cpp
@@ -19,8 +19,8 @@ auto RSP::XDETECT(r32& rd, u32 code) -> void {
   n64 detect = 0;
   n64 ioctl = 0;
   detect.bit(0x20) = 1;  // XDETECT
-  detect.bit(0x23) = 1;  // XTRACE-START
-  detect.bit(0x24) = 1;  // XTRACE-STOP
+  detect.bit(0x23) = 1;  // XTRACESTART
+  detect.bit(0x24) = 1;  // XTRACESTOP
   detect.bit(0x25) = 1;  // XLOG
   detect.bit(0x26) = 1;  // XLOGREGS
   detect.bit(0x27) = 1;  // XHEXDUMP

--- a/ares/n64/rsp/recompiler.cpp
+++ b/ares/n64/rsp/recompiler.cpp
@@ -1256,13 +1256,13 @@ auto RSP::Recompiler::emitSCC(u32 instruction) -> void {
     return;
   }
 
-  //XTRACE-START
+  //XTRACESTART
   case 0x23: {
     callf(&RSP::XTRACESTART, imm(XCODE));
     return;
   }
 
-  //XTRACE-STOP
+  //XTRACESTOP
   case 0x24: {
     callf(&RSP::XTRACESTOP);
     return;


### PR DESCRIPTION
New emux spec location, for reference: https://n64brew.dev/wiki/Emux