### PR TITLE
n64: Remove field swapping workaround for interlaced image

### DIFF
--- a/ares/n64/vi/vi.cpp
+++ b/ares/n64/vi/vi.cpp
@@ -143,12 +143,7 @@ auto VI::refresh() -> void {
     if(rgba) {
       screen->setViewport(0, 0, width, height);
       for(u32 y : range(height)) {
-        u32 y_fix = y; 
-        // When weave interlacing is active, we need to fix the order of interleaved lines for the image output
-        // but only when the VI is set to interlance and we don't use supersampling (causes severe bugs)
-        // Otherwise proceed as normal
-        if(io.serrate == 1 && vulkan.weaveDeinterlacing && !vulkan.supersampleScanout) y_fix = (y % 2 == 0)? y+1 : y-1; // Swap each even/odd line
-        auto source = rgba + width * y_fix * sizeof(u32);
+        auto source = rgba + width * y * sizeof(u32);
         auto target = screen->pixels(1).data() + y * vulkan.outputUpscale * 640;
         for(u32 x : range(width)) {
           target[x] = source[x * 4 + 0] << 16 | source[x * 4 + 1] << 8 | source[x * 4 + 2] << 0;


### PR DESCRIPTION
Before we were drawing the frame according to the VI registers at line 0. After a recent change (I believe https://github.com/ares-emulator/ares/commit/31526ded9196b046b0b5ce1769f14335eba9cc33 ), we now draw it according to VI registers when display area begins. This means that we take into account the vblank interrupt that normally changes the registers so the field swapping workaround is not needed anymore.