### PR TITLE
Fix aspect correction menu radio items in GTK

### DIFF
--- a/desktop-ui/presentation/presentation.cpp
+++ b/desktop-ui/presentation/presentation.cpp
@@ -217,33 +217,37 @@ Presentation::Presentation() {
 
   videoOutputMenu.append(videoOutputSeparator);
 
-  if(settings.video.output == "Integer"     ) videoOutputIntegerScale.setChecked();
-  if(settings.video.output == "Scale"       ) videoOutputScale.setChecked();
-  if(settings.video.output == "Stretch"     ) videoOutputStretch.setChecked();
+  if(settings.video.output == "Integer") videoOutputIntegerScale.setChecked();
+  if(settings.video.output == "Scale") videoOutputScale.setChecked();
+  if(settings.video.output == "Stretch") videoOutputStretch.setChecked();
 
   videoAspectCorrectionNone.setText("Aspect: No correction").onActivate([&] {
     settings.video.aspectCorrection = "None";
     if(settings.video.adaptiveSizing) resizeWindow();
   });
+  videoOutputMenu.append(videoAspectCorrectionNone);
+  videoAspectCorrectionGroup.append(videoAspectCorrectionNone);
 
   videoAspectCorrectionStandard.setText("Aspect: Standard").onActivate([&] {
     settings.video.aspectCorrection = "Standard";
     if(settings.video.adaptiveSizing) resizeWindow();
   });
+  videoOutputMenu.append(videoAspectCorrectionStandard);
+  videoAspectCorrectionGroup.append(videoAspectCorrectionStandard);
 
   videoAspectCorrectionAnamorphic.setText("Aspect: Anamorphic (16:9)").onActivate([&] {
     settings.video.aspectCorrection = "Anamorphic";
     if(settings.video.adaptiveSizing) resizeWindow();
   });
-
-  if(settings.video.aspectCorrection == "None")       videoAspectCorrectionNone.setChecked();
-  if(settings.video.aspectCorrection == "Standard")   videoAspectCorrectionStandard.setChecked();
-  if(settings.video.aspectCorrection == "Anamorphic") videoAspectCorrectionAnamorphic.setChecked();
-  videoOutputMenu.append(videoAspectCorrectionNone);
-  videoOutputMenu.append(videoAspectCorrectionStandard);
   videoOutputMenu.append(videoAspectCorrectionAnamorphic);
+  videoAspectCorrectionGroup.append(videoAspectCorrectionAnamorphic);
+
   videoOutputMenu.append(videoOutputSeparator2);
 
+  if(settings.video.aspectCorrection == "None") videoAspectCorrectionNone.setChecked();
+  if(settings.video.aspectCorrection == "Standard") videoAspectCorrectionStandard.setChecked();
+  if(settings.video.aspectCorrection == "Anamorphic") videoAspectCorrectionAnamorphic.setChecked();
+  
   videoAdaptiveSizing.setText("Window: Auto resize to content aspect").setChecked(settings.video.adaptiveSizing).onToggle([&] {
     settings.video.adaptiveSizing = videoAdaptiveSizing.checked();
     if(settings.video.adaptiveSizing) resizeWindow();

--- a/desktop-ui/presentation/presentation.hpp
+++ b/desktop-ui/presentation/presentation.hpp
@@ -31,8 +31,7 @@ struct Presentation : Window {
         MenuRadioItem videoAspectCorrectionNone;
         MenuRadioItem videoAspectCorrectionStandard;
         MenuRadioItem videoAspectCorrectionAnamorphic;
-        Group videoAspectCorrectionGroup{&videoAspectCorrectionNone, &videoAspectCorrectionStandard,
-                                         &videoAspectCorrectionAnamorphic};
+        Group videoAspectCorrectionGroup;
         MenuSeparator videoOutputSeparator2;
         MenuCheckItem videoAdaptiveSizing;
         MenuCheckItem videoAutoCentering;


### PR DESCRIPTION
I have no idea why GTK behaves differently then other UI frameworks here and I didn't bother to look into it. I just re-arranged some calls and set them up like the scale menu radio item options which already worked, and that fixed the aspect correction menu radio items. I was able to test that GTK & Qt6 on Linux work, and Windows still works.