### PR TITLE
gba: add OAM to memory viewer

### DIFF
--- a/ares/gba/ppu/background.cpp
+++ b/ares/gba/ppu/background.cpp
@@ -26,9 +26,9 @@ auto PPU::Background::outputPixel(u32 x, u32 y) -> void {
   //horizontal mosaic
   if(!mosaicOffset) {
     mosaicOffset = 1 + io.mosaicWidth;
-    mosaic = output[x];
+    mosaicLatch = output[x];
   } else if(!io.mosaic) {
-    mosaic = output[x];
+    mosaicLatch = output[x];
   }
   mosaicOffset--;
 }
@@ -211,7 +211,7 @@ auto PPU::Background::power(u32 id) -> void {
   latch = {};
   affine = {};
   for(auto& pixel : output) pixel = {};
-  mosaic = {};
+  mosaicLatch = {};
   mosaicOffset = 0;
   vmosaic = 0;
   fx = 0;

--- a/ares/gba/ppu/dac.cpp
+++ b/ares/gba/ppu/dac.cpp
@@ -19,11 +19,11 @@ auto PPU::DAC::upperLayer(u32 x, u32 y) -> void {
   }
 
   //priority sorting: find topmost two pixels
-  layers[OBJ] = ppu.objects.mosaic;
-  layers[BG0] = ppu.bg0.mosaic;
-  layers[BG1] = ppu.bg1.mosaic;
-  layers[BG2] = ppu.bg2.mosaic;
-  layers[BG3] = ppu.bg3.mosaic;
+  layers[OBJ] = ppu.objects.mosaicLatch;
+  layers[BG0] = ppu.bg0.mosaicLatch;
+  layers[BG1] = ppu.bg1.mosaicLatch;
+  layers[BG2] = ppu.bg2.mosaicLatch;
+  layers[BG3] = ppu.bg3.mosaicLatch;
   layers[SFX] = {true, 3, 0};
 
   aboveLayer = 5;

--- a/ares/gba/ppu/debugger.cpp
+++ b/ares/gba/ppu/debugger.cpp
@@ -9,12 +9,21 @@ auto PPU::Debugger::load(Node::Object parent) -> void {
   });
 
   memory.pram = parent->append<Node::Debugger::Memory>("PPU PRAM");
-  memory.pram->setSize(ppu.pram.size());
+  memory.pram->setSize(ppu.pram.size() * 2);
   memory.pram->setRead([&](u32 address) -> u8 {
     return ppu.pram[address >> 1].byte(address & 1);
   });
   memory.pram->setWrite([&](u32 address, u8 data) -> void {
     ppu.pram[address >> 1].byte(address & 1) = data;
+  });
+
+  memory.oam = parent->append<Node::Debugger::Memory>("PPU OAM");
+  memory.oam->setSize(ppu.oam.size() * 2);
+  memory.oam->setRead([&](u32 address) -> u8 {
+    return ppu.oam[address >> 1].byte(address & 1);
+  });
+  memory.oam->setWrite([&](u32 address, u8 data) -> void {
+    ppu.oam[address >> 1].byte(address & 1) = data;
   });
 
   graphics.tiles4bpp = parent->append<Node::Debugger::Graphics>("4 BPP Tiles");
