### PR TITLE
arm7tdmi: prevent STM writeback from modifying r15

### DIFF
--- a/ares/component/processor/arm7tdmi/instructions-arm.cpp
+++ b/ares/component/processor/arm7tdmi/instructions-arm.cpp
@@ -190,8 +190,8 @@ auto ARM7TDMI::armInstructionMoveMultiple
     if(!list.bit(m)) continue;
     if(mode == 1) r(m) = read(Word, rn);
     if(mode == 0) {
-      write(Word, rn, r(m) + (!(n == 15 && writeback) && m == 15 ? 4 : 0));
-      if(writeback) r(n) = rnEnd;  //writeback occurs after first access
+      write(Word, rn, r(m) + (m == 15 ? 4 : 0));
+      if(writeback && n != 15) r(n) = rnEnd;  //writeback occurs after first access, but incrementing r15 supersedes this
     }
     rn += 4;
   }

--- a/tests/arm7tdmi/arm7tdmi.cpp
+++ b/tests/arm7tdmi/arm7tdmi.cpp
@@ -213,6 +213,10 @@ auto CPU::run(const TestCase& test, bool logErrors) -> TestResult {
     if((test.opcode & 0x0000000F) == 0x0000000F) return skip;
   }
 
+  //tests/v1/arm_ldm_stm.json
+  //r15 base register writeback should not occur for STM
+  if(!thumb && (test.opcode & 0b00001000000111110000000000000000) == 0b0000'1'000000'01111'0000000000000000) return skip;
+
   //tests/v1/arm_ldr_str_immediate_offset.json
   //r15 tests incorrectly apply +4 offset on writeback to rn
   if(!thumb && (test.opcode & 0b00001110000011110000000000000000) == 0b0000'010'00000'1111'0000000000000000) {


### PR DESCRIPTION
Implements a [recently-discovered edge case](https://discord.com/channels/465585922579103744/465586361731121162/1521614330876137602) where the STM instruction cannot write back to R15.