### PR TITLE
Fixup versionconfig.cmake: pass `--no-show-signature` to the git command for getting the commit date

### DIFF
--- a/cmake/common/versionconfig.cmake
+++ b/cmake/common/versionconfig.cmake
@@ -76,7 +76,7 @@ function(ares_populate_version_info)
         OUTPUT_STRIP_TRAILING_WHITESPACE
       )
       execute_process(
-        COMMAND git show -s --format=%cs
+        COMMAND git show -s --no-show-signature --format=%cs
         OUTPUT_VARIABLE ares_git_commit_date
         WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}"
         OUTPUT_STRIP_TRAILING_WHITESPACE


### PR DESCRIPTION
Fixes #2521 , which happens when the user happens to have configured their git config with `git config log.showSignature true`