### PR TITLE
n64: fix partial load/stores in little-endian mode

### DIFF
--- a/ares/n64/cpu/interpreter-ipu.cpp
+++ b/ares/n64/cpu/interpreter-ipu.cpp
@@ -451,86 +451,34 @@ auto CPU::LDL(r64& rt, cr64& rs, s16 imm) -> void {
   u64 vaddr = rs.u64 + imm;
   u64 data = rt.u64;
 
-  if(context.littleEndian())
-  switch(vaddr & 7) {
-  case 0:
-    data &= 0x00ffffffffffffffull;
-    if(auto byte = read<Byte>(vaddr & ~7 | 7)) data |= byte() << 56; else return;
-    break;
-  case 1:
-    data &= 0x0000ffffffffffffull;
-    if(auto half = read<Half>(vaddr & ~7 | 6)) data |= half() << 48; else return;
-    break;
-  case 2:
-    data &= 0x000000ffffffffffull;
-    if(auto byte = read<Byte>(vaddr & ~7 | 5)) data |= byte() << 56; else return;
-    if(auto half = read<Half>(vaddr & ~7 | 6)) data |= half() << 40; else return;
-    break;
-  case 3:
-    data &= 0x00000000ffffffffull;
-    if(auto word = read<Word>(vaddr & ~7 | 4)) data |= word() << 32; else return;
-    break;
-  case 4:
-    data &= 0x0000000000ffffffull;
-    if(auto byte = read<Byte>(vaddr & ~7 | 3)) data |= byte() << 56; else return;
-    if(auto word = read<Word>(vaddr & ~7 | 4)) data |= word() << 24; else return;
-    break;
-  case 5:
-    data &= 0x000000000000ffffull;
-    if(auto half = read<Half>(vaddr & ~7 | 2)) data |= half() << 48; else return;
-    if(auto word = read<Word>(vaddr & ~7 | 4)) data |= word() << 16; else return;
-    break;
-  case 6:
-    data &= 0x00000000000000ffull;
-    if(auto byte = read<Byte>(vaddr & ~7 | 1)) data |= byte() << 56; else return;
-    if(auto half = read<Half>(vaddr & ~7 | 2)) data |= half() << 40; else return;
-    if(auto word = read<Word>(vaddr & ~7 | 4)) data |= word() <<  8; else return;
-    break;
-  case 7:
-    data &= 0x0000000000000000ull;
-    if(auto dual = read<Dual>(vaddr & ~7 | 0)) data |= dual() <<  0; else return;
-    break;
+  if(context.littleEndian()) {
+    auto mem = read<Dual>(vaddr & ~7);
+    if(!mem) return;
+    switch(vaddr & 7) {
+    case 0: data = (data & 0x00ffffffffffffffull) | (*mem << 56); break;
+    case 1: data = (data & 0x0000ffffffffffffull) | (*mem << 48); break;
+    case 2: data = (data & 0x000000ffffffffffull) | (*mem << 40); break;
+    case 3: data = (data & 0x00000000ffffffffull) | (*mem << 32); break;
+    case 4: data = (data & 0x0000000000ffffffull) | (*mem << 24); break;
+    case 5: data = (data & 0x000000000000ffffull) | (*mem << 16); break;
+    case 6: data = (data & 0x00000000000000ffull) | (*mem <<  8); break;
+    case 7: data = (data & 0x0000000000000000ull) | (*mem <<  0); break;
+    }
   }
 
-  if(context.bigEndian())
-  switch(vaddr & 7) {
-  case 0:
-    data &= 0x0000000000000000ull;
-    if(auto dual = read<Dual>(vaddr & ~7 | 0)) data |= dual() <<  0; else return;
-    break;
-  case 1:
-    data &= 0x00000000000000ffull;
-    if(auto byte = read<Byte>(vaddr & ~7 | 1)) data |= byte() << 56; else return;
-    if(auto half = read<Half>(vaddr & ~7 | 2)) data |= half() << 40; else return;
-    if(auto word = read<Word>(vaddr & ~7 | 4)) data |= word() <<  8; else return;
-    break;
-  case 2:
-    data &= 0x000000000000ffffull;
-    if(auto half = read<Half>(vaddr & ~7 | 2)) data |= half() << 48; else return;
-    if(auto word = read<Word>(vaddr & ~7 | 4)) data |= word() << 16; else return;
-    break;
-  case 3:
-    data &= 0x0000000000ffffffull;
-    if(auto byte = read<Byte>(vaddr & ~7 | 3)) data |= byte() << 56; else return;
-    if(auto word = read<Word>(vaddr & ~7 | 4)) data |= word() << 24; else return;
-    break;
-  case 4:
-    data &= 0x00000000ffffffffull;
-    if(auto word = read<Word>(vaddr & ~7 | 4)) data |= word() << 32; else return;
-    break;
-  case 5:
-    data &= 0x000000ffffffffffull;
-    if(auto byte = read<Byte>(vaddr & ~7 | 5)) data |= byte() << 56; else return;
-    if(auto half = read<Half>(vaddr & ~7 | 6)) data |= half() << 40; else return;
-    break;
-  case 6:
-    data &= 0x0000ffffffffffffull;
-    if(auto half = read<Half>(vaddr & ~7 | 6)) data |= half() << 48; else return;
-    break;
-  case 7:
-    data &= 0x00ffffffffffffffull;
-    if(auto byte = read<Byte>(vaddr & ~7 | 7)) data |= byte() << 56; else return;
-    break;
+  if(context.bigEndian()) {
+    auto mem = read<Dual>(vaddr & ~7);
+    if(!mem) return;
+    switch(vaddr & 7) {
+    case 0: data = (data & 0x0000000000000000ull) | (*mem <<  0); break;
+    case 1: data = (data & 0x00000000000000ffull) | (*mem <<  8); break;
+    case 2: data = (data & 0x000000000000ffffull) | (*mem << 16); break;
+    case 3: data = (data & 0x0000000000ffffffull) | (*mem << 24); break;
+    case 4: data = (data & 0x00000000ffffffffull) | (*mem << 32); break;
+    case 5: data = (data & 0x000000ffffffffffull) | (*mem << 40); break;
+    case 6: data = (data & 0x0000ffffffffffffull) | (*mem << 48); break;
+    case 7: data = (data & 0x00ffffffffffffffull) | (*mem << 56); break;
+    }
   }
 
   rt.u64 = data;
@@ -541,86 +489,34 @@ auto CPU::LDR(r64& rt, cr64& rs, s16 imm) -> void {
   u64 vaddr = rs.u64 + imm;
   u64 data = rt.u64;
 
-  if(context.littleEndian())
-  switch(vaddr & 7) {
-  case 0:
-    data &= 0x0000000000000000ull;
-    if(auto dual = read<Dual>(vaddr & ~7 | 0)) data |= dual() <<  0; else return;
-    break;
-  case 1:
-    data &= 0xff00000000000000ull;
-    if(auto word = read<Word>(vaddr & ~7 | 0)) data |= word() << 24; else return;
-    if(auto half = read<Half>(vaddr & ~7 | 4)) data |= half() <<  8; else return;
-    if(auto byte = read<Byte>(vaddr & ~7 | 6)) data |= byte() <<  0; else return;
-    break;
-  case 2:
-    data &= 0xffff000000000000ull;
-    if(auto word = read<Word>(vaddr & ~7 | 0)) data |= word() << 16; else return;
-    if(auto half = read<Half>(vaddr & ~7 | 4)) data |= half() <<  0; else return;
-    break;
-  case 3:
-    data &= 0xffffff0000000000ull;
-    if(auto word = read<Word>(vaddr & ~7 | 0)) data |= word() <<  8; else return;
-    if(auto byte = read<Byte>(vaddr & ~7 | 4)) data |= byte() <<  0; else return;
-    break;
-  case 4:
-    data &= 0xffffffff00000000ull;
-    if(auto word = read<Word>(vaddr & ~7 | 0)) data |= word() <<  0; else return;
-    break;
-  case 5:
-    data &= 0xffffffffff000000ull;
-    if(auto half = read<Half>(vaddr & ~7 | 0)) data |= half() <<  8; else return;
-    if(auto byte = read<Byte>(vaddr & ~7 | 2)) data |= byte() <<  0; else return;
-    break;
-  case 6:
-    data &= 0xffffffffffff0000ull;
-    if(auto half = read<Half>(vaddr & ~7 | 0)) data |= half() <<  0; else return;
-    break;
-  case 7:
-    data &= 0xffffffffffffff00ull;
-    if(auto byte = read<Byte>(vaddr & ~7 | 0)) data |= byte() <<  0; else return;
-    break;
+  if(context.littleEndian()) {
+    auto mem = read<Dual>(vaddr & ~7);
+    if(!mem) return;
+    switch(vaddr & 7) {
+    case 0: data = (data & 0x0000000000000000ull) | (*mem >>  0); break;
+    case 1: data = (data & 0xff00000000000000ull) | (*mem >>  8); break;
+    case 2: data = (data & 0xffff000000000000ull) | (*mem >> 16); break;
+    case 3: data = (data & 0xffffff0000000000ull) | (*mem >> 24); break;
+    case 4: data = (data & 0xffffffff00000000ull) | (*mem >> 32); break;
+    case 5: data = (data & 0xffffffffff000000ull) | (*mem >> 40); break;
+    case 6: data = (data & 0xffffffffffff0000ull) | (*mem >> 48); break;
+    case 7: data = (data & 0xffffffffffffff00ull) | (*mem >> 56); break;
+    }
   }
 
-  if(context.bigEndian())
-  switch(vaddr & 7) {
-  case 0:
-    data &= 0xffffffffffffff00ull;
-    if(auto byte = read<Byte>(vaddr & ~7 | 0)) data |= byte() <<  0; else return;
-    break;
-  case 1:
-    data &= 0xffffffffffff0000ull;
-    if(auto half = read<Half>(vaddr & ~7 | 0)) data |= half() <<  0; else return;
-    break;
-  case 2:
-    data &= 0xffffffffff000000ull;
-    if(auto half = read<Half>(vaddr & ~7 | 0)) data |= half() <<  8; else return;
-    if(auto byte = read<Byte>(vaddr & ~7 | 2)) data |= byte() <<  0; else return;
-    break;
-  case 3:
-    data &= 0xffffffff00000000ull;
-    if(auto word = read<Word>(vaddr & ~7 | 0)) data |= word() <<  0; else return;
-    break;
-  case 4:
-    data &= 0xffffff0000000000ull;
-    if(auto word = read<Word>(vaddr & ~7 | 0)) data |= word() <<  8; else return;
-    if(auto byte = read<Byte>(vaddr & ~7 | 4)) data |= byte() <<  0; else return;
-    break;
-  case 5:
-    data &= 0xffff000000000000ull;
-    if(auto word = read<Word>(vaddr & ~7 | 0)) data |= word() << 16; else return;
-    if(auto half = read<Half>(vaddr & ~7 | 4)) data |= half() <<  0; else return;
-    break;
-  case 6:
-    data &= 0xff00000000000000ull;
-    if(auto word = read<Word>(vaddr & ~7 | 0)) data |= word() << 24; else return;
-    if(auto half = read<Half>(vaddr & ~7 | 4)) data |= half() <<  8; else return;
-    if(auto byte = read<Byte>(vaddr & ~7 | 6)) data |= byte() <<  0; else return;
-    break;
-  case 7:
-    data &= 0x0000000000000000ull;
-    if(auto dual = read<Dual>(vaddr & ~7 | 0)) data |= dual() <<  0; else return;
-    break;
+  if(context.bigEndian()) {
+    auto mem = read<Dual>(vaddr & ~7);
+    if(!mem) return;
+    switch(vaddr & 7) {
+    case 0: data = (data & 0xffffffffffffff00ull) | (*mem >> 56); break;
+    case 1: data = (data & 0xffffffffffff0000ull) | (*mem >> 48); break;
+    case 2: data = (data & 0xffffffffff000000ull) | (*mem >> 40); break;
+    case 3: data = (data & 0xffffffff00000000ull) | (*mem >> 32); break;
+    case 4: data = (data & 0xffffff0000000000ull) | (*mem >> 24); break;
+    case 5: data = (data & 0xffff000000000000ull) | (*mem >> 16); break;
+    case 6: data = (data & 0xff00000000000000ull) | (*mem >>  8); break;
+    case 7: data = (data & 0x0000000000000000ull) | (*mem >>  0); break;
+    }
   }
 
   rt.u64 = data;
@@ -667,49 +563,27 @@ auto CPU::LWL(r64& rt, cr64& rs, s16 imm) -> void {
   u64 vaddr = rs.u64 + imm;
   u32 data = rt.u32;
   auto mem = read<Word>(vaddr & ~3);
-  if (!mem) return;
+  if(!mem) return;
+  u32 word = *mem;
 
-  if(context.littleEndian())
-  switch(vaddr & 3) {
-  case 0:
-    data &= 0x00ffffff;
-    *mem <<= 24;
-    break;
-  case 1:
-    data &= 0x0000ffff;
-    *mem <<= 16;
-    break;
-  case 2:
-    data &= 0x000000ff;
-    *mem <<= 8;
-    break;
-  case 3:
-    data &= 0x00000000;
-    *mem <<= 0;
-    break;
+  if(context.littleEndian()) {
+    switch(vaddr & 3) {
+    case 0: data = (data & 0x00ffffff) | (word << 24); break;
+    case 1: data = (data & 0x0000ffff) | (word << 16); break;
+    case 2: data = (data & 0x000000ff) | (word <<  8); break;
+    case 3: data = (data & 0x00000000) | (word <<  0); break;
+    }
+  }
+  
+  if(context.bigEndian()) {
+    switch(vaddr & 3) {
+    case 0: data = (data & 0x00000000) | (word <<  0); break;
+    case 1: data = (data & 0x000000ff) | (word <<  8); break;
+    case 2: data = (data & 0x0000ffff) | (word << 16); break;
+    case 3: data = (data & 0x00ffffff) | (word << 24); break;
+    }
   }
 
-  if(context.bigEndian())
-  switch(vaddr & 3) {
-  case 0:
-    data &= 0x00000000;
-    *mem <<= 0;
-    break;
-  case 1:
-    data &= 0x000000ff;
-    *mem <<= 8;
-    break;
-  case 2:
-    data &= 0x0000ffff;
-    *mem <<= 16;
-    break;
-  case 3:
-    data &= 0x00ffffff;
-    *mem <<= 24;
-    break;
-  }
-
-  data |= *mem;
   rt.s64 = (s32)data;
 }
 
@@ -718,63 +592,30 @@ auto CPU::LWR(r64& rt, cr64& rs, s16 imm) -> void {
   u64 upper = rt.u64 & 0xffffffff00000000ull;
   u32 data = rt.u32;
   auto mem = read<Word>(vaddr & ~3);
-  if (!mem) return;
+  if(!mem) return;
+  u32 word = *mem;
+  bool signExtended;
 
-  if(context.littleEndian())
-  switch(vaddr & 3) {
-  case 0:
-    data &= 0x00000000;
-    *mem >>= 0;
-    data |= *mem;
-    rt.s64 = (s32)data;
-    break;
-  case 1:
-    data &= 0xff000000;
-    *mem >>= 8;
-    data |= *mem;
-    rt.u64 = upper | data;
-    break;
-  case 2:
-    data &= 0xffff0000;
-    *mem >>= 16;
-    data |= *mem;
-    rt.u64 = upper | data;
-    break;
-  case 3:
-    data &= 0xffffff00;
-    *mem >>= 24;
-    data |= *mem;
-    rt.u64 = upper | data;
-    break;
+  if(context.littleEndian()) {
+    switch(vaddr & 3) {
+    case 0: data = (data & 0x00000000) | (word >>  0); signExtended = true;  break;
+    case 1: data = (data & 0xff000000) | (word >>  8); signExtended = false; break;
+    case 2: data = (data & 0xffff0000) | (word >> 16); signExtended = false; break;
+    case 3: data = (data & 0xffffff00) | (word >> 24); signExtended = false; break;
+    }
   }
 
-  if(context.bigEndian())
-  switch(vaddr & 3) {
-  case 0:
-    data &= 0xffffff00;
-    *mem >>= 24;
-    data |= *mem;
-    rt.u64 = upper | data;
-    break;
-  case 1:
-    data &= 0xffff0000;
-    *mem >>= 16;
-    data |= *mem;
-    rt.u64 = upper | data;
-    break;
-  case 2:
-    data &= 0xff000000;
-    *mem >>= 8;
-    data |= *mem;
-    rt.u64 = upper | data;
-    break;
-  case 3:
-    data &= 0x00000000;
-    *mem >>= 0;
-    data |= *mem;
-    rt.s64 = (s32)data;
-    break;
+  if(context.bigEndian()) {
+    switch(vaddr & 3) {
+    case 0: data = (data & 0xffffff00) | (word >> 24); signExtended = false; break;
+    case 1: data = (data & 0xffff0000) | (word >> 16); signExtended = false; break;
+    case 2: data = (data & 0xff000000) | (word >>  8); signExtended = false; break;
+    case 3: data = (data & 0x00000000) | (word >>  0); signExtended = true;  break;
+    }
   }
+
+  if(signExtended) rt.s64 = (s32)data;
+  else             rt.u64 = upper | data;
 }
 
 auto CPU::LWU(r64& rt, cr64& rs, s16 imm) -> void {
@@ -861,36 +702,36 @@ auto CPU::SDL(cr64& rt, cr64& rs, s16 imm) -> void {
   if(context.littleEndian())
   switch(vaddr & 7) {
   case 0:
-    if(!write<Byte>(vaddr & ~7 | 7, data >> 56)) return;
+    if(!write<Byte>(vaddr & ~7 | 0, data >> 56)) return;
     break;
   case 1:
-    if(!write<Half>(vaddr & ~7 | 6, data >> 48)) return;
+    if(!write<Half>(vaddr & ~7 | 0, data >> 48)) return;
     break;
   case 2:
-    if(!write<Byte>(vaddr & ~7 | 5, data >> 56)) return;
-    if(!write<Half>(vaddr & ~7 | 6, data >> 40)) return;
+    if(!write<Byte>(vaddr & ~7 | 2, data >> 56)) return;
+    if(!write<Half>(vaddr & ~7 | 0, data >> 40)) return;
     break;
   case 3:
-    if(!write<Word>(vaddr & ~7 | 4, data >> 32)) return;
+    if(!write<Word>(vaddr & ~7 | 0, data >> 32)) return;
     break;
   case 4:
-    if(!write<Byte>(vaddr & ~7 | 3, data >> 56)) return;
-    if(!write<Word>(vaddr & ~7 | 4, data >> 24)) return;
+    if(!write<Byte>(vaddr & ~7 | 4, data >> 56)) return;
+    if(!write<Word>(vaddr & ~7 | 0, data >> 24)) return;
     break;
   case 5:
-    if(!write<Half>(vaddr & ~7 | 2, data >> 48)) return;
-    if(!write<Word>(vaddr & ~7 | 4, data >> 16)) return;
+    if(!write<Half>(vaddr & ~7 | 4, data >> 48)) return;
+    if(!write<Word>(vaddr & ~7 | 0, data >> 16)) return;
     break;
   case 6:
-    if(!write<Byte>(vaddr & ~7 | 1, data >> 56)) return;
-    if(!write<Half>(vaddr & ~7 | 2, data >> 40)) return;
-    if(!write<Word>(vaddr & ~7 | 4, data >>  8)) return;
+    if(!write<Byte>(vaddr & ~7 | 6, data >> 56)) return;
+    if(!write<Half>(vaddr & ~7 | 4, data >> 40)) return;
+    if(!write<Word>(vaddr & ~7 | 0, data >>  8)) return;
     break;
   case 7:
     if(!write<Dual>(vaddr & ~7 | 0, data >>  0)) return;
     break;
   }
-
+  
   if(context.bigEndian())
   switch(vaddr & 7) {
   case 0:
@@ -936,30 +777,30 @@ auto CPU::SDR(cr64& rt, cr64& rs, s16 imm) -> void {
     if(!write<Dual>(vaddr & ~7 | 0, data >>  0)) return;
     break;
   case 1:
-    if(!write<Word>(vaddr & ~7 | 0, data >> 24)) return;
-    if(!write<Half>(vaddr & ~7 | 4, data >>  8)) return;
-    if(!write<Byte>(vaddr & ~7 | 6, data >>  0)) return;
+    if(!write<Word>(vaddr & ~7 | 4, data >> 24)) return;
+    if(!write<Half>(vaddr & ~7 | 2, data >>  8)) return;
+    if(!write<Byte>(vaddr & ~7 | 1, data >>  0)) return;
     break;
   case 2:
-    if(!write<Word>(vaddr & ~7 | 0, data >> 16)) return;
-    if(!write<Half>(vaddr & ~7 | 4, data >>  0)) return;
+    if(!write<Word>(vaddr & ~7 | 4, data >> 16)) return;
+    if(!write<Half>(vaddr & ~7 | 2, data >>  0)) return;
     break;
   case 3:
-    if(!write<Word>(vaddr & ~7 | 0, data >>  8)) return;
-    if(!write<Byte>(vaddr & ~7 | 4, data >>  0)) return;
+    if(!write<Word>(vaddr & ~7 | 4, data >>  8)) return;
+    if(!write<Byte>(vaddr & ~7 | 3, data >>  0)) return;
     break;
   case 4:
-    if(!write<Word>(vaddr & ~7 | 0, data >>  0)) return;
+    if(!write<Word>(vaddr & ~7 | 4, data >>  0)) return;
     break;
   case 5:
-    if(!write<Half>(vaddr & ~7 | 0, data >>  8)) return;
-    if(!write<Byte>(vaddr & ~7 | 2, data >>  0)) return;
+    if(!write<Half>(vaddr & ~7 | 6, data >>  8)) return;
+    if(!write<Byte>(vaddr & ~7 | 5, data >>  0)) return;
     break;
   case 6:
-    if(!write<Half>(vaddr & ~7 | 0, data >>  0)) return;
+    if(!write<Half>(vaddr & ~7 | 6, data >>  0)) return;
     break;
   case 7:
-    if(!write<Byte>(vaddr & ~7 | 0, data >>  0)) return;
+    if(!write<Byte>(vaddr & ~7 | 7, data >>  0)) return;
     break;
   }
 
@@ -1058,24 +899,23 @@ auto CPU::SWL(cr64& rt, cr64& rs, s16 imm) -> void {
   u64 vaddr = rs.u64 + imm;
   u32 data = rt.u32;
 
-  if(context.littleEndian())
-  switch(vaddr & 3) {
-  case 0:
-    if(!write<Byte>(vaddr & ~3 | 3, data >> 24)) return;
-    break;
-  case 1:
-    if(!write<Half>(vaddr & ~3 | 2, data >> 16)) return;
-    break;
-  case 2:
-    if(!write<Byte>(vaddr & ~3 | 1, data >> 24)) return;
-    if(!write<Half>(vaddr & ~3 | 2, data >>  8)) return;
-    break;
-  case 3:
-    if(!write<Word>(vaddr & ~3 | 0, data >>  0)) return;
-    break;
-  }
-
-  if(context.bigEndian())
+  if(context.littleEndian()) {
+    switch(vaddr & 3) {
+    case 0:
+      if(!write<Byte>(vaddr & ~3 | 0, data >> 24)) return;
+      break;
+    case 1:
+      if(!write<Half>(vaddr & ~3 | 0, data >> 16)) return;
+      break;
+    case 2:
+      if(!write<Byte>(vaddr & ~3 | 2, data >> 24)) return;
+      if(!write<Half>(vaddr & ~3 | 0, data >>  8)) return;
+      break;
+    case 3:
+      if(!write<Word>(vaddr & ~3 | 0, data >>  0)) return;
+      break;
+    }
+  } else {
   switch(vaddr & 3) {
   case 0:
     if(!write<Word>(vaddr + 0, data >>  0)) return;
@@ -1091,30 +931,30 @@ auto CPU::SWL(cr64& rt, cr64& rs, s16 imm) -> void {
     if(!write<Byte>(vaddr + 0, data >> 24)) return;
     break;
   }
+  }
 }
 
 auto CPU::SWR(cr64& rt, cr64& rs, s16 imm) -> void {
   u64 vaddr = rs.u64 + imm;
   u32 data = rt.u32;
 
-  if(context.littleEndian())
-  switch(vaddr & 3) {
-  case 0:
-    if(!write<Word>(vaddr & ~3 | 0, data >>  0)) return;
-    break;
-  case 1:
-    if(!write<Half>(vaddr & ~3 | 0, data >>  8)) return;
-    if(!write<Byte>(vaddr & ~3 | 2, data >>  0)) return;
-    break;
-  case 2:
-    if(!write<Half>(vaddr & ~3 | 0, data >>  0)) return;
-    break;
-  case 3:
-    if(!write<Byte>(vaddr & ~3 | 0, data >>  0)) return;
-    break;
-  }
-
-  if(context.bigEndian())
+  if(context.littleEndian()) {
+    switch(vaddr & 3) {
+    case 0:
+      if(!write<Word>(vaddr & ~3 | 0, data >>  0)) return;
+      break;
+    case 1:
+      if(!write<Half>(vaddr & ~3 | 2, data >>  8)) return;
+      if(!write<Byte>(vaddr & ~3 | 1, data >>  0)) return;
+      break;
+    case 2:
+      if(!write<Half>(vaddr & ~3 | 2, data >>  0)) return;
+      break;
+    case 3:
+      if(!write<Byte>(vaddr & ~3 | 3, data >>  0)) return;
+      break;
+    }
+  } else {
   switch(vaddr & 3) {
   case 0:
     if(!write<Byte>(vaddr + 0, data >>  0, false)) return;
@@ -1129,6 +969,7 @@ auto CPU::SWR(cr64& rt, cr64& rs, s16 imm) -> void {
   case 3:
     if(!write<Word>(vaddr + 0, data >>  0, false)) return;
     break;
+  }
   }
 }
 

--- a/ares/n64/cpu/recompiler-ipu.cpp
+++ b/ares/n64/cpu/recompiler-ipu.cpp
@@ -70,10 +70,11 @@ auto CPU::Recompiler::jitMemoryOpcode(u32 instruction, u32 size, u32 mode,
   bool partialRight = mode & PartialRight;
   bool floating  = mode & Floating;
   bool linkedConditional = mode & LinkedConditional;
+  bool reverseEndian = emitStateKey.reverseEndian();
   bool loadLinked = linkedConditional && !store;
   bool storeConditional = linkedConditional && store;
   u32 reverseEndianXor = 0;
-  if(emitStateKey.reverseEndian()) {
+  if(reverseEndian) {
     if(size == Byte) reverseEndianXor = 7;
     if(size == Half) reverseEndianXor = 6;
     if(size == Word) reverseEndianXor = 4;
@@ -219,6 +220,7 @@ auto CPU::Recompiler::jitMemoryOpcode(u32 instruction, u32 size, u32 mode,
       mov32(mem(reg(3), DcacheLineWordsOff + 4), reg(0));
     } else if(partialLeft && size == Word) {
       and32(reg(1), reg(0), imm(3));
+      if(reverseEndian) xor32(reg(1), reg(1), imm(3));
       shl32(reg(1), reg(1), imm(3));
       and32(reg(0), reg(0), imm(0x0c));
       add64(reg(0), reg(2), reg(0));
@@ -231,7 +233,7 @@ auto CPU::Recompiler::jitMemoryOpcode(u32 instruction, u32 size, u32 mode,
       mov32(mem(reg(0), DcacheLineWordsOff), reg(1));
     } else if(partialRight && size == Word) {
       and32(reg(4), reg(0), imm(3));
-      xor32(reg(4), reg(4), imm(3));
+      if(!reverseEndian) xor32(reg(4), reg(4), imm(3));
       shl32(reg(4), reg(4), imm(3));
       and32(reg(3), reg(0), imm(0x0c));
       add64(reg(3), reg(2), reg(3));
@@ -245,6 +247,7 @@ auto CPU::Recompiler::jitMemoryOpcode(u32 instruction, u32 size, u32 mode,
       mov32(mem(reg(3), DcacheLineWordsOff), reg(1));
     } else if(partialLeft && size == Dual) {
       and32(reg(1), reg(0), imm(7));
+      if(reverseEndian) xor32(reg(1), reg(1), imm(7));
       shl32(reg(1), reg(1), imm(3));
       and32(reg(0), reg(0), imm(0x08));
       add64(reg(3), reg(2), reg(0));
@@ -262,7 +265,7 @@ auto CPU::Recompiler::jitMemoryOpcode(u32 instruction, u32 size, u32 mode,
       mov32(mem(reg(3), DcacheLineWordsOff + 4), reg(0));
     } else if(partialRight && size == Dual) {
       and32(reg(1), reg(0), imm(7));
-      xor32(reg(1), reg(1), imm(7));
+      if(!reverseEndian) xor32(reg(1), reg(1), imm(7));
       shl32(reg(1), reg(1), imm(3));
       and32(reg(0), reg(0), imm(0x08));
       add64(reg(3), reg(2), reg(0));
@@ -310,12 +313,14 @@ auto CPU::Recompiler::jitMemoryOpcode(u32 instruction, u32 size, u32 mode,
       }
       if(partialLeft && size == Word) {
         and32(reg(3), reg(4), imm(3));
+        if(reverseEndian) xor32(reg(3), reg(3), imm(3));
         mov32(reg(1), imm(0x0f));
         lshr32(reg(1), reg(1), reg(3));
         and32(reg(3), reg(4), imm(0x0c));
         shl32(reg(1), reg(1), reg(3));
       } else if(partialRight && size == Word) {
         and32(reg(3), reg(4), imm(3));
+        if(reverseEndian) xor32(reg(3), reg(3), imm(3));
         add32(reg(3), reg(3), imm(1));
         mov32(reg(1), imm(1));
         shl32(reg(1), reg(1), reg(3));
@@ -371,6 +376,7 @@ auto CPU::Recompiler::jitMemoryOpcode(u32 instruction, u32 size, u32 mode,
       add64(reg(3), reg(2), reg(3));
       mov32(reg(3), mem(reg(3), DcacheLineWordsOff));
       and32(reg(1), reg(0), imm(3));
+      if(reverseEndian) xor32(reg(1), reg(1), imm(3));
       shl32(reg(1), reg(1), imm(3));
       shl32(reg(3), reg(3), reg(1));
       mov32(reg(0), imm(1));
@@ -381,6 +387,7 @@ auto CPU::Recompiler::jitMemoryOpcode(u32 instruction, u32 size, u32 mode,
       mov64_s32(reg(3), reg(3));
     } else if(partialLeft && size == Dual) {
       and32(reg(1), reg(0), imm(7));
+      if(reverseEndian) xor32(reg(1), reg(1), imm(7));
       shl32(reg(1), reg(1), imm(3));
       and32(reg(3), reg(0), imm(0x08));
       add64(reg(3), reg(2), reg(3));
@@ -397,7 +404,7 @@ auto CPU::Recompiler::jitMemoryOpcode(u32 instruction, u32 size, u32 mode,
       add64(reg(3), reg(2), reg(3));
       mov32(reg(3), mem(reg(3), DcacheLineWordsOff));
       and32(reg(1), reg(0), imm(3));
-      xor32(reg(1), reg(1), imm(3));
+      if(!reverseEndian) xor32(reg(1), reg(1), imm(3));
       shl32(reg(1), reg(1), imm(3));
       lshr32(reg(3), reg(3), reg(1));
       mov32(reg(2), imm((sljit_sw)0xffff'ffffu));
@@ -413,7 +420,7 @@ auto CPU::Recompiler::jitMemoryOpcode(u32 instruction, u32 size, u32 mode,
       cmov64(reg(3), reg(2), reg(3), flag_z);
     } else if(partialRight && size == Dual) {
       and32(reg(1), reg(0), imm(7));
-      xor32(reg(1), reg(1), imm(7));
+      if(!reverseEndian) xor32(reg(1), reg(1), imm(7));
       shl32(reg(1), reg(1), imm(3));
       and32(reg(3), reg(0), imm(0x08));
       add64(reg(3), reg(2), reg(3));


### PR DESCRIPTION
Uncovered by new tests in n64-systemtest. The JIT wasn't tested because little-endian is only supported in user-mode for now (RE=1), where memory accesses must go through TLBs so they currently are not JIT'd. Anyway the fix should be correct if we eventually uncover full little-endian mode (with BE=0).