### PR TITLE
Fix error: undeclared identifier 'renderSettingsLabel'

### DIFF
--- a/desktop-ui/settings/cores.cpp
+++ b/desktop-ui/settings/cores.cpp
@@ -105,7 +105,6 @@ auto CoreSettings::construct() -> void {
 
   #if !defined(VULKAN)
   //hide Vulkan-specific options if Vulkan is not available
-  renderSettingsLabel.setCollapsible(true).setVisible(false);
   renderQualityLayout.setCollapsible(true).setVisible(false);
   renderSupersamplingLayout.setCollapsible(true).setVisible(false);
   disableVideoInterfaceProcessingLayout.setCollapsible(true).setVisible(false);


### PR DESCRIPTION
The `renderSettingsLabel` identifier isn't declared anymore after the recent structural changes, but it's still referenced conditionally in `desktop-ui/settings/cores.cpp` and breaks the build if the N64 core is disabled:
```
/tmp/ares/desktop-ui/settings/cores.cpp:108:3: error: use of undeclared identifier 'renderSettingsLabel'
  108 |   renderSettingsLabel.setCollapsible(true).setVisible(false);
      |   ^
```
Remove it to fix the build.