### PR TITLE
n64: DIV/DIVU in user mode never raise a RI exception

### DIFF
--- a/ares/n64/cpu/interpreter-ipu.cpp
+++ b/ares/n64/cpu/interpreter-ipu.cpp
@@ -307,7 +307,6 @@ auto CPU::DDIVU(cr64& rs, cr64& rt) -> void {
 }
 
 auto CPU::DIV(cr64& rs, cr64& rt) -> void {
-  if(!context.kernelMode() && context.bits == 32) return exception.reservedInstruction();
   if(rt.s64) {
     //using s64 to match hardware behavior when input operands are not properly sign-extended
     //note: this does not give correct results when sgn(rt.s32) != sgn(rt.s64); on hardware this
@@ -322,7 +321,6 @@ auto CPU::DIV(cr64& rs, cr64& rt) -> void {
 }
 
 auto CPU::DIVU(cr64& rs, cr64& rt) -> void {
-  if(!context.kernelMode() && context.bits == 32) return exception.reservedInstruction();
   if(rt.u32) {
     LO.u64 = s32(rs.u32 / rt.u32);
     HI.u64 = s32(rs.u32 % rt.u32);

--- a/ares/n64/cpu/recompiler-ipu.cpp
+++ b/ares/n64/cpu/recompiler-ipu.cpp
@@ -1352,8 +1352,7 @@ auto CPU::Recompiler::emitSPECIAL(u32 instruction) -> EmitExecuteResult {
 
   //DIV Rs,Rt
   case 0x1a: {
-    bool reservedInstruction = reservedInstruction64();
-    if(emitSlowPathSection || reservedInstruction) {
+    if(emitSlowPathSection) {
       setupCallf();
       callf(&CPU::DIV, mem(Rs), mem(Rt));
       return EmitExecuteResult::MayFault;
@@ -1373,8 +1372,7 @@ auto CPU::Recompiler::emitSPECIAL(u32 instruction) -> EmitExecuteResult {
 
   //DIVU Rs,Rt
   case 0x1b: {
-    bool reservedInstruction = reservedInstruction64();
-    if(emitSlowPathSection || reservedInstruction) {
+    if(emitSlowPathSection) {
       setupCallf();
       callf(&CPU::DIVU, mem(Rs), mem(Rt));
       return EmitExecuteResult::MayFault;


### PR DESCRIPTION
Verified via new n64-systemtest test.