### PR TITLE
n64: Add GUI for Parallel-RDP overscan crop settings

### DIFF
--- a/ares/n64/system/system.cpp
+++ b/ares/n64/system/system.cpp
@@ -31,6 +31,11 @@ auto option(string name, string value) -> bool {
   if(name == "Supersampling") vulkan.supersampleScanout = value.boolean();
   if(name == "Disable Video Interface Processing") vulkan.disableVideoInterfaceProcessing = value.boolean();
   if(name == "Weave Deinterlacing") vulkan.weaveDeinterlacing = value.boolean();
+  if (name == "Enable Overscan Crop") vulkan.enableOverscanCrop = value.boolean();
+  if (name == "Overscan Crop Top") vulkan.overscanCropTop = value.natural();
+  if (name == "Overscan Crop Bottom") vulkan.overscanCropBottom = value.natural();
+  if (name == "Overscan Crop Left") vulkan.overscanCropLeft = value.natural();
+  if (name == "Overscan Crop Right") vulkan.overscanCropRight = value.natural();
   if(vulkan.internalUpscale == 1) vulkan.supersampleScanout = false;
   vulkan.outputUpscale = vulkan.supersampleScanout ? 1 : vulkan.internalUpscale;
   #endif

--- a/ares/n64/vulkan/vulkan.cpp
+++ b/ares/n64/vulkan/vulkan.cpp
@@ -166,8 +166,22 @@ auto Vulkan::scanoutAsync(bool field) -> bool {
   ::RDP::ScanoutOptions options;
   options.downscale_steps = supersampleScanout ? 16 : 0;
   options.persist_frame_on_invalid_input = true;  //this is a compatibility hack, but I'm not sure what for ...
+  options.crop_rect = {
+      .left = overscanCropLeft,
+      .right = overscanCropRight,
+      .top = overscanCropTop,
+      .bottom = overscanCropBottom,
+      .enable = enableOverscanCrop
+  };
   if(disableVideoInterfaceProcessing) {
-    options.vi = {false, false, true, false, false, false};
+    options.vi = {
+        .aa = false,
+        .scale =false,
+        .serrate = true,
+        .dither_filter = false,
+        .divot_filter = false,
+        .gamma_dither = false
+    };
   }
   if(!supersampleScanout){
     options.blend_previous_frame = weaveDeinterlacing;

--- a/ares/n64/vulkan/vulkan.hpp
+++ b/ares/n64/vulkan/vulkan.hpp
@@ -24,6 +24,11 @@ struct Vulkan {
   u32  internalUpscale = 1;  //1, 2, 4, 8
   bool supersampleScanout = false;
   u32  outputUpscale = supersampleScanout ? 1 : internalUpscale;
+  bool enableOverscanCrop = false;
+  u32  overscanCropTop = 0;
+  u32  overscanCropBottom = 0;
+  u32  overscanCropLeft = 0;
+  u32  overscanCropRight = 0;
 };
 
 extern Vulkan vulkan;

--- a/desktop-ui/emulator/nintendo-64.cpp
+++ b/desktop-ui/emulator/nintendo-64.cpp
@@ -117,6 +117,11 @@ auto Nintendo64::load() -> LoadResult {
   ares::Nintendo64::option("Recompiler", !settings.developer.forceInterpreter);
   ares::Nintendo64::option("Expansion Pak", settings.nintendo64.expansionPak);
   ares::Nintendo64::option("Controller Pak Banks", settings.nintendo64.controllerPakBankString);
+  ares::Nintendo64::option("Enable Overscan Crop", settings.nintendo64.enableOverscanCrop);
+  ares::Nintendo64::option("Overscan Crop Top", settings.nintendo64.overscanCropTop);
+  ares::Nintendo64::option("Overscan Crop Bottom", settings.nintendo64.overscanCropBottom);
+  ares::Nintendo64::option("Overscan Crop Left", settings.nintendo64.overscanCropLeft);
+  ares::Nintendo64::option("Overscan Crop Right", settings.nintendo64.overscanCropRight);
 
   if(!ares::Nintendo64::load(root, {"[Nintendo] ", name, " (", region, ")"})) return otherError;
 

--- a/desktop-ui/settings/cores.cpp
+++ b/desktop-ui/settings/cores.cpp
@@ -4,6 +4,8 @@ auto CoreSettings::construct() -> void {
 
   settingsHint.setText("Note: Settings changes require a game reload to take effect").setFont(Font().setSize(7.0)).setForegroundColor(SystemColor::Sublabel);
 
+  // N64 Core Settings
+
   nintendo64SettingsLabel.setText("Nintendo 64 Settings").setFont(Font().setBold());
 
   nintendo64ExpansionPakOption.setText("4MB Expansion Pak").setChecked(settings.nintendo64.expansionPak).onToggle([&] {
@@ -103,13 +105,86 @@ auto CoreSettings::construct() -> void {
   renderSupersamplingLayout.setAlignment(1).setPadding(12_sx, 0);
   renderSupersamplingHint.setText("Scales 2x and 4x resolutions back down to native.").setFont(Font().setSize(7.0)).setForegroundColor(SystemColor::Sublabel);
 
+  parallelOverscanCropLayout.setAlignment(0.5).setPadding(12_sx, 0);
+  parallelOverscanCropOption.setText("Enable Overscan Crop")
+      .setChecked(settings.nintendo64.enableOverscanCrop)
+      .onToggle([&] {
+          Program::Guard guard;
+          settings.nintendo64.enableOverscanCrop = parallelOverscanCropOption.checked();
+          if (emulator) emulator->setBoolean("Enable Overscan Crop", settings.nintendo64.enableOverscanCrop);
+      });
+  parallelOverscanCropHint.setText("Crops the overscan area from the rendered image.")
+      .setFont(Font().setSize(7.0))
+      .setForegroundColor(SystemColor::Sublabel);
+
+  parallelOverscanCropSettingsLayout.setAlignment(0.5).setPadding(12_sx, 0);
+  parallelOverscanCropTopLabel.setText("Top:");
+  parallelOverscanCropTopValue.setText(integer(settings.nintendo64.overscanCropTop))
+      .setEditable(true)
+      .onChange([&] {
+          if (parallelOverscanCropTopValue.text() == "") return;
+
+          Program::Guard guard;
+          int newValue = parallelOverscanCropTopValue.text().integer();
+          int clamped = std::clamp(newValue, 0, 120);
+          settings.nintendo64.overscanCropTop = clamped;
+          if (newValue != clamped)
+          {
+              // FIXME: This creates an object that looks strange in the debugger and crashes if you try to compare it with ==. Thankfully, we can just not do that but it hints at a structural problem with the code that should be fixed in the future.
+              string valueStr = string(clamped);
+              parallelOverscanCropTopValue.setText(valueStr);
+          }
+      });
+  parallelOverscanCropBottomLabel.setText("Bottom:");
+  parallelOverscanCropBottomValue.setText(integer(settings.nintendo64.overscanCropBottom))
+      .setEditable(true)
+      .onChange([&] {
+          if (parallelOverscanCropBottomValue.text() == "") return;
+
+          Program::Guard guard;
+          int newValue = parallelOverscanCropBottomValue.text().integer();
+          int clamped = std::clamp(newValue, 0, 120);
+          settings.nintendo64.overscanCropBottom = clamped;
+          if (newValue != clamped) parallelOverscanCropBottomValue.setText(string(clamped));
+      });
+  parallelOverscanCropLeftLabel.setText("Left:");
+  parallelOverscanCropLeftValue.setText(integer(settings.nintendo64.overscanCropLeft))
+      .setEditable(true)
+      .onChange([&] {
+          if (parallelOverscanCropLeftValue.text() == "") return;
+
+          Program::Guard guard;
+          int newValue = parallelOverscanCropLeftValue.text().integer();
+          int clamped = std::clamp(newValue, 0, 160);
+          settings.nintendo64.overscanCropLeft = clamped;
+          if (newValue != clamped) parallelOverscanCropLeftValue.setText(string(clamped));
+      });
+  parallelOverscanCropRightLabel.setText("Right:");
+  parallelOverscanCropRightValue.setText(integer(settings.nintendo64.overscanCropRight))
+      .setEditable(true)
+      .onChange([&] {
+          if (parallelOverscanCropRightValue.text() == "") return;
+
+          Program::Guard guard;
+          int newValue = parallelOverscanCropRightValue.text().integer();
+          int clamped = std::clamp(newValue, 0, 160);
+          settings.nintendo64.overscanCropRight = clamped;
+          if (newValue != clamped) parallelOverscanCropRightValue.setText(string(clamped));
+      });
+  parallelOverscanCropSettingsHint.setText("Top / Bottom values are implicitly doubled if image is interlaced.")
+      .setFont(Font().setSize(7.0))
+      .setForegroundColor(SystemColor::Sublabel);
+
   #if !defined(VULKAN)
   //hide Vulkan-specific options if Vulkan is not available
   renderQualityLayout.setCollapsible(true).setVisible(false);
   renderSupersamplingLayout.setCollapsible(true).setVisible(false);
   disableVideoInterfaceProcessingLayout.setCollapsible(true).setVisible(false);
   weaveDeinterlacingLayout.setCollapsible(true).setVisible(false);
+  parallelOverscanCropLayout.setCollapsible(true).setVisible(false);
   #endif
+
+  // GameBoy Core Settings
 
   gameBoyAdvanceSettingsLabel.setText("Game Boy Advance Settings").setFont(Font().setBold());
   gameBoyPlayerOption.setText("Game Boy Player").setChecked(settings.gameBoyAdvance.player).onToggle([&] {

--- a/desktop-ui/settings/settings.cpp
+++ b/desktop-ui/settings/settings.cpp
@@ -128,6 +128,11 @@ auto Settings::process(bool load) -> void {
   bind(boolean, "Nintendo64/Supersampling", nintendo64.supersampling);
   bind(boolean, "Nintendo64/DisableVideoInterfaceProcessing", nintendo64.disableVideoInterfaceProcessing);
   bind(boolean, "Nintendo64/WeaveDeinterlacing", nintendo64.weaveDeinterlacing);
+  bind(boolean, "Nintendo64/EnableOverscanCrop", nintendo64.enableOverscanCrop);
+  bind(natural, "Nintendo64/OverscanCropTop", nintendo64.overscanCropTop);
+  bind(natural, "Nintendo64/OverscanCropBottom", nintendo64.overscanCropBottom);
+  bind(natural, "Nintendo64/OverscanCropLeft", nintendo64.overscanCropLeft);
+  bind(natural, "Nintendo64/OverscanCropRight", nintendo64.overscanCropRight);
 
   bind(boolean, "GameBoyAdvance/Player", gameBoyAdvance.player);
 

--- a/desktop-ui/settings/settings.hpp
+++ b/desktop-ui/settings/settings.hpp
@@ -116,6 +116,11 @@ struct Settings : Markup::Node {
     bool supersampling = false;
     bool disableVideoInterfaceProcessing = false;
     bool weaveDeinterlacing = true;
+    bool enableOverscanCrop = false;
+    u32 overscanCropTop = 0;
+    u32 overscanCropBottom = 0;
+    u32 overscanCropLeft = 0;
+    u32 overscanCropRight = 0;
   } nintendo64;
 
   struct GameBoyAdvance {
@@ -394,6 +399,20 @@ struct CoreSettings : VerticalLayout {
     HorizontalLayout renderSupersamplingLayout{this, Size{~0, 0}, 5};
       CheckLabel renderSupersamplingOption{&renderSupersamplingLayout, Size{0, 0}, 5};
       Label renderSupersamplingHint{&renderSupersamplingLayout, Size{0, layoutVertSize}};
+    VerticalLayout parallelOverscanCropLayout {this, Size{~0, 0}, 5};
+      HorizontalLayout parallelOverscanCropCheckboxLayout {&parallelOverscanCropLayout, Size{~0, 0}, 5};
+        CheckLabel parallelOverscanCropOption {&parallelOverscanCropCheckboxLayout, Size{0, 0}, 5};
+        Label parallelOverscanCropHint {&parallelOverscanCropCheckboxLayout, Size{0, layoutVertSize}};
+      HorizontalLayout parallelOverscanCropSettingsLayout {&parallelOverscanCropLayout, Size{~0, 0}, 5};
+        Label parallelOverscanCropTopLabel {&parallelOverscanCropSettingsLayout, Size{0, layoutVertSize}};
+        LineEdit parallelOverscanCropTopValue {&parallelOverscanCropSettingsLayout, Size{30, 0}};
+        Label parallelOverscanCropBottomLabel {&parallelOverscanCropSettingsLayout, Size{0, layoutVertSize}};
+        LineEdit parallelOverscanCropBottomValue {&parallelOverscanCropSettingsLayout, Size{30, 0}};
+        Label parallelOverscanCropLeftLabel {&parallelOverscanCropSettingsLayout, Size{0, layoutVertSize}};
+        LineEdit parallelOverscanCropLeftValue {&parallelOverscanCropSettingsLayout, Size{30, 0}};
+        Label parallelOverscanCropRightLabel {&parallelOverscanCropSettingsLayout, Size{0, layoutVertSize}};
+        LineEdit parallelOverscanCropRightValue {&parallelOverscanCropSettingsLayout, Size{30, 0}};
+        Label parallelOverscanCropSettingsHint {&parallelOverscanCropSettingsLayout, Size{0, layoutVertSize}};
 
   Label gameBoyAdvanceSettingsLabel{this, Size{~0, 0}, 5};
     HorizontalLayout gameBoyPlayerLayout{this, Size{~0, 0}, 5};


### PR DESCRIPTION
### Description

This PR adds graphical user interface controls for Nintendo 64 overscan cropping settings in the Parallel-RDP renderer with a toggle option and 4 separate text boxes for each side.

GUI:

<img width="702" height="482" alt="image" src="https://github.com/user-attachments/assets/72134404-ff1c-4b09-aee5-38efcdfb9dc5" />

Example before enabling:

<img width="1154" height="940" alt="image" src="https://github.com/user-attachments/assets/dbae5d6e-752f-4174-902e-d8663e4a19b9" />

After:

<img width="1154" height="940" alt="image" src="https://github.com/user-attachments/assets/3a1ab487-2d41-4a96-9d13-e3cda39e51c6" />

### Possible improvements

- The overscan value controls should be spin boxes but I believe this control is currently missing in hiro.
- It would be great if this setting could be adjusted while the game is loaded (like in @HailToDodongo 's fork) because adjusting overscan to one's liking is likely to take a lot of fiddling by users.
- Add option to preserve the aspect ratio of the image left after overscan as been cropped. Currently, the remaining image is always forced into 4:3 or 16:9 if `Aspect: Anamorphic`. I think `Aspect: No correction` should mean that if I have 320x240 output and I crop 20px top and 20px bottom and then fullscreen ares on a 16:10 monitor, the image will fill my screen completely.
