### PR TITLE
n64: enable gdb reads of sizes that are not multiples of 4

### DIFF
--- a/ares/n64/system/system.cpp
+++ b/ares/n64/system/system.cpp
@@ -58,7 +58,7 @@ auto option(string name, string value) -> bool {
       system.configuredControllerPakBankCount = 62;
       system.controllerPakBankCount = 62;
     }
-  }  
+  }
   return true;
 }
 
@@ -173,16 +173,16 @@ auto System::initDebugHooks() -> void {
     // This makes sure we return the same value the CPU would get wrt to masking.
     u64 value;
     switch(byteCount) {
-      case Byte: 
+      case Byte:
         value = cpu.readDebug<Byte>(address);
         hexByte(resPtr, value);
         return res;
-      case Half: 
+      case Half:
         value = cpu.readDebug<Half>(address);
         hexByte(resPtr + 0, (value >> 8) & 0xff);
         hexByte(resPtr + 2, value & 0xff);
         return res;
-      case Word: 
+      case Word:
         value = cpu.readDebug<Word>(address);
         hexByte(resPtr + 0, (value >> 24) & 0xff);
         hexByte(resPtr + 2, (value >> 16) & 0xff);
@@ -228,7 +228,8 @@ auto System::initDebugHooks() -> void {
       // read for RCP, so it's the one that's most likely to return the data
       // as the user would expect.
       Thread dummyThread{};
-      for(u32 i : range(byteCount / 4)) {
+      res.resize((byteCount + 3) / 4 * 4 * 2);
+      for (u32 i : range((byteCount + 3) / 4)) {
         u64 value = bus.read<Word>(address & 0x1fff'ffff, dummyThread, RBusDevice::ARES_DEBUGGER);
         hexByte(resPtr + 0, (value >> 24) & 0xff);
         hexByte(resPtr + 2, (value >> 16) & 0xff);
@@ -237,6 +238,7 @@ auto System::initDebugHooks() -> void {
         resPtr += 8;
         address += 4;
       }
+      res.resize(byteCount * 2);
       return res;
     }
     return {};
@@ -249,23 +251,23 @@ auto System::initDebugHooks() -> void {
     // This makes sure we write the same value the CPU would write wrt to masking.
     u64 value;
     switch(data.size()) {
-      case Byte: 
+      case Byte:
         value = (u64)data[0];
         cpu.writeDebug<Byte>(address, value);
-        break;
-      case Half: 
+        return;
+      case Half:
         value = ((u64)data[0]<<8) | ((u64)data[1]<<0);
         cpu.writeDebug<Half>(address, value);
-        break;
-      case Word: 
+        return;
+      case Word:
         value = ((u64)data[0]<<24) | ((u64)data[1]<<16) | ((u64)data[2]<<8) | ((u64)data[3]<<0);
         cpu.writeDebug<Word>(address, value);
-        break;
+        return;
       case Dual:
         value  = ((u64)data[0]<<56) | ((u64)data[1]<<48) | ((u64)data[2]<<40) | ((u64)data[3]<<32);
         value |= ((u64)data[4]<<24) | ((u64)data[5]<<16) | ((u64)data[6]<< 8) | ((u64)data[7]<< 0);
         cpu.writeDebug<Dual>(address, value);
-        break;
+        return;
     }
 
     // Handle writes of different/unaligned sizes only within the RDRAM area,
@@ -329,7 +331,7 @@ auto System::initDebugHooks() -> void {
       cpu.ipu.r[regIdx].u64 = regValue;
       return true;
     }
- 
+
     switch (regIdx)
     {
       case 32: return true; // COP0 status (ignore write)
@@ -383,7 +385,7 @@ auto System::initDebugHooks() -> void {
 auto System::unload() -> void {
   if(!node) return;
   save();
-  
+
   if(vi.screen) vi.screen->quit(); //stop video thread
   #if defined(VULKAN)
   vulkan.unload();


### PR DESCRIPTION
If we hit the final branch of the if in the read hook and `byteCount` is not a multiple of 4, the remaining bytes are never read, but the buffer is still sent back with unset data. This adds one more iteration to the loop if necessary to read another word, and then shrinks the string to the correct size.

In the write hook, the simple cases will do a write and then break the switch and end up in the conditionals, potentially writing twice. So I switched the breaks to returns.

The final conditional code in the write hook also cannot handle data sizes that aren't multiples of 4 bytes, but I'm less confident about how to fix that. Happy to add it to this PR if someone who knows what they're doing advises.

Also trimmed some trailing whitespace.