### PR TITLE
gba: implement OAM stage timings for sprite rendering

### DIFF
--- a/ares/gba/cpu/bus.cpp
+++ b/ares/gba/cpu/bus.cpp
@@ -38,11 +38,7 @@ inline auto CPU::getBus(u32 mode, n32 address) -> n32 {
 
   case 0x05: word = readPRAM<UseDebugger>(mode, address); break;
   case 0x06: word = readVRAM<UseDebugger>(mode, address); break;
-
-  case 0x07:
-    if constexpr(!UseDebugger) prefetchStep(1);
-    word = ppu.readOAM(mode, address);
-    break;
+  case 0x07: word = readOAM<UseDebugger>(mode, address); break;
 
   case 0x08: case 0x09: case 0x0a: case 0x0b: case 0x0c: case 0x0d:
     if constexpr(UseDebugger) return readROM<true>(mode, address);
@@ -136,12 +132,7 @@ auto CPU::setBus(u32 mode, n32 address, n32 word) -> void {
 
   case 0x05: writePRAM(mode, address, word); break;
   case 0x06: writeVRAM(mode, address, word); break;
-
-  case 0x07:
-    prefetchStep(1);
-    synchronize(ppu);
-    ppu.writeOAM(mode, address, word);
-    break;
+  case 0x07: writeOAM(mode, address, word); break;
 
   case 0x08: case 0x09: case 0x0a: case 0x0b: case 0x0c: case 0x0d:
     context.burstActive = checkBurst<IsDMA>(mode);

--- a/ares/gba/cpu/cpu.hpp
+++ b/ares/gba/cpu/cpu.hpp
@@ -87,6 +87,9 @@ struct CPU : ARM7TDMI, Thread, IO {
   template<bool UseDebugger> auto readVRAM(u32 mode, n32 address) -> n32;
   auto writeVRAM(u32 mode, n32 address, n32 word) -> void;
 
+  template<bool UseDebugger> auto readOAM(u32 mode, n32 address) -> n32;
+  auto writeOAM(u32 mode, n32 address, n32 word) -> void;
+
   template<bool UseDebugger> auto readROM(u32 mode, n32 address) -> n32;
   auto writeROM(u32 mode, n32 address, n32 word) -> void;
 

--- a/ares/gba/cpu/memory.cpp
+++ b/ares/gba/cpu/memory.cpp
@@ -140,6 +140,29 @@ auto CPU::writeVRAM(u32 mode, n32 address, n32 word) -> void {
   ppu.writeVRAM(mode, address, word);
 }
 
+template <bool UseDebugger>
+auto CPU::readOAM(u32 mode, n32 address) -> n32 {
+  //stall until PPU is no longer accessing OAM (minimum 1 cycle)
+  if constexpr(!UseDebugger) {
+    do {
+      prefetchStep(1);
+      synchronize(ppu);
+    } while(ppu.oamContention());
+  }
+
+  return ppu.readOAM(mode, address);
+}
+
+auto CPU::writeOAM(u32 mode, n32 address, n32 word) -> void {
+  //stall until PPU is no longer accessing OAM (minimum 1 cycle)
+  do {
+    prefetchStep(1);
+    synchronize(ppu);
+  } while(ppu.oamContention());
+
+  ppu.writeOAM(mode, address, word);
+}
+
 template<bool UseDebugger>
 auto CPU::readROM(u32 mode, n32 address) -> n32 {
   if(mode & Word) {

--- a/ares/gba/ppu/memory.cpp
+++ b/ares/gba/ppu/memory.cpp
@@ -1,6 +1,10 @@
-auto PPU::releaseBus() -> void {
+auto PPU::bgReleaseBus() -> void {
   pramAccessed = false;
   vramAccessedBG = false;
+}
+
+auto PPU::objReleaseBus() -> void {
+  oamAccessed = false;
 }
 
 auto PPU::pramContention() -> bool {
@@ -17,10 +21,15 @@ auto PPU::pramContention() -> bool {
 }
 
 auto PPU::vramContention(n32 address) -> bool {
+  //todo: implement OBJ VRAM contention
   address &= 0x1ffff;
   if(Background::IO::mode < 3 && address >= 0x10000) return false;
   else if(address >= 0x14000) return false;
   return vramAccessedBG;
+}
+
+auto PPU::oamContention() -> bool {
+  return oamAccessed;
 }
 
 auto PPU::readVRAM_BG(u32 mode, n32 address) -> n16 {

--- a/ares/gba/ppu/object.cpp
+++ b/ares/gba/ppu/object.cpp
@@ -43,7 +43,8 @@ auto PPU::Objects::readA01(u32 y) -> void {
   latch.height = heights[shape * 4 + size];
 
   latch.py = y - ypos;
-  if((latch.affine == 0 && latch.affineSize == 1) || (latch.py >= latch.height << latch.affineSize)) {
+  n9 pxMax = latch.x + (latch.width << latch.affineSize);
+  if((latch.affine == 0 && latch.affineSize == 1) || (latch.py >= latch.height << latch.affineSize) || (latch.x >= 240 && pxMax >= 240)) {
     //object is hidden - skip rendering
     goToNext();
   } else {

--- a/ares/gba/ppu/object.cpp
+++ b/ares/gba/ppu/object.cpp
@@ -3,22 +3,171 @@ auto PPU::Objects::setEnable(n1 status) -> void {
   for(auto& flag : io.enable) flag &= status;
 }
 
-auto PPU::Objects::scanline(u32 y) -> void {
-  if(y >= 160) return;
+auto PPU::Objects::goToNext() -> void {
+  if(!(++objIndex)) active = false;
+  state = State::ReadA01;
+}
 
+auto PPU::Objects::readA01(u32 y) -> void {
   static const u32 widths[] = {
      8, 16, 32, 64,
     16, 32, 32, 64,
      8,  8, 16, 32,
-     8,  8,  8,  8,  //invalid modes
+     8,  8,  8,  8,  //invalid shapes
   };
 
   static const u32 heights[] = {
      8, 16, 32, 64,
      8,  8, 16, 32,
     16, 32, 32, 64,
-     8,  8,  8,  8,  //invalid modes
+     8,  8,  8,  8,  //invalid shapes
   };
+
+  n16 attr0 = ppu.oam[objIndex << 2 | 0];
+  n8 ypos          = attr0 >>  0;
+  latch.affine     = attr0 >>  8;
+  latch.affineSize = attr0 >>  9;
+  latch.mode       = attr0 >> 10;
+  latch.mosaic     = attr0 >> 12;
+  latch.colors     = attr0 >> 13;  //0 = 16, 1 = 256
+  n2 shape         = attr0 >> 14;  //0 = square, 1 = horizontal, 2 = vertical
+
+  n16 attr1 = ppu.oam[objIndex << 2 | 1];
+  latch.x           = attr1 >>  0;
+  latch.affineParam = attr1 >>  9;
+  latch.hflip       = attr1 >> 12;
+  latch.vflip       = attr1 >> 13;
+  n2 size           = attr1 >> 14;
+
+  latch.width  = widths [shape * 4 + size];
+  latch.height = heights[shape * 4 + size];
+
+  latch.py = y - ypos;
+  if((latch.affine == 0 && latch.affineSize == 1) || (latch.py >= latch.height << latch.affineSize)) {
+    //object is hidden - skip rendering
+    goToNext();
+  } else {
+    if(latch.mosaic) {
+      latch.py = ypos >= 160 || mosaicY - ypos >= 0 ? u32(mosaicY - ypos) : 0;
+    }
+    state = State::ReadA2;
+  }
+}
+
+auto PPU::Objects::readA2() -> void {
+  n16 attr2 = ppu.oam[objIndex << 2 | 2];
+  latch.character = attr2 >>  0;
+  latch.priority  = attr2 >> 10;
+  latch.palette   = attr2 >> 12;
+
+  if(!latch.affine) {
+    drawObject(renderY);
+  } else {
+    state = State::ReadPA;
+  }
+}
+
+auto PPU::Objects::drawObject(u32 y) -> void {
+  auto& buffer = lineBuffers[y & 1];
+
+  //center-of-sprite coordinates
+  i16 centerX = latch.width  >> 1;
+  i16 centerY = latch.height >> 1;
+
+  //origin coordinates (top-left of sprite)
+  i28 originX = -(centerX << latch.affineSize);
+  i28 originY = -(centerY << latch.affineSize) + latch.py;
+
+  //fractional pixel coordinates
+  i28 fx = originX * latch.pa + originY * latch.pb;
+  i28 fy = originX * latch.pc + originY * latch.pd;
+
+  for(u32 px : range(latch.width << latch.affineSize)) {
+    //calculate address within tile
+    u32 sx, sy;
+    if(!latch.affine) {
+      sx =       px ^ (latch.hflip ? latch.width  - 1 : 0);
+      sy = latch.py ^ (latch.vflip ? latch.height - 1 : 0);
+    } else {
+      sx = (fx >> 8) + centerX;
+      sy = (fy >> 8) + centerY;
+    }
+    n6 subTileAddr = ((sy & 7) * 8 + (sx & 7)) >> !latch.colors;
+
+    //calculate address of tile
+    n10 tileAddr;
+    if(io.mapping) {
+      u32 offset = (sy >> 3) * (latch.width >> 3) + (sx >> 3);
+      tileAddr = latch.character + (offset << latch.colors);
+    } else {
+      n5 row = (latch.character >> 5) + (sy >> 3);
+      n5 rowEntry = latch.character + ((sx >> 3) << latch.colors);
+      tileAddr = (row << 5) + rowEntry;
+    }
+
+    //output pixel
+    n8 color = ppu.readObjectVRAM((tileAddr << 5) + subTileAddr);
+    if(latch.colors == 0) color = sx & 1 ? color >> 4 : color & 15;
+    n9 bx = latch.x + px;
+    if(bx < 240 && sx < latch.width && sy < latch.height) {
+      if(latch.mode & 2) {
+        if(color) {
+          buffer[bx].window = true;
+        }
+      } else if(!buffer[bx].enable || latch.priority < buffer[bx].priority) {
+        buffer[bx].priority = latch.priority;  //updated regardless of transparency
+        buffer[bx].mosaic = latch.mosaic;  //updated regardless of transparency
+        if(color) {
+          if(latch.colors == 0) color = latch.palette * 16 + color;
+          buffer[bx].enable = true;
+          buffer[bx].color = 256 + color;
+          buffer[bx].translucent = latch.mode == 1;
+        }
+      }
+    }
+
+    fx += latch.pa;
+    fy += latch.pc;
+  }
+
+  goToNext();
+}
+
+auto PPU::Objects::step() -> void {
+  if(!active) return;
+
+  if(activeCycle) {
+    switch(state) {
+    case State::ReadA01:
+      readA01(renderY);
+      break;
+    case State::ReadA2:
+      readA2();
+      break;
+    case State::ReadPA:
+      latch.pa = ppu.oam[latch.affineParam << 4 | 0x3];
+      state = State::ReadPB;
+      break;
+    case State::ReadPB:
+      latch.pb = ppu.oam[latch.affineParam << 4 | 0x7];
+      state = State::ReadPC;
+      break;
+    case State::ReadPC:
+      latch.pc = ppu.oam[latch.affineParam << 4 | 0xb];
+      state = State::ReadPD;
+      break;
+    case State::ReadPD:
+      latch.pd = ppu.oam[latch.affineParam << 4 | 0xf];
+      drawObject(renderY);
+      break;
+    }
+    ppu.oamAccessed = true;
+  }
+  activeCycle = !activeCycle;
+}
+
+auto PPU::Objects::scanline(u32 y) -> void {
+  if(y >= 160) return;
 
   hmosaicOffset = io.mosaicWidth;
   if(y == 0 || vmosaicOffset == io.mosaicHeight) {
@@ -32,103 +181,18 @@ auto PPU::Objects::scanline(u32 y) -> void {
   for(auto& pixel : buffer) pixel = {};
   if(ppu.io.forceBlank[1] || cpu.stopped() || !io.enable[1]) return;  //checks if display conditions will be met next scanline
 
-  for(auto oamIndex : range(128)) {
-    n16 attr0 = ppu.oam[oamIndex << 2 | 0];
-    n8 ypos       = attr0 >>  0;
-    n1 affine     = attr0 >>  8;
-    n1 affineSize = attr0 >>  9;
-    n2 mode       = attr0 >> 10;
-    n1 mosaic     = attr0 >> 12;
-    n1 colors     = attr0 >> 13;  //0 = 16, 1 = 256
-    n2 shape      = attr0 >> 14;  //0 = square, 1 = horizontal, 2 = vertical
+  renderY = y;
+  objIndex = 0;
+  active = true;
+  activeCycle = true;
+  state = State::ReadA01;
+}
 
-    n16 attr1 = ppu.oam[oamIndex << 2 | 1];
-    n9 xpos        = attr1 >>  0;
-    n5 affineParam = attr1 >>  9;
-    n1 hflip       = attr1 >> 12;
-    n1 vflip       = attr1 >> 13;
-    n2 size        = attr1 >> 14;
-
-    n8 py = y - ypos;
-    n32 width  = widths [shape * 4 + size];
-    n32 height = heights[shape * 4 + size];
-    if(affine == 0 && affineSize == 1) continue;  //hidden
-    if(py >= height << affineSize) continue;  //offscreen
-
-    if(mosaic) {
-      py = ypos >= 160 || mosaicY - ypos >= 0 ? u32(mosaicY - ypos) : 0;
-    }
-
-    n16 attr2 = ppu.oam[oamIndex << 2 | 2];
-    n10 character = attr2 >>  0;
-    n2  priority  = attr2 >> 10;
-    n4  palette   = attr2 >> 12;
-
-    i16 pa = ppu.oam[affineParam << 4 | 0x3];
-    i16 pb = ppu.oam[affineParam << 4 | 0x7];
-    i16 pc = ppu.oam[affineParam << 4 | 0xb];
-    i16 pd = ppu.oam[affineParam << 4 | 0xf];
-
-    //center-of-sprite coordinates
-    i16 centerX = width  >> 1;
-    i16 centerY = height >> 1;
-
-    //origin coordinates (top-left of sprite)
-    i28 originX = -(centerX << affineSize);
-    i28 originY = -(centerY << affineSize) + py;
-
-    //fractional pixel coordinates
-    i28 fx = originX * pa + originY * pb;
-    i28 fy = originX * pc + originY * pd;
-
-    for(u32 px : range(width << affineSize)) {
-      //calculate address within tile
-      u32 sx, sy;
-      if(!affine) {
-        sx = px ^ (hflip ? width  - 1 : 0);
-        sy = py ^ (vflip ? height - 1 : 0);
-      } else {
-        sx = (fx >> 8) + centerX;
-        sy = (fy >> 8) + centerY;
-      }
-      n6 subTileAddr = ((sy & 7) * 8 + (sx & 7)) >> !colors;
-
-      //calculate address of tile
-      n10 tileAddr;
-      if(io.mapping) {
-        u32 offset = (sy >> 3) * (width >> 3) + (sx >> 3);
-        tileAddr = character + (offset << colors);
-      } else {
-        n5 row = (character >> 5) + (sy >> 3);
-        n5 rowEntry = character + ((sx >> 3) << colors);
-        tileAddr = (row << 5) + rowEntry;
-      }
-
-      //output pixel
-      n8 color = ppu.readObjectVRAM((tileAddr << 5) + subTileAddr);
-      if(colors == 0) color = sx & 1 ? color >> 4 : color & 15;
-      n9 bx = xpos + px;
-      if(bx < 240 && sx < width && sy < height) {
-        if(mode & 2) {
-          if(color) {
-            buffer[bx].window = true;
-          }
-        } else if(!buffer[bx].enable || priority < buffer[bx].priority) {
-          buffer[bx].priority = priority;  //updated regardless of transparency
-          buffer[bx].mosaic = mosaic;  //updated regardless of transparency
-          if(color) {
-            if(colors == 0) color = palette * 16 + color;
-            buffer[bx].enable = true;
-            buffer[bx].color = 256 + color;
-            buffer[bx].translucent = mode == 1;
-          }
-        }
-      }
-
-      fx += pa;
-      fy += pc;
-    }
-  }
+auto PPU::Objects::renderScanline(u32 y) -> void {
+  scanline(y);
+  for(auto _ : range(1232)) step();
+  active = false;
+  ppu.objReleaseBus();
 }
 
 auto PPU::Objects::outputPixel(u32 x, u32 y) -> void {
@@ -155,12 +219,18 @@ auto PPU::Objects::outputPixel(u32 x, u32 y) -> void {
 
 auto PPU::Objects::power() -> void {
   io = {};
+  latch = {};
   for(auto& buffer : lineBuffers) {
     for(auto& pixel : buffer) pixel = {};
   }
   output = {};
   mosaicLatch = {};
+  renderY = 0;
   mosaicY = 0;
   hmosaicOffset = 0;
   vmosaicOffset = 0;
+  objIndex = 0;
+  active = false;
+  activeCycle = false;
+  state = State::ReadA01;
 }

--- a/ares/gba/ppu/ppu.cpp
+++ b/ares/gba/ppu/ppu.cpp
@@ -73,8 +73,12 @@ inline auto PPU::blank() -> bool {
 }
 
 auto PPU::step(u32 clocks) -> void {
-  Thread::step(clocks);
-  Thread::synchronize(cpu, display);
+  for(auto _ : range(clocks)) {
+    objects.step();
+    Thread::step(1);
+    Thread::synchronize(cpu, display);
+    objReleaseBus();
+  }
 }
 
 template<s32 Cycle>
@@ -134,7 +138,7 @@ auto PPU::cycle(u32 y) -> void {
   if constexpr(Cycle >= 46 && Cycle <= 1005 && (Cycle - 46) % 4 == 0) cycleUpperLayer((Cycle - 46) / 4, y);
   if constexpr(Cycle >= 46 && Cycle <= 1005 && (Cycle - 46) % 4 == 2) dac.lowerLayer((Cycle - 46) / 4, y);
   step(1);
-  releaseBus();
+  bgReleaseBus();
 }
 
 auto PPU::main() -> void {
@@ -159,7 +163,6 @@ auto PPU::main() -> void {
   bg1.scanline(y);
   bg2.scanline(y);
   bg3.scanline(y);
-  objects.scanline((y + 1) % 228);
   window0.scanline(y);
   window1.scanline(y);
   dac.scanline(y);
@@ -184,9 +187,12 @@ auto PPU::main() -> void {
 
       //cycle 31 - start rendering backgrounds unconditionally
       cycles01( 31);
-      cycles02( 32);
-      cycles04( 34);
-      cycles08( 38);
+      cycles08( 32);
+
+      //cycle 40 - start rendering sprites
+      objects.scanline((y + 1) % 228);
+      cycles02( 40);
+      cycles04( 42);
 
       //cycle 46 - start pixel output
       cycles64( 46);
@@ -219,6 +225,7 @@ auto PPU::main() -> void {
       #undef cycles64
     } else {
       step(renderingCycle);
+      objects.renderScanline((y + 1) % 228);
       for(s32 x : range(247)) {
         bg0.run(x - 7, y);
         bg1.run(x - 7, y);
@@ -230,11 +237,19 @@ auto PPU::main() -> void {
         cycleUpperLayer(x, y);
         dac.lowerLayer(x, y);
       }
-      releaseBus();
+      bgReleaseBus();
       step(1035 - renderingCycle);
     }
   } else {
-    step(1035);
+    if(accurate) {
+      step(37);
+      objects.scanline((y + 1) % 228);
+      step(998);
+    } else {
+      step(renderingCycle);
+      objects.renderScanline((y + 1) % 228);
+      step(1035 - renderingCycle);
+    }
   }
 
   step(193);

--- a/ares/gba/ppu/ppu.hpp
+++ b/ares/gba/ppu/ppu.hpp
@@ -57,9 +57,11 @@ struct PPU : Thread, IO {
   auto writeIO(n32 address, n8 byte) -> void;
 
   //memory.cpp
-  auto releaseBus() -> void;
+  auto bgReleaseBus() -> void;
+  auto objReleaseBus() -> void;
   auto pramContention() -> bool;
   auto vramContention(n32 address) -> bool;
+  auto oamContention() -> bool;
 
   auto readVRAM(u32 mode, n32 address) -> n16;
   auto readVRAM_BG(u32 mode, n32 address) -> n16;
@@ -193,7 +195,13 @@ private:
   struct Objects {
     //object.cpp
     auto setEnable(n1 status) -> void;
+    auto goToNext() -> void;
+    auto readA01(u32 y) -> void;
+    auto readA2() -> void;
+    auto drawObject(u32 y) -> void;
+    auto step() -> void;
     auto scanline(u32 y) -> void;
+    auto renderScanline(u32 y) -> void;
     auto outputPixel(u32 x, u32 y) -> void;
     auto power() -> void;
 
@@ -209,12 +217,46 @@ private:
       n4 mosaicHeight;
     } io;
 
+    struct Latch {
+      n1 affine;
+      n1 affineSize;
+      n2 mode;
+      n1 mosaic;
+      n1 colors;
+
+      n9 x;
+      n5 affineParam;
+      n1 hflip;
+      n1 vflip;
+
+      n10 character;
+      n2  priority;
+      n4  palette;
+
+      n32 width;
+      n32 height;
+      n8  py;
+
+      i16 pa;
+      i16 pb;
+      i16 pc;
+      i16 pd;
+    } latch;
+
     Pixel lineBuffers[2][240];
     Pixel output;
     Pixel mosaicLatch;
+    u32 renderY;
     s32 mosaicY;
-    n4 hmosaicOffset;
-    n4 vmosaicOffset;
+    n4  hmosaicOffset;
+    n4  vmosaicOffset;
+    n7  objIndex;
+    bool active;
+    bool activeCycle;
+
+    enum class State : u32 {
+      ReadA01, ReadA2, ReadPA, ReadPB, ReadPC, ReadPD
+    } state;
   } objects;
 
   struct Window {
@@ -278,6 +320,7 @@ private:
 
   bool pramAccessed;
   bool vramAccessedBG;
+  bool oamAccessed;
   n32  renderingCycle;
 };
 

--- a/ares/gba/ppu/serialization.cpp
+++ b/ares/gba/ppu/serialization.cpp
@@ -26,6 +26,7 @@ auto PPU::serialize(serializer& s) -> void {
 
   s(pramAccessed);
   s(vramAccessedBG);
+  s(oamAccessed);
 }
 
 auto PPU::Background::serialize(serializer& s) -> void {
@@ -64,9 +65,15 @@ auto PPU::Objects::serialize(serializer& s) -> void {
   s(io.mosaicWidth);
   s(io.mosaicHeight);
 
+  s(renderY);
   s(mosaicY);
   s(hmosaicOffset);
   s(vmosaicOffset);
+  s(objIndex);
+  s(active);
+  s(activeCycle);
+
+  s(state);
 }
 
 auto PPU::Window::serialize(serializer& s) -> void {

--- a/ares/gba/system/serialization.cpp
+++ b/ares/gba/system/serialization.cpp
@@ -1,4 +1,4 @@
-static const string SerializerVersion = "v148.6";
+static const string SerializerVersion = "v148.7";
 
 auto System::serialize(bool synchronize) -> serializer {
   if(synchronize) scheduler.enter(Scheduler::Mode::Synchronize);


### PR DESCRIPTION
Implements timings for the OAM stage of the OBJ render pipeline as described in [fleroviux's sprite rendering documentation](https://github.com/nba-emu/hw-docs/blob/main/src/ppu/sprite.md). The CPU cycle penalty for OAM access conflicts is also implemented. VRAM stage timings are not yet implemented, so while sprite rendering is no longer instant, it is still faster than on real hardware.