### PR TITLE
n64: implement VR4300 reverse-endian mode

### DIFF
--- a/ares/n64/cpu/memory.cpp
+++ b/ares/n64/cpu/memory.cpp
@@ -146,19 +146,31 @@ inline auto CPU::busReadBurst(u32 address, u32 *data) -> bool {
   return bus.readBurst<Size>(address, data, *this);
 }
 
+template<u32 Size>
+static auto reverseEndianPaddr(u32 paddr) -> u32 {
+  if constexpr(Size == Byte) return paddr ^ 7;
+  if constexpr(Size == Half) return paddr ^ 6;
+  if constexpr(Size == Word) return paddr ^ 4;
+  return paddr;
+}
+
 auto CPU::fetch(PhysAccess access) -> maybe<u32> {
   step(1 * 2);
   if(!access) return nothing;
-  if(access.cache) return icache.fetch(access.vaddr, access.paddr, cpu);
-  return busRead<Word>(access.paddr);
+  u32 paddr = access.paddr;
+  if(context.littleEndian()) paddr = reverseEndianPaddr<Word>(paddr);
+  if(access.cache) return icache.fetch(access.vaddr, paddr, cpu);
+  return busRead<Word>(paddr);
 }
 
 template<u32 Size>
 auto CPU::read(PhysAccess access) -> maybe<u64> {
   if(!access) return nothing;
   GDB::server.reportMemRead(access.vaddr, Size);
-  if(access.cache) return dcache.read<Size>(access.vaddr, access.paddr);
-  return busRead<Size>(access.paddr);
+  u32 paddr = access.paddr;
+  if(context.littleEndian()) paddr = reverseEndianPaddr<Size>(paddr);
+  if(access.cache) return dcache.read<Size>(access.vaddr, paddr);
+  return busRead<Size>(paddr);
 }
 
 template<u32 Size>
@@ -175,8 +187,10 @@ template<u32 Size>
 auto CPU::write(PhysAccess access, u64 data) -> bool {
   if(!access) return false;
   GDB::server.reportMemWrite(access.vaddr, Size);
-  if(access.cache) return dcache.write<Size>(access.vaddr, access.paddr, data), true;
-  return busWrite<Size>(access.paddr, data), true;
+  u32 paddr = access.paddr;
+  if(context.littleEndian()) paddr = reverseEndianPaddr<Size>(paddr);
+  if(access.cache) return dcache.write<Size>(access.vaddr, paddr, data), true;
+  return busWrite<Size>(paddr, data), true;
 }
 
 template<u32 Size>
@@ -185,8 +199,10 @@ auto CPU::writeDebug(u64 vaddr, u64 data) -> bool {
   auto access = devirtualize<Write, Size>(vaddr, false, false);
   if(!access) return false;
   GDB::server.reportMemWrite(access.vaddr, Size);
-  if(access.cache) return dcache.writeDebug<Size>(access.vaddr, access.paddr, data), true;
-  return bus.write<Size>(access.paddr, data, dummyThread, RBusDevice::ARES_DEBUGGER), true;
+  u32 paddr = access.paddr;
+  if(context.littleEndian()) paddr = reverseEndianPaddr<Size>(paddr);
+  if(access.cache) return dcache.writeDebug<Size>(access.vaddr, paddr, data), true;
+  return bus.write<Size>(paddr, data, dummyThread, RBusDevice::ARES_DEBUGGER), true;
 }
 
 template<u32 Size>

