### PR TITLE
sfc: Improve autojoypad polling accuracy

### DIFF
--- a/ares/sfc/cpu/cpu.hpp
+++ b/ares/sfc/cpu/cpu.hpp
@@ -130,6 +130,12 @@ private:
     bool hdmaMode = 0;  //0 = init, 1 = run
 
     u32  autoJoypadCounter = 33;  //state machine; 4224 / 128 = 33 (inactive)
+
+    n2 autoJoypadPort1 = 0;
+    n2 autoJoypadPort2 = 0;
+
+    bool cpuLatch = false;
+    bool autoJoypadLatch = false;
   } status;
 
   struct IO {

--- a/ares/sfc/cpu/io.cpp
+++ b/ares/sfc/cpu/io.cpp
@@ -120,13 +120,22 @@ auto CPU::writeCPU(n24 address, n8 data) -> void {
     //bit 0 is shared between JOYSER0 and JOYSER1:
     //strobing $4016.d0 affects both controller port latches.
     //$4017 bit 0 writes are ignored.
-    controllerPort1.latch(data.bit(0));
-    controllerPort2.latch(data.bit(0));
+    status.cpuLatch = data.bit(0);
+    controllerPort1.latch(status.autoJoypadLatch | status.cpuLatch);
+    controllerPort2.latch(status.autoJoypadLatch | status.cpuLatch);
     return;
 
   case 0x4200:  //NMITIMEN
     io.autoJoypadPoll = data.bit(0);
-    if(!io.autoJoypadPoll) status.autoJoypadCounter = 33;  //disable polling
+    if(status.autoJoypadCounter == 0) {
+      // allow controller latches during this time
+      status.autoJoypadLatch = io.autoJoypadPoll;
+      controllerPort1.latch(status.autoJoypadLatch | status.cpuLatch);
+      controllerPort2.latch(status.autoJoypadLatch | status.cpuLatch);
+    } else if (!io.autoJoypadPoll && status.autoJoypadCounter >= 2) {
+      status.autoJoypadCounter = 33;
+    }
+
     nmitimenUpdate(data);
     return;
 

--- a/ares/sfc/cpu/serialization.cpp
+++ b/ares/sfc/cpu/serialization.cpp
@@ -43,6 +43,12 @@ auto CPU::serialize(serializer& s) -> void {
 
   s(status.autoJoypadCounter);
 
+  s(status.autoJoypadPort1);
+  s(status.autoJoypadPort2);
+
+  s(status.cpuLatch);
+  s(status.autoJoypadLatch);
+
   s(io.wramAddress);
 
   s(io.hirqEnable);

--- a/ares/sfc/cpu/timing.cpp
+++ b/ares/sfc/cpu/timing.cpp
@@ -141,45 +141,55 @@ alwaysinline auto CPU::dmaEdge() -> void {
 
 //called every 128 clocks; see CPU::step()
 alwaysinline auto CPU::joypadEdge() -> void {
-  //it is not yet confirmed if polling can be stopped early and/or (re)started later
-  if(!io.autoJoypadPoll) return;
-
-  if(vcounter() == ppu.vdisp() && hcounter() >= 130 && hcounter() <= 256) {
+  if(vcounter() == ppu.vdisp() && (counter.cpu & 255) == 0 && hcounter() >= 130 && hcounter() <= 384) {
     //begin new polling sequence
     status.autoJoypadCounter = 0;
-  }
+  } else {
+    //stop after polling has been completed for this frame
+    if(status.autoJoypadCounter >= 33) return;
 
-  //stop after polling has been completed for this frame
-  if(status.autoJoypadCounter >= 33) return;
+    status.autoJoypadCounter++;
+  }
 
   if(status.autoJoypadCounter == 0) {
     //latch controller states on the first polling cycle
-    controllerPort1.latch(1);
-    controllerPort2.latch(1);
+    //TODO: this may need to happen one cycle earlier
+    status.autoJoypadLatch = io.autoJoypadPoll;
+    controllerPort1.latch(status.autoJoypadLatch | status.cpuLatch);
+    controllerPort2.latch(status.autoJoypadLatch | status.cpuLatch);
+    if(io.autoJoypadPoll) {
+      //shift registers are cleared to zero at start of auto-joypad polling
+      io.joy1 = 0;
+      io.joy2 = 0;
+      io.joy3 = 0;
+      io.joy4 = 0;
+    }
   }
 
   if(status.autoJoypadCounter == 1) {
     //release latch and begin reading on the second cycle
-    controllerPort1.latch(0);
-    controllerPort2.latch(0);
-
-    //shift registers are cleared to zero at start of auto-joypad polling
-    io.joy1 = 0;
-    io.joy2 = 0;
-    io.joy3 = 0;
-    io.joy4 = 0;
+    status.autoJoypadLatch = 0;
+    controllerPort1.latch(status.autoJoypadLatch | status.cpuLatch);
+    controllerPort2.latch(status.autoJoypadLatch | status.cpuLatch);
   }
 
-  if(status.autoJoypadCounter >= 2 && !(status.autoJoypadCounter & 1)) {
+  if(status.autoJoypadCounter != 1 && !io.autoJoypadPoll) {
+    // if auto-joypad polling is disabled at this point skip the rest of the polling
+    status.autoJoypadCounter = 33;
+    return;
+  }
+
+  if(status.autoJoypadCounter >= 2) {
     //sixteen bits are shifted into joy{1-4}, one bit per 256 clocks
-    n2 port0 = controllerPort1.data();
-    n2 port1 = controllerPort2.data();
-
-    io.joy1 = io.joy1 << 1 | port0.bit(0);
-    io.joy2 = io.joy2 << 1 | port1.bit(0);
-    io.joy3 = io.joy3 << 1 | port0.bit(1);
-    io.joy4 = io.joy4 << 1 | port1.bit(1);
+    //the bits are read on one 128-clock cycle and written on the next
+    if ((status.autoJoypadCounter & 1) == 0) {
+      status.autoJoypadPort1 = controllerPort1.data();
+      status.autoJoypadPort2 = controllerPort2.data();
+    } else {
+      io.joy1 = io.joy1 << 1 | status.autoJoypadPort1.bit(0);
+      io.joy2 = io.joy2 << 1 | status.autoJoypadPort2.bit(0);
+      io.joy3 = io.joy3 << 1 | status.autoJoypadPort1.bit(1);
+      io.joy4 = io.joy4 << 1 | status.autoJoypadPort2.bit(1);
+    }
   }
-
-  status.autoJoypadCounter++;
 }

--- a/ares/sfc/system/serialization.cpp
+++ b/ares/sfc/system/serialization.cpp
@@ -1,4 +1,4 @@
-static const string SerializerVersion = "v145";
+static const string SerializerVersion = "v146";
 
 auto System::serialize(bool synchronize) -> serializer {
   if(synchronize) scheduler.enter(Scheduler::Mode::Synchronize);


### PR DESCRIPTION
- resolves #970

This is a port of the changes for bsnes in https://github.com/bsnes-emu/bsnes/pull/351 and should have the same effect in ares as the logic is the same. All caveats from the original PR and surrounding discussion still apply; this is not a perfect implementation but it's much more accurate than the previous logic.

I have added an additional TODO to mark one place where an accuracy improvement could most likely be made, but I didn't want to attempt any additional changes without stricter test roms to verify accuracy.