### PR TITLE
ruby: improve SDL3 audio performance

### DIFF
--- a/ruby/audio/audio.cpp
+++ b/ruby/audio/audio.cpp
@@ -9,7 +9,7 @@ auto Audio::create() -> bool {
   return initialize();
 }
 
-auto Audio::hasDevices() -> std::vector<string> { 
+auto Audio::hasDevices() -> std::vector<string> {
   _devices.clear();
   _devices.push_back("Default");
   int count = 0;
@@ -18,7 +18,7 @@ auto Audio::hasDevices() -> std::vector<string> {
     _devices.push_back(SDL_GetAudioDeviceName(deviceIds[i]));
   }
   SDL_free(deviceIds);
-  return _devices; 
+  return _devices;
 }
 
 auto Audio::hasDevice(string device) -> bool {
@@ -106,7 +106,7 @@ auto Audio::output(const f64 samples[]) -> void {
     auto bytesRemaining = SDL_GetAudioStreamQueued(static_cast<SDL_AudioStream*>(_stream));
     while(bytesRemaining > _bufferSize) {
       // wait for audio to drain
-      auto bytesToWait = (bytesRemaining - _bufferSize) * 4;
+      auto bytesToWait = bytesRemaining - _bufferSize;
       auto framesRemaining = bytesToWait / _bytesPerFrame;
       auto secondsRemaining = framesRemaining / (f64)_frequency;
       usleep(max(1.0, secondsRemaining * 1000000.0));
@@ -139,11 +139,11 @@ auto Audio::initialize() -> bool {
     spec.channels = 2;
     spec.freq = _frequency;
 
-    auto desired_samples = (_latency * _frequency) / 1000;
+    auto desired_samples = _frequency / 100; // 10ms device buffer
     string desired_samples_string = (string)desired_samples;
     SDL_SetHint(SDL_HINT_AUDIO_DEVICE_SAMPLE_FRAMES, desired_samples_string);
 
-    
+
     if(_device == "Default") {
       _deviceId = SDL_AUDIO_DEVICE_DEFAULT_PLAYBACK;
     } else {
@@ -166,7 +166,7 @@ auto Audio::initialize() -> bool {
     _channels = spec.channels;
 
     _bytesPerFrame = SDL_AUDIO_FRAMESIZE(spec);
-    _bufferSize = desired_samples * _bytesPerFrame;
+    _bufferSize = desired_samples * _bytesPerFrame * (_latency / 10); // (10ms * X) queue buffer
 
     _ready = true;
     clear();

--- a/ruby/audio/audio.hpp
+++ b/ruby/audio/audio.hpp
@@ -7,12 +7,12 @@ struct Audio {
   auto ready() -> bool { return _ready; }
 
   auto hasContext() -> bool { return false; }
-  auto hasDevices() -> std::vector<string>; 
+  auto hasDevices() -> std::vector<string>;
   auto hasBlocking() -> bool { return true; }
   auto hasDynamic() -> bool { return true; }
   auto hasChannels() -> std::vector<u32> { return { _channels }; }
   auto hasFrequencies() -> std::vector<u32> { return {22050, 44100, 48000, 96000}; }
-  auto hasLatencies() -> std::vector<u32> { return {10, 20, 40, 60, 80}; }
+  auto hasLatencies() -> std::vector<u32> { return {10, 20, 30, 40, 60, 80}; }
 
   auto hasDevice(string device) -> bool;
   auto hasChannels(u32 channels) -> bool;
@@ -56,7 +56,7 @@ private:
   u32 _channels = 2;
   u32 _frequency = 48000;
   u32 _latency = 40;
-  
+
   void* _stream = nullptr;
   uintptr _context = 0;
   string _device = "Default";


### PR DESCRIPTION
Some platforms experienced very poor performance with the SDL3 audio driver, especially in combination with a demanding core like the N64. It is assumed that SDL couldn't keep up filling the output device buffer with the audio data from the input queue buffer. Increasing the amount of generated input data before feeding it to the device buffer has shown to greatly improve the performance.

This sparked the following idea and change to how the SDL3 audio driver fills its buffers: request a fixed-sized 10ms device buffer and apply the latency to the input buffer, i.e. the input buffer holds a multiple of 10ms worth of audio. This allows SDL to steadily consume audio from the input buffer and feed it into the 10ms device buffer, while the user can still control the latency.

Additionally add the value 30 to the possible latency options. This allows users to specify a lower latency than 40 if 20 is just a tiny bit shy of being good enough.

This is tested on FreeBSD. The N64 core is now perfectly playable if I set the latency above 20. Other tested cores, SNES and Genesis, are already perfect at 20. 10 is just too low for my system, but other users could have more luck with it.

This needs definitly testing on other operating systems, and more opinions if this proposed change is actually a good idea.