### PR TITLE
Restore old symlink behaviour on Linux

### DIFF
--- a/desktop-ui/emulator/emulator.cpp
+++ b/desktop-ui/emulator/emulator.cpp
@@ -165,7 +165,12 @@ auto Emulator::load(std::shared_ptr<mia::Pak> pak, string& path) -> string {
     filters.trimRight(":", 1L);
     filters.prepend(pak->name(), "|");
     dialog.setFilters({filters, "All|*"});
+#if defined (PLATFORM_LINUX) || defined (PLATFORM_BSD)
+    //leave resolving symlinks to the OS on linux
+    location = program.openFile(dialog);
+#else
     location = directory::resolveSymLink(program.openFile(dialog));
+#endif
   }
 
   if(location) {


### PR DESCRIPTION
Closes #2557 

As expressed in the issue, this needs feedback from other Linux users. Did pre-v148 ares not handle symlinks on your distro? Did the changes in v148 fix any issues? I don't want to cause any regressions so I'm opening this as a draft pending feedback.