--- a/ares/n64/cpu/recompiler-ipu.cpp
+++ b/ares/n64/cpu/recompiler-ipu.cpp
@@ -72,6 +72,12 @@ auto CPU::Recompiler::jitMemoryOpcode(u32 instruction, u32 size, u32 mode,
   bool linkedConditional = mode & LinkedConditional;
   bool loadLinked = linkedConditional && !store;
   bool storeConditional = linkedConditional && store;
+  u32 reverseEndianXor = 0;
+  if(emitStateKey.reverseEndian()) {
+    if(size == Byte) reverseEndianXor = 7;
+    if(size == Half) reverseEndianXor = 6;
+    if(size == Word) reverseEndianXor = 4;
+  }
   s32 floatingWordOff = 0;
   s32 floatingDualOff = 0;
   if(floating) {
@@ -84,7 +90,6 @@ auto CPU::Recompiler::jitMemoryOpcode(u32 instruction, u32 size, u32 mode,
     }
   }
   if(emitSlowPath || emitStateKey.watchpointsActive() || (require64 && reservedInstruction64())
-  || ((partialLeft || partialRight) && emitStateKey.reverseEndian())
   || (store && size == Dual && (partialLeft || partialRight) && system.homebrewMode)
   || (floating && !emitStateKey.coprocessor1Enabled())) {
     return fallback();
@@ -140,6 +145,9 @@ auto CPU::Recompiler::jitMemoryOpcode(u32 instruction, u32 size, u32 mode,
 
   // Convert the cached virtual address to an RDRAM physical address and locate its dcache line.
   and32(reg(0), reg(0), imm(0x007f'ffff));
+  if(reverseEndianXor) {
+    xor32(reg(0), reg(0), imm(reverseEndianXor));
+  }
   lshr32(reg(1), reg(0), imm(4));
   and32(reg(1), reg(1), imm(0x1ff));
   mul64(reg(2), reg(1), imm(CpuDcacheLineBytes));
@@ -297,6 +305,9 @@ auto CPU::Recompiler::jitMemoryOpcode(u32 instruction, u32 size, u32 mode,
     if(system.homebrewMode) {
       add64(reg(4), mem(Rs), imm(i16));
       and32(reg(4), reg(4), imm(0x0f));
+      if(reverseEndianXor) {
+        xor32(reg(4), reg(4), imm(reverseEndianXor));
+      }
       if(partialLeft && size == Word) {
         and32(reg(3), reg(4), imm(3));
         mov32(reg(1), imm(0x0f));

--- a/ares/n64/cpu/recompiler.cpp
+++ b/ares/n64/cpu/recompiler.cpp
@@ -224,6 +224,10 @@ are extremely common) and moves cleanup work to lookup time.
 
 auto CPU::Recompiler::computeStateKey() const -> u64 {
   StateKey stateKey = 0;
+  bool reverseEndian = !self.scc.status.exceptionLevel
+                    && !self.scc.status.errorLevel
+                    && self.scc.status.privilegeMode >= 2
+                    && self.scc.status.reverseEndian;
   stateKey.setCoprocessor1Enabled(self.scc.status.enable.coprocessor1);
   stateKey.setFloatingPointMode(self.scc.status.floatingPointMode);
   stateKey.setExceptionLevel(self.scc.status.exceptionLevel);
@@ -232,7 +236,7 @@ auto CPU::Recompiler::computeStateKey() const -> u64 {
   stateKey.setUserExtendedAddressing(self.scc.status.userExtendedAddressing);
   stateKey.setSupervisorExtendedAddressing(self.scc.status.supervisorExtendedAddressing);
   stateKey.setKernelExtendedAddressing(self.scc.status.kernelExtendedAddressing);
-  stateKey.setReverseEndian(self.scc.status.reverseEndian);
+  stateKey.setReverseEndian(reverseEndian);
   stateKey.setCoprocessor0Enabled(self.scc.status.enable.coprocessor0);
   stateKey.setFpuRoundMode(self.fpu.csr.roundMode);
   stateKey.setFpuFlushSubnormals(self.fpu.csr.flushSubnormals);
@@ -466,7 +470,8 @@ auto buildEmitPlan(ares::Nintendo64::CPU::Recompiler& recompiler, u64 vaddr, u32
     while(true) {
       if(recompiler.sectionIndex(currentAddress) != plan.startSection) break;
       if(!plan.instructions.empty() && GDB::server.hasBreakpointAt(u32(currentVaddr))) break;
-      u32 instruction = bus.read<Word>(currentAddress, thread, RBusDevice::ARES_JIT);
+      u32 fetchAddress = currentAddress ^ (recompiler.emitStateKey.reverseEndian() ? 4 : 0);
+      u32 instruction = bus.read<Word>(fetchAddress, thread, RBusDevice::ARES_JIT);
       auto info = recompiler.self.decoderEXECUTEInfo(instruction);
       // Materialize one prepass record per guest instruction.
       EmitPlannedInstruction pi;


### PR DESCRIPTION
This is a mode available only in the user mode, activated when RE=0. It facilitates running MIPS binary code that was build for a little-endian architecture, assuming that the code/data was 8-byte swapped in memory before running it.

It passes the new RE tests in n64-systemtest