### PR TITLE
gdb: Fix number parsing for read register and step packets

### DIFF
--- a/nall/nall/gdb/server.cpp
+++ b/nall/nall/gdb/server.cpp
@@ -218,7 +218,7 @@ namespace nall::GDB {
 
       case 'p': // read specific register (e.g.: "p15")
         if(hooks.regRead) {
-          u32 regIdx = cmdName.slice(1).integer();
+          u32 regIdx = cmdName.slice(1).hex();
           return hooks.regRead(regIdx);
         } else {
           return "00000000";

--- a/nall/nall/gdb/server.cpp
+++ b/nall/nall/gdb/server.cpp
@@ -305,7 +305,7 @@ namespace nall::GDB {
 
       case 's': {
         if(cmdName.size() > 1) {
-          u64 address = cmdName.slice(1).integer();
+          u64 address = cmdName.slice(1).hex();
           printf("stepping at address unsupported, ignore (%016" PRIX64 ")\n", address);
         }
 


### PR DESCRIPTION
Two packet request commands are currently parsing data as integers when the GDB specification calls for them to be treated as hexadecimal.

I initially ran into this when working on a custom client to interface with ares's GDB server and found that sending `p25` to read the `pc` register on the N64 core was returning `0000000000000000` all the time. After digging through the code, I saw that it was parsing the packet as an integer instead and returning the value of `t9`.

I included a fix for the step at address packet (even though it's only contributing to a warning message) since I saw it was another instance of this occurring and not following the specification.

For reference, the specification I found for [read register packet](https://sourceware.org/gdb/current/onlinedocs/gdb.html/Packets.html#index-p-packet) explicitly calls out "'p _n_'   Read the value of register _n_; _n_ is in hex." For the other packet change, I interpreted the [overview](https://sourceware.org/gdb/current/onlinedocs/gdb.html/Overview.html) section specifying that "Except where otherwise noted all numbers are represented in `HEX` ..." and the section on the `s [addr]` packet, did not call out an explicitly different interpretation of the value.

If these changes are going to break well-known usages of GDB with ares that adhere to its implementation of the protocol, feel free to close this PR.