### PR TITLE
Expose rewind controls in the UI

### DIFF
--- a/desktop-ui/input/hotkeys.cpp
+++ b/desktop-ui/input/hotkeys.cpp
@@ -3,6 +3,7 @@ auto InputManager::createHotkeys() -> void {
   static bool fastForwardAudioBlocking;
   static bool fastForwardAudioDynamic;
   static bool toggleFastForwardState = false;
+  static double volume = 0.0;
 
   hotkeys.push_back(InputHotkey("Toggle Fullscreen").onPress([&] {
     program.videoFullScreenToggle();
@@ -77,15 +78,24 @@ auto InputManager::createHotkeys() -> void {
   hotkeys.push_back(InputHotkey("Rewind").onPress([&] {
     Program::Guard guard;
     if(!emulator || program.fastForwarding) return;
-    if(program.rewind.frequency == 0) {
+    if(settings.general.rewind == false) {
       return program.showMessage("Please enable rewind support in the emulator settings first.");
     }
     program.rewinding = true;
     program.rewindSetMode(Program::Rewind::Mode::Rewinding);
+    volume = settings.audio.volume;
+    if(settings.rewind.mute) {
+      settings.audio.volume = 0.0;
+    } else if (!settings.audio.mute) {
+      settings.audio.volume = volume * 0.5;
+    }
   }).onRelease([&] {
     if(!emulator) return;
     program.rewinding = false;
     program.rewindSetMode(Program::Rewind::Mode::Playing);
+    if(!settings.audio.mute) {
+      settings.audio.volume = volume;
+    }
   }));
 
   hotkeys.push_back(InputHotkey("Frame Advance").onPress([&] {

--- a/desktop-ui/settings/cores.cpp
+++ b/desktop-ui/settings/cores.cpp
@@ -46,7 +46,7 @@ auto CoreSettings::construct() -> void {
       }
     }
   });
-  nintendo64ControllerPakBankLayout.setAlignment(1).setPadding(12_sx, 0);
+  nintendo64ControllerPakBankLayout.setAlignment(0.5).setPadding(12_sx, 0);
     nintendo64ControllerPakBankLabel.setText("Controller Pak Size:");
     nintendo64ControllerPakBankHint.setText("Sets the size of a newly created Controller Pak's available memory").setFont(Font().setSize(7.0)).setForegroundColor(SystemColor::Sublabel);
 

--- a/desktop-ui/settings/developer.cpp
+++ b/desktop-ui/settings/developer.cpp
@@ -3,8 +3,8 @@ auto DeveloperSettings::construct() -> void {
   setVisible(false);
 
   gdbLabel.setText("Debug Server Options").setFont(Font().setBold());
-  portLayout.setAlignment(1);
-    portLabel.setText("Port");
+  portLayout.setAlignment(0.5).setPadding(12_sx, 0);
+    portLabel.setText("Port:");
 
     port.setText(integer(settings.developer.debugServerPort));
     port.setEditable(true);
@@ -21,6 +21,7 @@ auto DeveloperSettings::construct() -> void {
 
     portHint.setText("Safe range: 1024 - 32767").setFont(Font().setSize(7.0)).setForegroundColor(SystemColor::Sublabel);
 
+    ipv4Layout.setAlignment(0.5).setPadding(12_sx, 0);
     ipv4.setEnabled(true);
     ipv4.setText("Use IPv4");
     ipv4.setChecked(settings.developer.debugServerUseIPv4);
@@ -30,6 +31,7 @@ auto DeveloperSettings::construct() -> void {
       infoRefresh();
     });
 
+    enabledLayout.setAlignment(0.5).setPadding(12_sx, 0);
     enabled.setEnabled(true);
     enabled.setText("Enabled");
     enabled.setChecked(settings.developer.debugServerEnabled);
@@ -46,7 +48,7 @@ auto DeveloperSettings::construct() -> void {
   homebrewMode.setText("Homebrew Development Mode").setChecked(settings.developer.homebrewMode).onToggle([&] {
     settings.developer.homebrewMode = homebrewMode.checked();
   });
-  homebrewModeLayout.setAlignment(1).setPadding(12_sx, 0);
+  homebrewModeLayout.setAlignment(0.5).setPadding(12_sx, 0);
     homebrewModeHint.setText("Activate system-specific features to help homebrew developers").setFont(Font().setSize(7.0)).setForegroundColor(SystemColor::Sublabel);
 
   forceInterpreter.setText("Force Interpreter").setChecked(settings.developer.forceInterpreter).onToggle([&] {

--- a/desktop-ui/settings/options.cpp
+++ b/desktop-ui/settings/options.cpp
@@ -61,24 +61,24 @@ auto OptionSettings::construct() -> void {
     program.rewindReset();
   }).doToggle();
   rewindLayout.setAlignment(1).setPadding(12_sx, 0);
-    rewindHint.setText("Allows you to reverse time via the rewind hotkey").setFont(Font().setSize(7.0)).setForegroundColor(SystemColor::Sublabel);
+    rewindHint.setText("Allows you to reverse time via the rewind hotkey (may impact performance)").setFont(Font().setSize(7.0)).setForegroundColor(SystemColor::Sublabel);
 
   rewindSettingsLayout.setAlignment(0.5).setPadding(12_sx, 0);
   rewindFrequencyLabel.setText("Frequency:");
-  rewindFrequencyOption.append(ComboButtonItem().setText("Every 10 frames"));
   rewindFrequencyOption.append(ComboButtonItem().setText("Every 20 frames"));
-  rewindFrequencyOption.append(ComboButtonItem().setText("Every 30 frames"));
   rewindFrequencyOption.append(ComboButtonItem().setText("Every 40 frames"));
-  rewindFrequencyOption.append(ComboButtonItem().setText("Every 50 frames"));
   rewindFrequencyOption.append(ComboButtonItem().setText("Every 60 frames"));
-  if(settings.rewind.frequency == 10) rewindFrequencyOption.item(0).setSelected();
-  if(settings.rewind.frequency == 20) rewindFrequencyOption.item(1).setSelected();
-  if(settings.rewind.frequency == 30) rewindFrequencyOption.item(2).setSelected();
-  if(settings.rewind.frequency == 40) rewindFrequencyOption.item(3).setSelected();
-  if(settings.rewind.frequency == 50) rewindFrequencyOption.item(4).setSelected();
-  if(settings.rewind.frequency == 60) rewindFrequencyOption.item(5).setSelected();
+  rewindFrequencyOption.append(ComboButtonItem().setText("Every 80 frames"));
+  rewindFrequencyOption.append(ComboButtonItem().setText("Every 100 frames"));
+  rewindFrequencyOption.append(ComboButtonItem().setText("Every 120 frames"));
+  if(settings.rewind.frequency == 20) rewindFrequencyOption.item(0).setSelected();
+  if(settings.rewind.frequency == 40) rewindFrequencyOption.item(1).setSelected();
+  if(settings.rewind.frequency == 60) rewindFrequencyOption.item(2).setSelected();
+  if(settings.rewind.frequency == 80) rewindFrequencyOption.item(3).setSelected();
+  if(settings.rewind.frequency == 100) rewindFrequencyOption.item(4).setSelected();
+  if(settings.rewind.frequency == 120) rewindFrequencyOption.item(5).setSelected();
   rewindFrequencyOption.onChange([&] {
-    settings.rewind.frequency = rewindFrequencyOption.selected().offset() * 10 + 10;
+    settings.rewind.frequency = rewindFrequencyOption.selected().offset() * 10 + 20;
     program.rewindReset();
   });
 

--- a/desktop-ui/settings/options.cpp
+++ b/desktop-ui/settings/options.cpp
@@ -27,17 +27,10 @@ auto OptionSettings::construct() -> void {
     ruby::video.setFlush(settings.video.flush);
   });
 
-  synchronizationLayout.setAlignment(1).setPadding(12_sx, 0);
+  synchronizationLayout.setAlignment(0.5).setPadding(12_sx, 0);
   synchronizationHint.setText("Synchronize to audio (Recommended) or to your monitor's refresh rate").setFont(Font().setSize(7.0)).setForegroundColor(SystemColor::Sublabel);
 
   commonSettingsLabel.setText("Emulator Options").setFont(Font().setBold());
-
-  rewind.setText("Rewind").setChecked(settings.general.rewind).onToggle([&] {
-    settings.general.rewind = rewind.checked();
-    program.rewindReset();
-  }).doToggle();
-  rewindLayout.setAlignment(1).setPadding(12_sx, 0);
-    rewindHint.setText("Allows you to reverse time via the rewind hotkey").setFont(Font().setSize(7.0)).setForegroundColor(SystemColor::Sublabel);
 
   runAhead.setText("Run-Ahead").setEnabled(co_serializable()).setChecked(settings.general.runAhead && co_serializable()).onToggle([&] {
     settings.general.runAhead = runAhead.checked() && co_serializable();
@@ -58,4 +51,56 @@ auto OptionSettings::construct() -> void {
   });
   noFilePromptLayout.setAlignment(1).setPadding(12_sx, 0);
     noFilePromptHint.setText("Suppress secondary media file load prompts").setFont(Font().setSize(7.0)).setForegroundColor(SystemColor::Sublabel);
+
+  rewindSettingsLabel.setText("Rewind Settings").setFont(Font().setBold());
+  rewind.setText("Enable Rewind").setChecked(settings.general.rewind).onToggle([&] {
+    settings.general.rewind = rewind.checked();
+    rewindFrequencyOption.setEnabled(settings.general.rewind);
+    rewindLengthOption.setEnabled(settings.general.rewind);
+    rewindMute.setEnabled(settings.general.rewind);
+    program.rewindReset();
+  }).doToggle();
+  rewindLayout.setAlignment(1).setPadding(12_sx, 0);
+    rewindHint.setText("Allows you to reverse time via the rewind hotkey").setFont(Font().setSize(7.0)).setForegroundColor(SystemColor::Sublabel);
+
+  rewindSettingsLayout.setAlignment(0.5).setPadding(12_sx, 0);
+  rewindFrequencyLabel.setText("Frequency:");
+  rewindFrequencyOption.append(ComboButtonItem().setText("Every 10 frames"));
+  rewindFrequencyOption.append(ComboButtonItem().setText("Every 20 frames"));
+  rewindFrequencyOption.append(ComboButtonItem().setText("Every 30 frames"));
+  rewindFrequencyOption.append(ComboButtonItem().setText("Every 40 frames"));
+  rewindFrequencyOption.append(ComboButtonItem().setText("Every 50 frames"));
+  rewindFrequencyOption.append(ComboButtonItem().setText("Every 60 frames"));
+  if(settings.rewind.frequency == 10) rewindFrequencyOption.item(0).setSelected();
+  if(settings.rewind.frequency == 20) rewindFrequencyOption.item(1).setSelected();
+  if(settings.rewind.frequency == 30) rewindFrequencyOption.item(2).setSelected();
+  if(settings.rewind.frequency == 40) rewindFrequencyOption.item(3).setSelected();
+  if(settings.rewind.frequency == 50) rewindFrequencyOption.item(4).setSelected();
+  if(settings.rewind.frequency == 60) rewindFrequencyOption.item(5).setSelected();
+  rewindFrequencyOption.onChange([&] {
+    settings.rewind.frequency = rewindFrequencyOption.selected().offset() * 10 + 10;
+    program.rewindReset();
+  });
+
+  rewindLengthLabel.setText("Length:");
+  rewindLengthOption.append(ComboButtonItem().setText( "10 states"));
+  rewindLengthOption.append(ComboButtonItem().setText( "20 states"));
+  rewindLengthOption.append(ComboButtonItem().setText( "40 states"));
+  rewindLengthOption.append(ComboButtonItem().setText( "80 states"));
+  rewindLengthOption.append(ComboButtonItem().setText("160 states"));
+  rewindLengthOption.append(ComboButtonItem().setText("320 states"));
+  if(settings.rewind.length ==  10) rewindLengthOption.item(0).setSelected();
+  if(settings.rewind.length ==  20) rewindLengthOption.item(1).setSelected();
+  if(settings.rewind.length ==  40) rewindLengthOption.item(2).setSelected();
+  if(settings.rewind.length ==  80) rewindLengthOption.item(3).setSelected();
+  if(settings.rewind.length == 160) rewindLengthOption.item(4).setSelected();
+  if(settings.rewind.length == 320) rewindLengthOption.item(5).setSelected();
+  rewindLengthOption.onChange([&] {
+    settings.rewind.length = 10 << rewindLengthOption.selected().offset();
+    program.rewindReset();
+  });
+
+  rewindMute.setText("Mute while rewinding").setChecked(settings.rewind.mute).onToggle([&] {
+    settings.rewind.mute = rewindMute.checked();
+  });
 }

--- a/desktop-ui/settings/options.cpp
+++ b/desktop-ui/settings/options.cpp
@@ -78,7 +78,7 @@ auto OptionSettings::construct() -> void {
   if(settings.rewind.frequency == 100) rewindFrequencyOption.item(4).setSelected();
   if(settings.rewind.frequency == 120) rewindFrequencyOption.item(5).setSelected();
   rewindFrequencyOption.onChange([&] {
-    settings.rewind.frequency = rewindFrequencyOption.selected().offset() * 10 + 20;
+    settings.rewind.frequency = rewindFrequencyOption.selected().offset() * 20 + 20;
     program.rewindReset();
   });
 

--- a/desktop-ui/settings/settings.cpp
+++ b/desktop-ui/settings/settings.cpp
@@ -104,6 +104,7 @@ auto Settings::process(bool load) -> void {
 
   bind(natural, "Rewind/Length", rewind.length);
   bind(natural, "Rewind/Frequency", rewind.frequency);
+  bind(boolean, "Rewind/Mute", rewind.mute);
 
   bind(string,  "Paths/Home", paths.home);
   bind(string,  "Paths/Firmware", paths.firmware);

--- a/desktop-ui/settings/settings.hpp
+++ b/desktop-ui/settings/settings.hpp
@@ -78,7 +78,7 @@ struct Settings : Markup::Node {
 
   struct Rewind {
     u32 length = 80;
-    u32 frequency = 10;
+    u32 frequency = 60;
     bool mute = false;
   } rewind;
 

--- a/desktop-ui/settings/settings.hpp
+++ b/desktop-ui/settings/settings.hpp
@@ -77,8 +77,9 @@ struct Settings : Markup::Node {
   } general;
 
   struct Rewind {
-    u32 length = 100;
+    u32 length = 80;
     u32 frequency = 10;
+    bool mute = false;
   } rewind;
 
   struct Paths {
@@ -287,9 +288,6 @@ struct OptionSettings : VerticalLayout {
       ComboButton synchronizationList{&synchronizationLayout, Size{0, 0}};
       Label synchronizationHint{&synchronizationLayout, Size{~0, layoutVertSize}};
   Label commonSettingsLabel{this, Size{~0, 0}, 5};
-    HorizontalLayout rewindLayout{this, Size{~0, 0}, 5};
-      CheckLabel rewind{&rewindLayout, Size{0, 0}, 5};
-      Label rewindHint{&rewindLayout, Size{~0, layoutVertSize}};
     HorizontalLayout runAheadLayout{this, Size{~0, 0}, 5};
       CheckLabel runAhead{&runAheadLayout, Size{0, 0}, 5};
       Label runAheadHint{&runAheadLayout, Size{~0, layoutVertSize}};
@@ -299,6 +297,16 @@ struct OptionSettings : VerticalLayout {
     HorizontalLayout noFilePromptLayout{this, Size{~0, 0}, 5};
       CheckLabel noFilePromptOption{&noFilePromptLayout, Size{0, 0}, 5};
       Label noFilePromptHint{&noFilePromptLayout, Size{0, layoutVertSize}};
+  Label rewindSettingsLabel{this, Size{~0, 0}, 5};
+    HorizontalLayout rewindLayout{this, Size{~0, 0}, 5};
+      CheckLabel rewind{&rewindLayout, Size{0, 0}, 5};
+      Label rewindHint{&rewindLayout, Size{~0, layoutVertSize}};
+    HorizontalLayout rewindSettingsLayout{this, Size{~0, 0}, 5};
+      Label rewindFrequencyLabel{&rewindSettingsLayout, Size{0, 0}};
+      ComboButton rewindFrequencyOption{&rewindSettingsLayout, Size{0, 0}};
+      Label rewindLengthLabel{&rewindSettingsLayout, Size{0, 0}};
+      ComboButton rewindLengthOption{&rewindSettingsLayout, Size{0, 0}};
+      CheckLabel rewindMute{&rewindSettingsLayout, Size{0, 0}};
 };
 
 struct FirmwareSettings : VerticalLayout {
@@ -410,15 +418,15 @@ struct DeveloperSettings : VerticalLayout {
 
   Label gdbLabel{this, Size{~0, 0}, 5};
 
-  HorizontalLayout portLayout{this, Size{~0, 0}};
-    Label portLabel{&portLayout, Size{48, 20}};
+  HorizontalLayout portLayout{this, Size{~0, 0}, 5};
+    Label portLabel{&portLayout, Size{0, 0}};
     LineEdit port{&portLayout, Size{~0, 0}};
     Label portHint{&portLayout, Size{~0, layoutVertSize}};
 
-  HorizontalLayout ipv4Layout{this, Size{~0, 0}};
+  HorizontalLayout ipv4Layout{this, Size{~0, 0}, 5};
     CheckLabel ipv4{&ipv4Layout, Size{~0, 0}};
 
-  HorizontalLayout enabledLayout{this, Size{~0, 0}};
+  HorizontalLayout enabledLayout{this, Size{~0, 0}, 5};
     CheckLabel enabled{&enabledLayout, Size{~0, 0}};
 
   Label connectInfo{this, Size{~0, 30}, 5};


### PR DESCRIPTION
Most of the plumbing for configuring rewind was in the emulator already (you could manually manipulate the settings.bml file). This exposes these controls in emulator options. 
