### PR TITLE
n64: reduce 1 frame of input latency, fix flickering with CPU drawing

### DIFF
--- a/ares/n64/vi/vi.cpp
+++ b/ares/n64/vi/vi.cpp
@@ -83,6 +83,9 @@ auto VI::main() -> void {
         io.vcounter = 0;
         io.field += !io.halfLinesPerField.bit(0);
         if(++io.leapCounter == 5) io.leapCounter = 0;
+      }
+
+      if(io.vcounter == io.vstart >> 1) {
         #if defined(VULKAN)
         if (vulkan.enable) {
           gpuOutputValid = vulkan.scanoutAsync(io.field);


### PR DESCRIPTION
We were telling Vulkan to display a frame as per the VI configuration at vblank (line 0). This is wrong since all games will actually use vblank to configure VI for the new frame. Vulkan would thus draw the *previous* frame, rather than the new one that was just created, causing one full frame of latency. The correct point where to kick Vulkan is at vstart, when the active display begins.

With CPU-based rendering in a double-buffering scenario (rather than triple buffering), this means that the wrong framebuffer would always be shown: the one that was just going to be drawn upon. Thus, we would basically get a race between the emulated CPU writing to RDRAM and the host Vulkan reading RDRAM.

The bug was hidden when using RDP rendering because RDP emulation also goes through Vulkan, so it would basically be queued *after* the VI drawing rather than *during* it.

Fixes #1653 