### PR TITLE
n64/pi: index cartridge ROM base-relative so >256MiB ROMs boot

### DIFF
--- a/ares/n64/pi/bus.hpp
+++ b/ares/n64/pi/bus.hpp
@@ -49,7 +49,9 @@ inline auto PI::busRead(u32 address) -> u32 {
     return cartridge.isviewer.read<Size>(address);
   }
   if(address <= 0x1000'0000 + cartridge.rom.size - 1) {
-    return cartridge.rom.read<Size>(address);
+    //index base-relative: for ROMs >256MiB the power-of-two Readable mask no longer
+    //strips the 0x1000'0000 cart base (bit::round jumps past it), so pass the offset.
+    return cartridge.rom.read<Size>(address - 0x1000'0000);
   }
   return unmapped;
 }
@@ -105,7 +107,9 @@ inline auto PI::busWrite(u32 address, u32 data) -> void {
     }
   }
   if(address <= 0x1000'0000 + cartridge.rom.size - 1) {
-    return cartridge.rom.write<Size>(address, data);
+    //index base-relative (see busRead): keeps >256MiB ROMs from wrapping into the wrong
+    //buffer offset when the power-of-two mask stops covering the 0x1000'0000 base.
+    return cartridge.rom.write<Size>(address - 0x1000'0000, data);
   }
   if(address <= 0x7fff'ffff) return;
 }


### PR DESCRIPTION
The PI bus dispatches cart reads/writes with the full 0x1000'0000-based address and relies on the Readable power-of-two mask to strip the base. That only holds while bit::round(rom.size) <= 0x1000'0000 (<=256MiB): for a larger ROM the mask widens to 0x1FFF'FFFF and the 0x1000'0000 cart base leaks into the buffer index, so every cart access (including the IPL3 bytes the PIF's IPL2 checksum validates) reads ~256MiB into the wrong offset -> checksum fails -> PIF Error/NMI -> CPU parked at the reset vector.

Pass the base-relative offset (address - 0x1000'0000) at the two cart dispatch sites. Identical result for <=256MiB ROMs (mask already stripped the base); fixes >256MiB.