### PR TITLE
CI: Cleanup build dependencies on Linux/FreeBSD

### DIFF
--- a/.github/workflows/build-aux.yml
+++ b/.github/workflows/build-aux.yml
@@ -89,7 +89,7 @@ jobs:
       if: runner.os == 'Linux' && matrix.platform.name != 'freebsd'
       run: |
         sudo apt-get update -y -qq
-        sudo apt-get install cmake ccache ninja-build libsdl2-dev libgtk-3-dev libao-dev libopenal-dev qt6-base-dev
+        sudo apt-get install cmake ccache ninja-build libsdl2-dev libgtk-3-dev qt6-base-dev
     - name: Build SDL3
       if: runner.os == 'Linux' && matrix.platform.name != 'freebsd'
       run: .github/scripts/build_sdl.sh
@@ -116,7 +116,7 @@ jobs:
         version: '15.0'
         environment_variables: TARGET_PRESET
         run: |
-          sudo pkg install -y cmake pkgconf ccache ninja gtk3 libX11 libXext libXrandr libXrender libglvnd alsa-lib libao libudev-devd librashader openal-soft pulseaudio sdl3 vulkan-loader
+          sudo pkg install -y cmake pkgconf ccache ninja gtk3 sdl3 librashader
           .github/scripts/build_ubuntu.sh
     - name: "Compress Build Artifacts (Windows)"
       if: runner.os != 'macOS' && runner.os != 'Linux'


### PR DESCRIPTION
Remove the build dependencies of the removed audio and input drivers, now that SDL3 is the only supported driver.

Additional cleanup on FreeBSD:

- libX* and libglvnd are dependencies of sdl3 itself and can reasonable be expected to continue to be so. This allows to remove them from the list of explicit bulid dependencies.

- vulkan-loader provides libvulkan.so which is a dlopen'ed runtime dependency of parallel-rdp used in the N64 core. It is not a build dependency and can be removed (though it gets installed anyway as a dependency of sdl3).