@@ -134,6 +143,7 @@ auto PPU::Debugger::load(Node::Object parent) -> void {
 auto PPU::Debugger::unload(Node::Object parent) -> void {
   parent->remove(memory.vram);
   parent->remove(memory.pram);
+  parent->remove(memory.oam);
   parent->remove(graphics.tiles4bpp);
   parent->remove(graphics.tiles8bpp);
   parent->remove(graphics.mode3);
@@ -141,6 +151,7 @@ auto PPU::Debugger::unload(Node::Object parent) -> void {
   parent->remove(graphics.mode5);
   memory.vram.reset();
   memory.pram.reset();
+  memory.oam.reset();
   graphics.tiles4bpp.reset();
   graphics.tiles8bpp.reset();
   graphics.mode3.reset();

--- a/ares/gba/ppu/memory.cpp
+++ b/ares/gba/ppu/memory.cpp
@@ -79,43 +79,8 @@ auto PPU::writePRAM(u32 mode, n32 address, n16 half) -> void {
 }
 
 auto PPU::readOAM(u32 mode, n32 address) -> n32 {
-  auto& obj = object[address >> 3 & 127];
-  auto& par = objectParam[address >> 5 & 31];
-  n16 param;
-  switch(address >> 3 & 3) {
-  case 0: param = par.pa; break;
-  case 1: param = par.pb; break;
-  case 2: param = par.pc; break;
-  case 3: param = par.pd; break;
-  }
-
-  switch(address & 4) {
-
-  case 0: return (
-    (obj.y           <<  0)
-  | (obj.affine      <<  8)
-  | (obj.affineSize  <<  9)
-  | (obj.mode        << 10)
-  | (obj.mosaic      << 12)
-  | (obj.colors      << 13)
-  | (obj.shape       << 14)
-  | (obj.x           << 16)
-  | (obj.affineParam << 25)
-  | (obj.hflip       << 28)
-  | (obj.vflip       << 29)
-  | (obj.size        << 30)
-  );
-
-  case 4: return (
-    (obj.character <<  0)
-  | (obj.priority  << 10)
-  | (obj.palette   << 12)
-  | (param         << 16)
-  );
-
-  }
-
-  unreachable;
+  address = (n10)address;
+  return oam[address >> 1 & ~1] << 0 | oam[address >> 1 | 1] << 16;
 }
 
 auto PPU::writeOAM(u32 mode, n32 address, n32 word) -> void {
@@ -126,61 +91,7 @@ auto PPU::writeOAM(u32 mode, n32 address, n32 word) -> void {
   }
 
   if(mode & Byte) return;  //8-bit writes to OAM are ignored
-
-  auto& obj = object[address >> 3 & 127];
-  auto& par = objectParam[address >> 5 & 31];
-  switch(address & 6) {
-
-  case 0:
-    obj.y          = word >>  0;
-    obj.affine     = word >>  8;
-    obj.affineSize = word >>  9;
-    obj.mode       = word >> 10;
-    obj.mosaic     = word >> 12;
-    obj.colors     = word >> 13;
-    obj.shape      = word >> 14;
-    break;
-
-  case 2:
-    obj.x           = word >>  0;
-    obj.affineParam = word >>  9;
-    obj.hflip       = word >> 12;
-    obj.vflip       = word >> 13;
-    obj.size        = word >> 14;
-    break;
-
-  case 4:
-    obj.character = word >>  0;
-    obj.priority  = word >> 10;
-    obj.palette   = word >> 12;
-    break;
-
-  case 6:
-    switch(address >> 3 & 3) {
-    case 0: par.pa = word; break;
-    case 1: par.pb = word; break;
-    case 2: par.pc = word; break;
-    case 3: par.pd = word; break;
-    }
-
-  }
-
-  static u32 widths[] = {
-     8, 16, 32, 64,
-    16, 32, 32, 64,
-     8,  8, 16, 32,
-     8,  8,  8,  8,  //invalid modes
-  };
-
-  static u32 heights[] = {
-     8, 16, 32, 64,
-     8,  8, 16, 32,
-    16, 32, 32, 64,
-     8,  8,  8,  8,  //invalid modes
-  };
-
-  obj.width  = widths [obj.shape * 4 + obj.size];
-  obj.height = heights[obj.shape * 4 + obj.size];
+  oam[address >> 1 & 511] = word;
 }
 
 auto PPU::readObjectVRAM(u32 address) const -> n8 {

--- a/ares/gba/ppu/object.cpp
+++ b/ares/gba/ppu/object.cpp
@@ -6,6 +6,20 @@ auto PPU::Objects::setEnable(n1 status) -> void {
 auto PPU::Objects::scanline(u32 y) -> void {
   if(y >= 160) return;
 
+  static const u32 widths[] = {
+     8, 16, 32, 64,
+    16, 32, 32, 64,
+     8,  8, 16, 32,
+     8,  8,  8,  8,  //invalid modes
+  };
+
+  static const u32 heights[] = {
+     8, 16, 32, 64,
+     8,  8, 16, 32,
+    16, 32, 32, 64,
+     8,  8,  8,  8,  //invalid modes
+  };
+
   hmosaicOffset = io.mosaicWidth;
   if(y == 0 || vmosaicOffset == io.mosaicHeight) {
     vmosaicOffset = 0;
@@ -18,72 +32,95 @@ auto PPU::Objects::scanline(u32 y) -> void {
   for(auto& pixel : buffer) pixel = {};
   if(ppu.io.forceBlank[1] || cpu.stopped() || !io.enable[1]) return;  //checks if display conditions will be met next scanline
 
-  for(auto& object : ppu.object) {
-    n8 py = y - object.y;
-    if(object.affine == 0 && object.affineSize == 1) continue;  //hidden
-    if(py >= object.height << object.affineSize) continue;  //offscreen
+  for(auto oamIndex : range(128)) {
+    n16 attr0 = ppu.oam[oamIndex << 2 | 0];
+    n8 ypos       = attr0 >>  0;
+    n1 affine     = attr0 >>  8;
+    n1 affineSize = attr0 >>  9;
+    n2 mode       = attr0 >> 10;
+    n1 mosaic     = attr0 >> 12;
+    n1 colors     = attr0 >> 13;  //0 = 16, 1 = 256
+    n2 shape      = attr0 >> 14;  //0 = square, 1 = horizontal, 2 = vertical
 
-    if(object.mosaic) {
-      py = object.y >= 160 || mosaicY - object.y >= 0 ? u32(mosaicY - object.y) : 0;
+    n16 attr1 = ppu.oam[oamIndex << 2 | 1];
+    n9 xpos        = attr1 >>  0;
+    n5 affineParam = attr1 >>  9;
+    n1 hflip       = attr1 >> 12;
+    n1 vflip       = attr1 >> 13;
+    n2 size        = attr1 >> 14;
+
+    n8 py = y - ypos;
+    n32 width  = widths [shape * 4 + size];
+    n32 height = heights[shape * 4 + size];
+    if(affine == 0 && affineSize == 1) continue;  //hidden
+    if(py >= height << affineSize) continue;  //offscreen
+
+    if(mosaic) {
+      py = ypos >= 160 || mosaicY - ypos >= 0 ? u32(mosaicY - ypos) : 0;
     }
 
-    i16 pa = ppu.objectParam[object.affineParam].pa;
-    i16 pb = ppu.objectParam[object.affineParam].pb;
-    i16 pc = ppu.objectParam[object.affineParam].pc;
-    i16 pd = ppu.objectParam[object.affineParam].pd;
+    n16 attr2 = ppu.oam[oamIndex << 2 | 2];
+    n10 character = attr2 >>  0;
+    n2  priority  = attr2 >> 10;
+    n4  palette   = attr2 >> 12;
+
+    i16 pa = ppu.oam[affineParam << 4 | 0x3];
+    i16 pb = ppu.oam[affineParam << 4 | 0x7];
+    i16 pc = ppu.oam[affineParam << 4 | 0xb];
+    i16 pd = ppu.oam[affineParam << 4 | 0xf];
 
     //center-of-sprite coordinates
-    i16 centerX = object.width  >> 1;
-    i16 centerY = object.height >> 1;
+    i16 centerX = width  >> 1;
+    i16 centerY = height >> 1;
 
     //origin coordinates (top-left of sprite)
-    i28 originX = -(centerX << object.affineSize);
-    i28 originY = -(centerY << object.affineSize) + py;
+    i28 originX = -(centerX << affineSize);
+    i28 originY = -(centerY << affineSize) + py;
 
     //fractional pixel coordinates
     i28 fx = originX * pa + originY * pb;
     i28 fy = originX * pc + originY * pd;
 
-    for(u32 px : range(object.width << object.affineSize)) {
+    for(u32 px : range(width << affineSize)) {
       //calculate address within tile
       u32 sx, sy;
-      if(!object.affine) {
-        sx = px ^ (object.hflip ? object.width  - 1 : 0);
-        sy = py ^ (object.vflip ? object.height - 1 : 0);
+      if(!affine) {
+        sx = px ^ (hflip ? width  - 1 : 0);
+        sy = py ^ (vflip ? height - 1 : 0);
       } else {
         sx = (fx >> 8) + centerX;
         sy = (fy >> 8) + centerY;
       }
-      n6 subTileAddr = ((sy & 7) * 8 + (sx & 7)) >> !object.colors;
+      n6 subTileAddr = ((sy & 7) * 8 + (sx & 7)) >> !colors;
 
       //calculate address of tile
       n10 tileAddr;
       if(io.mapping) {
-        u32 offset = (sy >> 3) * (object.width >> 3) + (sx >> 3);
-        tileAddr = object.character + (offset << object.colors);
+        u32 offset = (sy >> 3) * (width >> 3) + (sx >> 3);
+        tileAddr = character + (offset << colors);
       } else {
-        n5 row = (object.character >> 5) + (sy >> 3);
-        n5 rowEntry = object.character + ((sx >> 3) << object.colors);
+        n5 row = (character >> 5) + (sy >> 3);
+        n5 rowEntry = character + ((sx >> 3) << colors);
         tileAddr = (row << 5) + rowEntry;
       }
 
       //output pixel
       n8 color = ppu.readObjectVRAM((tileAddr << 5) + subTileAddr);
-      if(object.colors == 0) color = sx & 1 ? color >> 4 : color & 15;
-      n9 bx = object.x + px;
-      if(bx < 240 && sx < object.width && sy < object.height) {
-        if(object.mode & 2) {
+      if(colors == 0) color = sx & 1 ? color >> 4 : color & 15;
+      n9 bx = xpos + px;
+      if(bx < 240 && sx < width && sy < height) {
+        if(mode & 2) {
           if(color) {
             buffer[bx].window = true;
           }
-        } else if(!buffer[bx].enable || object.priority < buffer[bx].priority) {
-          buffer[bx].priority = object.priority;  //updated regardless of transparency
-          buffer[bx].mosaic = object.mosaic;  //updated regardless of transparency
+        } else if(!buffer[bx].enable || priority < buffer[bx].priority) {
+          buffer[bx].priority = priority;  //updated regardless of transparency
+          buffer[bx].mosaic = mosaic;  //updated regardless of transparency
           if(color) {
-            if(object.colors == 0) color = object.palette * 16 + color;
+            if(colors == 0) color = palette * 16 + color;
             buffer[bx].enable = true;
             buffer[bx].color = 256 + color;
-            buffer[bx].translucent = object.mode == 1;
+            buffer[bx].translucent = mode == 1;
           }
         }
       }
@@ -97,7 +134,7 @@ auto PPU::Objects::scanline(u32 y) -> void {
 auto PPU::Objects::outputPixel(u32 x, u32 y) -> void {
   output = {};
   if(ppu.blank() || !io.enable[0]) {
-    mosaic = {};
+    mosaicLatch = {};
     return;
   }
 
@@ -106,13 +143,13 @@ auto PPU::Objects::outputPixel(u32 x, u32 y) -> void {
 
   if(hmosaicOffset == io.mosaicWidth) {
     hmosaicOffset = 0;
-    mosaic = output;
+    mosaicLatch = output;
   } else {
     hmosaicOffset++;
   }
 
-  if(!mosaic.mosaic || !output.mosaic || (output.priority < mosaic.priority)) {
-    mosaic = output;
+  if(!mosaicLatch.mosaic || !output.mosaic || (output.priority < mosaicLatch.priority)) {
+    mosaicLatch = output;
   }
 }
 
@@ -122,7 +159,7 @@ auto PPU::Objects::power() -> void {
     for(auto& pixel : buffer) pixel = {};
   }
   output = {};
-  mosaic = {};
+  mosaicLatch = {};
   mosaicY = 0;
   hmosaicOffset = 0;
   vmosaicOffset = 0;

--- a/ares/gba/ppu/ppu.cpp
+++ b/ares/gba/ppu/ppu.cpp
@@ -20,6 +20,7 @@ auto PPU::setAccurate(bool value) -> void {
 auto PPU::load(Node::Object parent) -> void {
   vram.allocate(96_KiB);
   pram.allocate(512);
+  oam.allocate(512);
 
   node = parent->append<Node::Object>("PPU");
 
@@ -256,8 +257,6 @@ auto PPU::power() -> void {
   for(u32 n = 0; n < 1024; n += 2) writeOAM(Half, n, 0x0000);
 
   io = {};
-  for(auto& object : this->object) object = {};
-  for(auto& param : this->objectParam) param = {};
 
   bg0.power(BG0);
   bg1.power(BG1);

--- a/ares/gba/ppu/ppu.hpp
+++ b/ares/gba/ppu/ppu.hpp
@@ -6,6 +6,7 @@ struct PPU : Thread, IO {
   Node::Setting::String rotation;
   Memory::Writable<n8 > vram;  //96KB
   Memory::Writable<n16> pram;
+  Memory::Writable<n16> oam;
 
   bool accurate;
 
@@ -17,6 +18,7 @@ struct PPU : Thread, IO {
     struct Memory {
       Node::Debugger::Memory vram;
       Node::Debugger::Memory pram;
+      Node::Debugger::Memory oam;
     } memory;
 
     struct Graphics {
@@ -180,7 +182,7 @@ private:
     } affine;
 
     Pixel output[240];
-    Pixel mosaic;
+    Pixel mosaicLatch;
     u32 mosaicOffset;
     u32 vmosaic;
 
@@ -209,7 +211,7 @@ private:
 
     Pixel lineBuffers[2][240];
     Pixel output;
-    Pixel mosaic;
+    Pixel mosaicLatch;
     s32 mosaicY;
     n4 hmosaicOffset;
     n4 vmosaicOffset;
@@ -273,43 +275,6 @@ private:
 
     u32* line = nullptr;
   } dac;
-
-  struct Object {
-    //serialization.cpp
-    auto serialize(serializer&) -> void;
-
-    n8  y;
-    n1  affine;
-    n1  affineSize;
-    n2  mode;
-    n1  mosaic;
-    n1  colors;  //0 = 16, 1 = 256
-    n2  shape;   //0 = square, 1 = horizontal, 2 = vertical
-
-    n9  x;
-    n5  affineParam;
-    n1  hflip;
-    n1  vflip;
-    n2  size;
-
-    n10 character;
-    n2  priority;
-    n4  palette;
-
-    //ancillary data
-    n32 width;
-    n32 height;
-  } object[128];
-
-  struct ObjectParam {
-    //serialization.cpp
-    auto serialize(serializer&) -> void;
-
-    i16 pa;
-    i16 pb;
-    i16 pc;
-    i16 pd;
-  } objectParam[32];
 
   bool pramAccessed;
   bool vramAccessedBG;

--- a/ares/gba/ppu/serialization.cpp
+++ b/ares/gba/ppu/serialization.cpp
@@ -3,6 +3,7 @@ auto PPU::serialize(serializer& s) -> void {
 
   s(vram);
   s(pram);
+  s(oam);
 
   s(io.gameBoyColorMode);
   for(auto& flag : io.forceBlank) s(flag);
@@ -22,8 +23,6 @@ auto PPU::serialize(serializer& s) -> void {
   s(window2);
   s(window3);
   s(dac);
-  for(auto& object : this->object) s(object);
-  for(auto& param : this->objectParam) s(param);
 
   s(pramAccessed);
   s(vramAccessedBG);
@@ -92,31 +91,4 @@ auto PPU::DAC::serialize(serializer& s) -> void {
   s(io.blendEVA);
   s(io.blendEVB);
   s(io.blendEVY);
-}
-
-auto PPU::Object::serialize(serializer& s) -> void {
-  s(y);
-  s(affine);
-  s(affineSize);
-  s(mode);
-  s(mosaic);
-  s(colors);
-  s(shape);
-  s(x);
-  s(affineParam);
-  s(hflip);
-  s(vflip);
-  s(size);
-  s(character);
-  s(priority);
-  s(palette);
-  s(width);
-  s(height);
-}
-
-auto PPU::ObjectParam::serialize(serializer& s) -> void {
-  s(pa);
-  s(pb);
-  s(pc);
-  s(pd);
 }

--- a/ares/gba/system/serialization.cpp
+++ b/ares/gba/system/serialization.cpp
@@ -1,4 +1,4 @@
-static const string SerializerVersion = "v148.5";
+static const string SerializerVersion = "v148.6";
 
 auto System::serialize(bool synchronize) -> serializer {
   if(synchronize) scheduler.enter(Scheduler::Mode::Synchronize);


### PR DESCRIPTION
Exposes OAM in the memory viewer/editor tab. OAM handling has been refactored to simplify the implementation, and to facilitate future work on sprite rendering timings.

Also fixes a bug where the upper half of PRAM was inaccessible in the memory viewer/editor tab.