### PR TITLE
Remove "eat stdin" behavior on exit

### DIFF
--- a/nall/nall/main.cpp
+++ b/nall/nall/main.cpp
@@ -22,20 +22,6 @@ auto main(int argc, char** argv) -> int {
 
   main(Arguments{argc, argv});
 
-  #if !defined(PLATFORM_WINDOWS)
-  //when a program is running, input on the terminal queues in stdin
-  //when terminating the program, the shell proceeds to try and execute all stdin data
-  //this is annoying behavior: this code tries to minimize the impact as much as it can
-  //we can flush all of stdin up to the last line feed, preventing spurious commands from executing
-  //however, even with setvbuf(_IONBF), we can't stop the last line from echoing to the terminal
-  auto flags = fcntl(fileno(stdin), F_GETFL, 0);
-  fcntl(fileno(stdin), F_SETFL, flags | O_NONBLOCK);  //don't allow read() to block when empty
-  char buffer[4096], data = false;
-  while(read(fileno(stdin), buffer, sizeof(buffer)) > 0) data = true;
-  fcntl(fileno(stdin), F_SETFL, flags);  //restore original flags for the terminal
-  if(data) putchar('\r');  //ensures PS1 is printed at the start of the line
-  #endif
-
   #if defined(PLATFORM_WINDOWS)
   WSACleanup();
   CoUninitialize();


### PR DESCRIPTION
Currently, ares "eats" stdin on non-windows. For example:

```
$ ares
OpenGL Version: 4.6 (Core Profile) Mesa 25.2.8-0ubuntu0.24.04.1, GLSL: 4.60
echo Hello World  # typed by me while ares was open
# ares closed
$  # notice no Hello World was echo'd
```

<img width="1226" height="143" alt="image" src="https://github.com/user-attachments/assets/5db4884c-424f-41cd-ae93-ec5b4358b3be" />

This is unlike every other program ever, which just does not do anything with stdin. For example `sleep`:

```
$ sleep 10
echo Hello World  # typed by me during the sleep
$ echo Hello World  # not typed by me; this is from the commands I typed during sleep
Hello World
$
```

<img width="1226" height="178" alt="image" src="https://github.com/user-attachments/assets/9bf83dbf-86be-468d-901a-ec3121f24b6b" />

-------------

This also causes ares to hang on exit when no stdin is attached, for example when running ares in the background from a terminal with `ares &` then closing ares:

<img width="1605" height="776" alt="image" src="https://github.com/user-attachments/assets/41d77204-9a4c-4fec-9c16-22774aa0f69e" />

-------------

This behavior was added in february 2019 without any context besides the comments that remain to this day in the codebase: a1411748bbc1bb3dad0966984d6111b12494cc46 (see `main.hpp`)

-------------

I suggest we just remove this "eat stdin" code which as good-willed as may have been and despite the intent of making the behavior less surprising, actually makes the behavior surprising because different from everything else, and also causes a hang when closing a background-launched ares.