### PR TITLE
n64: rewrite PI bus implementation to make it closer to the hardware

### DIFF
--- a/ares/n64/CMakeLists.txt
+++ b/ares/n64/CMakeLists.txt
@@ -205,6 +205,7 @@ ares_add_sources(
   INCLUDED #
     pi/bus.hpp
     pi/debugger.cpp
+    pi/device.hpp
     pi/dma.cpp
     pi/io.cpp
     pi/pi.hpp

--- a/ares/n64/cartridge/cartridge.cpp
+++ b/ares/n64/cartridge/cartridge.cpp
@@ -54,6 +54,11 @@ auto Cartridge::connect() -> void {
     isviewer.tracer->setTerminal(true);
   }
 
+  pi.attach(romDevice, 0);
+  if(ram) pi.attach(ramDevice, 1);
+  if(flash) pi.attach(flash, 1);
+  if(isviewer.enabled()) pi.attach(isviewer, 1);
+
   debugger.load(node);
 
   power(false);
@@ -62,6 +67,10 @@ auto Cartridge::connect() -> void {
 auto Cartridge::disconnect() -> void {
   if(!node) return;
   save();
+  pi.detach(romDevice);
+  pi.detach(ramDevice);
+  pi.detach(flash);
+  pi.detach(isviewer);
   debugger.unload(node);
   rom.reset();
   ram.reset();
@@ -95,6 +104,7 @@ auto Cartridge::power(bool reset) -> void {
   flash.status = 0;
   flash.source = 0;
   flash.offset = 0;
+  flash.writeLatchValid = false;
   isviewer.ram.fill(0);
   rtc.power(reset);
 }

--- a/ares/n64/cartridge/cartridge.cpp
+++ b/ares/n64/cartridge/cartridge.cpp
@@ -43,6 +43,7 @@ auto Cartridge::connect() -> void {
   if(auto fp = pak->read("save.flash")) {
     flash.allocate(fp->size());
     flash.load(fp);
+    flash.setModel(pak->attribute("flash/model"));
   }
 
   rtc.load();
@@ -100,11 +101,7 @@ auto Cartridge::save() -> void {
 }
 
 auto Cartridge::power(bool reset) -> void {
-  flash.mode = Flash::Mode::Idle;
-  flash.status = 0;
-  flash.source = 0;
-  flash.offset = 0;
-  flash.writeLatchValid = false;
+  flash.power(reset);
   isviewer.ram.fill(0);
   rtc.power(reset);
 }

--- a/ares/n64/cartridge/cartridge.hpp
+++ b/ares/n64/cartridge/cartridge.hpp
@@ -23,8 +23,17 @@ struct Cartridge {
     auto piAddress(u32 address, PIDeviceTiming timing) -> bool override {
       if(!timing.fasterThan(min)) return false;
       if(address < 0x0800'0000 || address > 0x0fff'ffff) return false;
-      piView = {self.ram.data, self.ram.size};
-      piViewOffset = (address - 0x0800'0000) & self.ram.maskByte;
+      u32 offset = address - 0x0800'0000;
+      if(self.ram.size > 32_KiB) {
+        u32 bank = offset >> 18;
+        if(bank >= self.ram.size >> 15) return false;
+        if((offset & 0x3ffff) >= 0x8000) return false;
+        piView = {self.ram.data + (bank << 15), 0x8000};
+        piViewOffset = offset & 0x7fff;
+      } else {
+        piView = {self.ram.data, self.ram.size};
+        piViewOffset = offset & self.ram.maskByte;
+      }
       piViewWritable = true;
       return true;
     }

--- a/ares/n64/cartridge/cartridge.hpp
+++ b/ares/n64/cartridge/cartridge.hpp
@@ -31,24 +31,67 @@ struct Cartridge {
   } ramDevice{*this};
 
   struct Flash : Memory::Writable, PIDevice {
+    struct Model {
+      const char* name;
+      u16 manufacturerId;
+      u16 deviceId;
+      bool wordIndexed;
+      u32 sectorEraseClocks;
+      u32 chipEraseClocks;
+      u32 programClocks;
+    };
+    static const Model models[];
+
     auto piAddress(u32 address, PIDeviceTiming timing) -> bool override;
     auto piReadHalf(PIDeviceTiming timing) -> maybe<u16> override;
     auto piWriteHalf(u16 data, PIDeviceTiming timing) -> void override;
 
-    //flash.cpp
-    auto readHalf(u32 address) -> u64;
-    auto writeHalf(u32 address, u64 data) -> void;
-    auto writeWord(u32 address, u64 data) -> void;
+    auto setModel(string name) -> void;
+    auto power(bool reset) -> void;
+    auto finish() -> void;
     auto serialize(serializer& s) -> void;
 
-    enum class Mode : u32 { Idle, Erase, Write, Read, Status };
-    Mode mode = Mode::Idle;
-    u64  status = 0;
-    u32  source = 0;
-    u32  offset = 0;
-    u32  piAddr = 0;
-    u16  writeLatch = 0;
-    n1   writeLatchValid;
+    auto macronix() const -> bool { return model->manufacturerId == 0x00c2; }
+    auto matsushita() const -> bool { return model->manufacturerId == 0x0032; }
+
+    enum class Mode : u32 { ReadArray, Status, SiliconID, LoadBytePage };
+    enum class EraseSetup : u32 { None, Chip, Sector };
+    enum class Busy : u32 { None, Erase, Program };
+
+    struct Status {
+      n8 data = 0;
+      auto wsmReady()     { return data.bit(7); }
+      auto eraseOk()      { return data.bit(3); }
+      auto programOk()    { return data.bit(2); }
+      auto eraseBusy()    { return data.bit(1); }
+      auto programBusy()  { return data.bit(0); }
+      auto ok()           { return data.bit(2, 3); }
+      auto busy()         { return data.bit(0, 1); }
+      auto serialize(serializer& s) -> void { s(data); }
+    };
+
+    const Model* model = &models[3];
+    Mode mode = Mode::ReadArray;
+    Status status;
+    EraseSetup eraseSetup = EraseSetup::None;
+    n3  eraseSector = 0;
+    Busy busy = Busy::None;
+    u8  pageBuffer[128];
+    u32 piOffset = 0;
+    n1  cirHighValid;
+    u16 cirHigh = 0;
+    n1  openBus;
+    n1  statusStale;
+    u16 statusStaleValue = 0;
+    u8  pendingModeCmd = 0;
+    u8  pendingModeCount = 0;
+    u16 burstIndex = 0;
+
+  private:
+    auto command(u32 data) -> void;
+    auto wrapMask() const -> u32 { return model->wordIndexed ? 0x3fff : 0x7fff; }
+    auto arrayOffset(u32 flashOffset) const -> u32;
+    auto siliconHalf(u32 halfIndex) const -> u16;
   } flash;
 
   struct ISViewer : PIDevice {
@@ -91,9 +134,9 @@ struct Cartridge {
   } rtc{*this};
 
   struct Debugger {
-    //debugger.cpp
     auto load(Node::Object) -> void;
     auto unload(Node::Object) -> void;
+    auto flash(u32 command) -> void;
 
     struct Memory {
       Node::Debugger::Memory rom;
@@ -101,6 +144,10 @@ struct Cartridge {
       Node::Debugger::Memory eeprom;
       Node::Debugger::Memory flash;
     } memory;
+
+    struct Tracer {
+      Node::Debugger::Tracer::Notification flash;
+    } tracer;
   } debugger;
 
   Memory::Writable16 eeprom;

--- a/ares/n64/cartridge/cartridge.hpp
+++ b/ares/n64/cartridge/cartridge.hpp
@@ -3,34 +3,42 @@ struct Cartridge {
   VFS::Pak pak;
   Memory::Readable16 rom;
   Memory::Writable16 ram;
-  struct Flash : Memory::Writable {
-    template<u32 Size>
-    auto read(u32 address) -> u64 {
-      if constexpr(Size == Byte) return readByte(address);
-      if constexpr(Size == Half) return readHalf(address);
-      if constexpr(Size == Word) return readWord(address);
-      if constexpr(Size == Dual) return readDual(address);
-      unreachable;
-    }
 
-    template<u32 Size>
-    auto write(u32 address, u64 data) -> void {
-      if constexpr(Size == Byte) return writeByte(address, data);
-      if constexpr(Size == Half) return writeHalf(address, data);
-      if constexpr(Size == Word) return writeWord(address, data);
-      if constexpr(Size == Dual) return writeDual(address, data);
+  struct RomDevice : PIDeviceMemory {
+    Cartridge& self;
+    RomDevice(Cartridge& self) : self(self) {}
+    auto piAddress(u32 address, PIDeviceTiming timing) -> bool override {
+      if(!timing.fasterThan(min)) return false;
+      if(address < 0x1000'0000 || address >= 0x1000'0000 + self.rom.size) return false;
+      piView = {self.rom.data, self.rom.size};
+      piViewOffset = address - 0x1000'0000;
+      piViewWritable = false;
+      return true;
     }
+  } romDevice{*this};
+
+  struct RamDevice : PIDeviceMemory {
+    Cartridge& self;
+    RamDevice(Cartridge& self) : self(self) {}
+    auto piAddress(u32 address, PIDeviceTiming timing) -> bool override {
+      if(!timing.fasterThan(min)) return false;
+      if(address < 0x0800'0000 || address > 0x0fff'ffff) return false;
+      piView = {self.ram.data, self.ram.size};
+      piViewOffset = (address - 0x0800'0000) & self.ram.maskByte;
+      piViewWritable = true;
+      return true;
+    }
+  } ramDevice{*this};
+
+  struct Flash : Memory::Writable, PIDevice {
+    auto piAddress(u32 address, PIDeviceTiming timing) -> bool override;
+    auto piReadHalf(PIDeviceTiming timing) -> maybe<u16> override;
+    auto piWriteHalf(u16 data, PIDeviceTiming timing) -> void override;
 
     //flash.cpp
-    auto readByte(u32 adddres) -> u64;
     auto readHalf(u32 address) -> u64;
-    auto readWord(u32 address) -> u64;
-    auto readDual(u32 address) -> u64;
-    auto writeByte(u32 address, u64 data) -> void;
     auto writeHalf(u32 address, u64 data) -> void;
     auto writeWord(u32 address, u64 data) -> void;
-    auto writeDual(u32 address, u64 data) -> void;
-    
     auto serialize(serializer& s) -> void;
 
     enum class Mode : u32 { Idle, Erase, Write, Read, Status };
@@ -38,19 +46,26 @@ struct Cartridge {
     u64  status = 0;
     u32  source = 0;
     u32  offset = 0;
+    u32  piAddr = 0;
+    u16  writeLatch = 0;
+    n1   writeLatchValid;
   } flash;
-  struct ISViewer : Memory::PI<ISViewer> {
+
+  struct ISViewer : PIDevice {
     Memory::Writable ram;
     Node::Debugger::Tracer::Notification tracer;
+    u32 piAddr = 0;
 
     auto enabled() -> bool { return ram.size; }
+
+    auto piAddress(u32 address, PIDeviceTiming timing) -> bool override;
+    auto piReadHalf(PIDeviceTiming timing) -> maybe<u16> override;
+    auto piWriteHalf(u16 data, PIDeviceTiming timing) -> void override;
 
     //isviewer.cpp
     auto messageChar(char c) -> void;
     auto readHalf(u32 address) -> u16;
     auto writeHalf(u32 address, u16 data) -> void;
-    auto readWord(u32 address) -> u32;
-    auto writeWord(u32 address, u32 data) -> void;
   } isviewer;
 
   struct RTC {

--- a/ares/n64/cartridge/debugger.cpp
+++ b/ares/n64/cartridge/debugger.cpp
@@ -39,6 +39,7 @@ auto Cartridge::Debugger::load(Node::Object parent) -> void {
     memory.flash->setWrite([&](u32 address, u8 data) -> void {
       return static_cast<::ares::Nintendo64::Memory::Writable&>(cartridge.flash).write<Byte>(address, data);
     });
+    tracer.flash = parent->append<Node::Debugger::Tracer::Notification>("Flash", "Cartridge");
   }
 }
 
@@ -47,8 +48,38 @@ auto Cartridge::Debugger::unload(Node::Object parent) -> void {
   parent->remove(memory.ram);
   parent->remove(memory.eeprom);
   parent->remove(memory.flash);
+  parent->remove(tracer.flash);
   memory.rom.reset();
   memory.ram.reset();
   memory.eeprom.reset();
   memory.flash.reset();
+  tracer.flash.reset();
+}
+
+auto Cartridge::Debugger::flash(u32 command) -> void {
+  if(unlikely(!tracer.flash) || unlikely(!tracer.flash->enabled())) return;
+
+  auto& flash = cartridge.flash;
+  u8 cmd = command >> 24;
+  string name;
+  switch(cmd) {
+  case 0x3c: name = "ChipEraseSetup"; break;
+  case 0x4b: name = {"SectorEraseSetup page=", hex(command & 0x3ff, 3L)}; break;
+  case 0x78: name = "Erase"; break;
+  case 0xa5: name = {"ProgramPage page=", hex(command & 0x3ff, 3L)}; break;
+  case 0xb4: name = "LoadBytePage"; break;
+  case 0xd2: name = "Status"; break;
+  case 0xe1: name = "SiliconID"; break;
+  case 0xf0: name = "ReadArray"; break;
+  default:   name = {"Unknown cmd=", hex(cmd, 2L)}; break;
+  }
+
+  static const char* modes[] = {"ReadArray", "Status", "SiliconID", "LoadBytePage"};
+  static const char* busys[] = {"None", "Erase", "Program"};
+  tracer.flash->notify({
+    name, " cmd=", hex(command, 8L),
+    " mode=", modes[(u32)flash.mode],
+    " busy=", busys[(u32)flash.busy],
+    " status=", hex(flash.status.data, 2L),
+  });
 }

--- a/ares/n64/cartridge/debugger.cpp
+++ b/ares/n64/cartridge/debugger.cpp
@@ -34,10 +34,10 @@ auto Cartridge::Debugger::load(Node::Object parent) -> void {
     memory.flash = parent->append<Node::Debugger::Memory>("Cartridge Flash");
     memory.flash->setSize(cartridge.flash.size);
     memory.flash->setRead([&](u32 address) -> u8 {
-      return cartridge.flash.read<Byte>(address);
+      return static_cast<::ares::Nintendo64::Memory::Writable&>(cartridge.flash).read<Byte>(address);
     });
     memory.flash->setWrite([&](u32 address, u8 data) -> void {
-      return cartridge.flash.write<Byte>(address, data);
+      return static_cast<::ares::Nintendo64::Memory::Writable&>(cartridge.flash).write<Byte>(address, data);
     });
   }
 }

--- a/ares/n64/cartridge/flash.cpp
+++ b/ares/n64/cartridge/flash.cpp
@@ -1,6 +1,32 @@
-auto Cartridge::Flash::readByte(u32 address) -> u64 {
-  debug(unusual, "[Cartridge::Flash::readByte] mode=", (u32)mode);
-  return 0;
+auto Cartridge::Flash::piAddress(u32 address, PIDeviceTiming) -> bool {
+  if(address < 0x0800'0000 || address > 0x0fff'ffff) return false;
+  piAddr = address;
+  writeLatchValid = false;
+  return true;
+}
+
+auto Cartridge::Flash::piReadHalf(PIDeviceTiming) -> maybe<u16> {
+  u16 data = readHalf(piAddr);
+  piAddr += 2;
+  return data;
+}
+
+auto Cartridge::Flash::piWriteHalf(u16 data, PIDeviceTiming) -> void {
+  if(mode == Mode::Write) {
+    writeHalf(piAddr, data);
+    piAddr += 2;
+    return;
+  }
+  if(!writeLatchValid) {
+    writeLatch = data;
+    writeLatchValid = true;
+    piAddr += 2;
+    return;
+  }
+  u32 word = (u32)writeLatch << 16 | data;
+  writeWord(piAddr - 2, word);
+  writeLatchValid = false;
+  piAddr += 2;
 }
 
 auto Cartridge::Flash::readHalf(u32 address) -> u64 {
@@ -21,26 +47,8 @@ auto Cartridge::Flash::readHalf(u32 address) -> u64 {
   return 0;
 }
 
-auto Cartridge::Flash::readWord(u32 address) -> u64 {
-  switch(address & 4) { default:
-  case 0: return status >> 32;
-  case 4: return status >>  0;
-  }
-}
-
-auto Cartridge::Flash::readDual(u32 address) -> u64 {
-  debug(unusual, "[Cartridge::Flash::readDual] mode=", (u32)mode);
-  return 0;
-}
-
-auto Cartridge::Flash::writeByte(u32 address, u64 data) -> void {
-  debug(unusual, "[Cartridge::Flash::writeByte] mode=", (u32)mode);
-  return;
-}
-
 auto Cartridge::Flash::writeHalf(u32 address, u64 data) -> void {
   if(mode == Mode::Write) {
-    //writes are deferred until the flash execute command is sent later
     source = pi.io.dramAddress;
     return;
   }
@@ -85,7 +93,6 @@ auto Cartridge::Flash::writeWord(u32 address, u64 data) -> void {
     }
     if(mode == Mode::Write) {
       for(u32 index = 0; index < 128; index += 2) {
-        // FIXME: this is obviously wrong, the flash can't access RDRAM
         u16 half = rdram.ram.read<Half>(source + index, RBusDevice::ARES_FLASH);
         Memory::Writable::write<Half>(offset + index, half);
       }
@@ -106,11 +113,6 @@ auto Cartridge::Flash::writeWord(u32 address, u64 data) -> void {
     debug(unusual, "[Cartridge::Flash::writeWord] command=", hex(command, 2L));
     return;
   }
-}
-
-auto Cartridge::Flash::writeDual(u32 address, u64 data) -> void {
-  debug(unusual, "[Cartridge::Flash::writeDual] mode=", (u32)mode);
-  return;
 }
 
 auto Cartridge::Flash::serialize(serializer& s) -> void {

--- a/ares/n64/cartridge/flash.cpp
+++ b/ares/n64/cartridge/flash.cpp
@@ -1,123 +1,282 @@
+static constexpr u32 FlashMs = 187'500;
+
+const Cartridge::Flash::Model Cartridge::Flash::models[] = {
+  {"MX29L0000",   0x00c2, 0x0000, true,  85 * FlashMs,  85 * FlashMs, (3500 * FlashMs) / 1000},
+  {"MX29L0001",   0x00c2, 0x0001, true,  85 * FlashMs,  85 * FlashMs, (3500 * FlashMs) / 1000},
+  {"MX29L1100",   0x00c2, 0x001e, true,  85 * FlashMs,  85 * FlashMs, (3500 * FlashMs) / 1000},
+  {"MX29L1101_A", 0x00c2, 0x001d, false, 85 * FlashMs,  85 * FlashMs, (3500 * FlashMs) / 1000},
+  {"MX29L1101_B", 0x00c2, 0x0084, false, 85 * FlashMs,  85 * FlashMs, (3500 * FlashMs) / 1000},
+  {"MX29L1101_C", 0x00c2, 0x008e, false, 85 * FlashMs,  85 * FlashMs, (3500 * FlashMs) / 1000},
+  {"MN63F81MPN",  0x0032, 0x00f1, false, 280 * FlashMs, 300 * FlashMs, (300 * FlashMs) / 1000},
+};
+
+auto Cartridge::Flash::setModel(string name) -> void {
+  model = &models[3];
+  if(!name || name == "Unknown") return;
+  for(auto& entry : models) {
+    if(name == entry.name) { model = &entry; return; }
+  }
+}
+
+auto Cartridge::Flash::power(bool) -> void {
+  queue.remove(Queue::Flash_Complete);
+  mode = Mode::ReadArray;
+  status.data = 0;
+  status.wsmReady() = 1;
+  if(macronix()) status.ok() = 3;
+  eraseSetup = EraseSetup::None;
+  eraseSector = 0;
+  busy = Busy::None;
+  memory::fill<u8>(pageBuffer, sizeof(pageBuffer), 0xff);
+  piOffset = 0;
+  cirHighValid = 0;
+  cirHigh = 0;
+  openBus = 0;
+  statusStale = 0;
+  statusStaleValue = 0;
+  pendingModeCmd = 0;
+  pendingModeCount = 0;
+  burstIndex = 0;
+}
+
+auto Cartridge::Flash::arrayOffset(u32 flashOffset) const -> u32 {
+  if(model->wordIndexed) return flashOffset << 1;
+  return flashOffset;
+}
+
+auto Cartridge::Flash::siliconHalf(u32 halfIndex) const -> u16 {
+  u16 id[4] = {0x1111, 0x8001, model->manufacturerId, model->deviceId};
+  if(halfIndex < 4) return id[halfIndex];
+  if(matsushita()) return id[3];
+  return id[halfIndex & 3];
+}
+
 auto Cartridge::Flash::piAddress(u32 address, PIDeviceTiming) -> bool {
   if(address < 0x0800'0000 || address > 0x0fff'ffff) return false;
-  piAddr = address;
-  writeLatchValid = false;
+  piOffset = address - 0x0800'0000;
+  cirHighValid = 0;
+  burstIndex = 0;
   return true;
 }
 
 auto Cartridge::Flash::piReadHalf(PIDeviceTiming) -> maybe<u16> {
-  u16 data = readHalf(piAddr);
-  piAddr += 2;
+  if(openBus) return nothing;
+
+  if(mode == Mode::Status) {
+    if(piOffset & 0x2'0000) {
+      openBus = 1;
+      return nothing;
+    }
+    if(statusStale) {
+      statusStale = 0;
+      u16 data = statusStaleValue;
+      piOffset += 2;
+      burstIndex++;
+      return data;
+    }
+    u16 data = status.data;
+    statusStaleValue = data;
+    piOffset += 2;
+    burstIndex++;
+    return data;
+  }
+
+  if(mode == Mode::SiliconID) {
+    if((piOffset & 0x2'0000) && matsushita()) {
+      openBus = 1;
+      return nothing;
+    }
+    u16 data = siliconHalf(burstIndex);
+    statusStaleValue = data;
+    piOffset += 2;
+    burstIndex++;
+    return data;
+  }
+
+  if(mode == Mode::LoadBytePage) {
+    u32 index = (piOffset & 0x7f) & ~1;
+    u16 data = pageBuffer[index] << 8 | pageBuffer[index + 1];
+    statusStaleValue = data;
+    piOffset += 2;
+    return data;
+  }
+
+  u32 mask = wrapMask();
+  u32 offset = arrayOffset(piOffset);
+  u16 data = 0;
+  if(offset < size) data = Memory::Writable::read<Half>(offset);
+  statusStaleValue = data;
+  if(model->wordIndexed) {
+    piOffset = (piOffset & ~mask) | ((piOffset + 1) & mask);
+  } else {
+    piOffset = (piOffset & ~mask) | ((piOffset + 2) & mask);
+  }
   return data;
 }
 
 auto Cartridge::Flash::piWriteHalf(u16 data, PIDeviceTiming) -> void {
-  if(mode == Mode::Write) {
-    writeHalf(piAddr, data);
-    piAddr += 2;
-    return;
-  }
-  if(!writeLatchValid) {
-    writeLatch = data;
-    writeLatchValid = true;
-    piAddr += 2;
-    return;
-  }
-  u32 word = (u32)writeLatch << 16 | data;
-  writeWord(piAddr - 2, word);
-  writeLatchValid = false;
-  piAddr += 2;
-}
+  u32 offset = piOffset & ~1;
 
-auto Cartridge::Flash::readHalf(u32 address) -> u64 {
-  if(mode == Mode::Read) {
-    return Memory::Writable::read<Half>(address);
+  if(offset == 0x1'0000 || offset == 0x1'0002) {
+    if(!cirHighValid) {
+      cirHigh = data;
+      cirHighValid = 1;
+      piOffset += 2;
+      return;
+    }
+    cirHighValid = 0;
+    piOffset += 2;
+    command((u32)cirHigh << 16 | data);
+    return;
   }
 
   if(mode == Mode::Status) {
-    switch(address & 6) { default:
-    case 0: return status >> 48;
-    case 2: return status >> 32;
-    case 4: return status >> 16;
-    case 6: return status >>  0;
+    if(matsushita()) {
+      status.ok() = 0;
+    } else if(macronix() && offset == 0 && data == 0) {
+      status.ok() = 3;
     }
+    piOffset += 2;
+    return;
   }
 
-  debug(unusual, "[Cartridge::Flash::readHalf] mode=", (u32)mode);
-  return 0;
+  if(mode == Mode::LoadBytePage) {
+    u32 index = offset & 0x7f;
+    if(matsushita()) {
+      pageBuffer[index    ] &= data >> 8;
+      pageBuffer[index + 1] &= data >> 0;
+    } else {
+      pageBuffer[index    ] = data >> 8;
+      pageBuffer[index + 1] = data >> 0;
+    }
+    piOffset += 2;
+    return;
+  }
+
+  piOffset += 2;
 }
 
-auto Cartridge::Flash::writeHalf(u32 address, u64 data) -> void {
-  if(mode == Mode::Write) {
-    source = pi.io.dramAddress;
-    return;
+auto Cartridge::Flash::command(u32 data) -> void {
+  u8 cmd = data >> 24;
+  openBus = 0;
+  cartridge.debugger.flash(data);
+
+  if(busy != Busy::None) return;
+
+  if(macronix() && cmd == 0xd2) {
+    if(pendingModeCmd != cmd) {
+      pendingModeCmd = cmd;
+      pendingModeCount = 1;
+      return;
+    }
+    pendingModeCount++;
+    if(pendingModeCount < 2) return;
   }
+  pendingModeCmd = 0;
+  pendingModeCount = 0;
 
-  debug(unusual, "[Cartridge::Flash::writeHalf] mode=", (u32)mode);
-  return;
-}
-
-auto Cartridge::Flash::writeWord(u32 address, u64 data) -> void {
-  address = (address & 0x7ff'ffff) >> 2;
-
-  if(address == 0) {
-    debug(unusual, "[Cartridge::Flash::writeWord] ignoring write to status register");
-    return;
-  }
-
-  u8 command = data >> 24;
-  switch(command) {
-  case 0x4b:  //set erase offset
-    offset = u16(data) * 128;
+  switch(cmd) {
+  case 0x3c: //ChipEraseSetup
+    eraseSetup = EraseSetup::Chip;
     return;
 
-  case 0x78:  //erase
-    mode = Mode::Erase;
-    status = 0x1111'8008'00c2'001dull;
+  case 0x4b: //SectorEraseSetup
+    eraseSetup = EraseSetup::Sector;
+    eraseSector = (data & 0x3ff) >> 7;
     return;
 
-  case 0xa5:  //set write offset
-    offset = u16(data) * 128;
-    status = 0x1111'8004'00c2'001dull;
-    return;
-
-  case 0xb4:  //write
-    mode = Mode::Write;
-    return;
-
-  case 0xd2:  //execute
-    if(mode == Mode::Erase) {
-      for(u32 index = 0; index < 128; index += 2) {
-        Memory::Writable::write<Half>(offset + index, 0xffff);
+  case 0x78: { //Erase
+    if(eraseSetup == EraseSetup::None) return;
+    u32 duration = model->sectorEraseClocks;
+    if(eraseSetup == EraseSetup::Chip) {
+      duration = model->chipEraseClocks;
+      for(u32 address = 0; address < size; address += 2) {
+        Memory::Writable::write<Half>(address, 0xffff);
       }
     }
-    if(mode == Mode::Write) {
-      for(u32 index = 0; index < 128; index += 2) {
-        u16 half = rdram.ram.read<Half>(source + index, RBusDevice::ARES_FLASH);
-        Memory::Writable::write<Half>(offset + index, half);
+    if(eraseSetup == EraseSetup::Sector) {
+      u32 base = (u32)eraseSector << 14;
+      for(u32 address = 0; address < 0x4000; address += 2) {
+        Memory::Writable::write<Half>(base + address, 0xffff);
       }
     }
-    return;
-
-  case 0xe1:  //status
+    eraseSetup = EraseSetup::None;
     mode = Mode::Status;
-    status = 0x1111'8001'00c2'001dull;
+    status.wsmReady() = 0;
+    status.eraseBusy() = 1;
+    statusStale = macronix();
+    busy = Busy::Erase;
+    cpu.queueInsert(Queue::Flash_Complete, duration);
+    return;
+  }
+
+  case 0xa5: { //ProgramPage
+    u32 page = data & 0x3ff;
+    u32 base = page << 7;
+    for(u32 index = 0; index < 128; index++) {
+      u8 value = Memory::Writable::read<Byte>(base + index);
+      Memory::Writable::write<Byte>(base + index, value & pageBuffer[index]);
+    }
+    memory::fill<u8>(pageBuffer, sizeof(pageBuffer), 0xff);
+    mode = Mode::Status;
+    status.wsmReady() = 0;
+    status.programBusy() = 1;
+    statusStale = macronix();
+    busy = Busy::Program;
+    cpu.queueInsert(Queue::Flash_Complete, model->programClocks);
+    return;
+  }
+
+  case 0xb4: //LoadBytePage
+    mode = Mode::LoadBytePage;
     return;
 
-  case 0xf0:  //read
-    mode = Mode::Read;
-    status = 0x1111'8004'f000'001dull;
+  case 0xd2: //Status
+    mode = Mode::Status;
+    statusStale = macronix();
+    return;
+
+  case 0xe1: //SiliconID
+    mode = Mode::SiliconID;
+    return;
+
+  case 0xf0: //ReadArray
+    mode = Mode::ReadArray;
     return;
 
   default:
-    debug(unusual, "[Cartridge::Flash::writeWord] command=", hex(command, 2L));
+    debug(unusual, "[Cartridge::Flash::command] command=", hex(cmd, 2L));
     return;
   }
 }
 
+auto Cartridge::Flash::finish() -> void {
+  status.wsmReady() = 1;
+  status.busy() = 0;
+  if(busy == Busy::Erase) {
+    if(matsushita()) status.eraseOk() = 1;
+  }
+  if(busy == Busy::Program) {
+    if(matsushita()) status.programOk() = 1;
+  }
+  busy = Busy::None;
+}
+
 auto Cartridge::Flash::serialize(serializer& s) -> void {
+  Memory::Writable::serialize(s);
   s((u32&)mode);
   s(status);
-  s(source);
-  s(offset);
+  s((u32&)eraseSetup);
+  s(eraseSector);
+  s((u32&)busy);
+  s(std::span<u8>{pageBuffer, sizeof(pageBuffer)});
+  s(piOffset);
+  s(cirHighValid);
+  s(cirHigh);
+  s(openBus);
+  s(statusStale);
+  s(statusStaleValue);
+  s(pendingModeCmd);
+  s(pendingModeCount);
+  s(burstIndex);
 }

--- a/ares/n64/cartridge/isviewer.cpp
+++ b/ares/n64/cartridge/isviewer.cpp
@@ -1,11 +1,25 @@
+auto Cartridge::ISViewer::piAddress(u32 address, PIDeviceTiming) -> bool {
+  if(!enabled()) return false;
+  if(address < 0x13ff'0000 || address > 0x13ff'ffff) return false;
+  piAddr = address & 0xffff;
+  return true;
+}
+
+auto Cartridge::ISViewer::piReadHalf(PIDeviceTiming) -> maybe<u16> {
+  u16 data = readHalf(piAddr);
+  piAddr += 2;
+  return data;
+}
+
+auto Cartridge::ISViewer::piWriteHalf(u16 data, PIDeviceTiming) -> void {
+  pi.writeForceFinish();
+  writeHalf(piAddr, data);
+  piAddr += 2;
+}
+
 auto Cartridge::ISViewer::readHalf(u32 address) -> u16 {
   address = (address & 0xffff);
   return ram.read<Half>(address);
-}
-
-auto Cartridge::ISViewer::readWord(u32 address) -> u32 {
-  address = (address & 0xffff);
-  return ram.read<Word>(address);
 }
 
 auto Cartridge::ISViewer::messageChar(char c) -> void {
@@ -39,10 +53,3 @@ auto Cartridge::ISViewer::writeHalf(u32 address, u16 data) -> void {
 
   ram.write<Half>(address, data);
 }
-
-auto Cartridge::ISViewer::writeWord(u32 address, u32 data) -> void {
-  address = (address & 0xffff);
-  writeHalf(address+0, data >> 16);
-  writeHalf(address+2, data & 0xffff);
-}
-

--- a/ares/n64/cpu/cpu.cpp
+++ b/ares/n64/cpu/cpu.cpp
@@ -91,6 +91,7 @@ auto CPU::synchronize() -> void {
     case Queue::SI_BUS_Write:  return si.writeFinished();
     case Queue::RTC_Tick:      return cartridge.rtc.tick();
     case Queue::EEPROM_Write:  return cartridge.eepromFinish();
+    case Queue::Flash_Complete: return cartridge.flash.finish();
     case Queue::DD_Clock_Tick:  return dd.rtc.tickClock();
     case Queue::DD_MECHA_Response:  return dd.mechaResponse();
     case Queue::DD_BM_Request:  return dd.bmRequest();

--- a/ares/n64/dd/dd.cpp
+++ b/ares/n64/dd/dd.cpp
@@ -33,12 +33,14 @@ auto DD::load(Node::Object parent) -> void {
   rtc.load();
 
   debugger.load(parent->append<Node::Object>("Nintendo 64DD"));
+  pi.attach(dd, 2);
 }
 
 auto DD::unload() -> void {
   if(!node) return;
   disconnect();
 
+  pi.detach(dd);
   debugger = {};
   iplrom.reset();
   c2s.reset();

--- a/ares/n64/dd/dd.hpp
+++ b/ares/n64/dd/dd.hpp
@@ -2,7 +2,7 @@
 
 #include <nall/bcd.hpp>
 
-struct DD : Memory::PI<DD> {
+struct DD : PIDeviceMemory {
   Node::Object obj;
   Node::Port port;
   Node::Peripheral node;
@@ -13,6 +13,7 @@ struct DD : Memory::PI<DD> {
   Memory::Writable ms;
   Memory::Writable disk;
   Memory::Writable error;
+  n1 asicAccess;
 
   struct Debugger {
     //debugger.cpp
@@ -74,10 +75,11 @@ struct DD : Memory::PI<DD> {
   auto motorChange() -> void;
 
   //io.cpp
-  auto readHalf(u32 address) -> u16;
-  auto writeHalf(u32 address, u16 data) -> void;
-  auto readWord(u32 address) -> u32;
-  auto writeWord(u32 address, u32 data) -> void;
+  auto piAddress(u32 address, PIDeviceTiming timing) -> bool override;
+  auto piReadHalf(PIDeviceTiming timing) -> maybe<u16> override;
+  auto piWriteHalf(u16 data, PIDeviceTiming timing) -> void override;
+  auto readAsicHalf(u32 address) -> u16;
+  auto writeAsicHalf(u32 address, u16 data) -> void;
 
   //serialization.cpp
   auto serialize(serializer&) -> void;

--- a/ares/n64/dd/io.cpp
+++ b/ares/n64/dd/io.cpp
@@ -1,4 +1,62 @@
-auto DD::readHalf(u32 address) -> u16 {
+auto DD::piAddress(u32 address, PIDeviceTiming timing) -> bool {
+  if(!timing.fasterThan(min)) return false;
+  asicAccess = false;
+  if(address < 0x0500'0000) return false;
+
+  if(address <= 0x0500'03ff) {
+    piView = {c2s.data, c2s.size};
+    piViewOffset = address & 0x3ff;
+    piViewWritable = true;
+    return true;
+  }
+  if(address <= 0x0500'04ff) {
+    piView = {ds.data, ds.size};
+    piViewOffset = address & 0xff;
+    piViewWritable = true;
+    return true;
+  }
+  if(address <= 0x0500'057f) {
+    asicAccess = true;
+    piViewOffset = address;
+    return true;
+  }
+  if(address <= 0x0500'05bf) {
+    piView = {ms.data, ms.size};
+    piViewOffset = address & 0x3f;
+    piViewWritable = true;
+    return true;
+  }
+  if(address <= 0x05ff'ffff) return false;
+  if(address <= 0x063f'ffff) {
+    piView = {iplrom.data, iplrom.size};
+    piViewOffset = address - 0x0600'0000;
+    piViewWritable = false;
+    return true;
+  }
+  return false;
+}
+
+auto DD::piReadHalf(PIDeviceTiming timing) -> maybe<u16> {
+  if(asicAccess) {
+    u16 data = readAsicHalf(piViewOffset);
+    debugger.io(Read, (piViewOffset & 0x7f) >> 2, data);
+    piViewOffset += 2;
+    return data;
+  }
+  return PIDeviceMemory::piReadHalf(timing);
+}
+
+auto DD::piWriteHalf(u16 data, PIDeviceTiming timing) -> void {
+  if(asicAccess) {
+    writeAsicHalf(piViewOffset, data);
+    debugger.io(Write, (piViewOffset & 0x7f) >> 2, data);
+    piViewOffset += 2;
+    return;
+  }
+  return PIDeviceMemory::piWriteHalf(data, timing);
+}
+
+auto DD::readAsicHalf(u32 address) -> u16 {
   address = (address & 0x7f) >> 1;
   n16 data = 0;
 
@@ -126,7 +184,7 @@ auto DD::readHalf(u32 address) -> u16 {
   return data;
 }
 
-auto DD::writeHalf(u32 address, u16 data_) -> void {
+auto DD::writeAsicHalf(u32 address, u16 data_) -> void {
   address = (address & 0x7f) >> 1;
   n16 data = data_;
 
@@ -241,20 +299,4 @@ auto DD::writeHalf(u32 address, u16 data_) -> void {
   //ASIC_TEST_PIN_SEL
   if(address == 36) {
   }
-}
-
-auto DD::readWord(u32 address) -> u32 {
-  address = (address & 0x7f);
-  n32 data;
-  data.bit(16,31) = readHalf(address + 0);
-  data.bit( 0,15) = readHalf(address + 2);
-  debugger.io(Read, address >> 2, data);
-  return (u32)data;
-}
-
-auto DD::writeWord(u32 address, u32 data) -> void {
-  address = (address & 0x7f);
-  writeHalf(address + 0, data >> 16);
-  writeHalf(address + 2, data & 0xffff);
-  debugger.io(Write, address >> 2, data);
 }

--- a/ares/n64/memory/io.hpp
+++ b/ares/n64/memory/io.hpp
@@ -59,33 +59,6 @@ struct RCP {  //A device which is part of RCP
 };
 
 template<typename T>
-struct PI {  //A device which is reachable only behind PI
-  template<u32 Size>
-  auto read(u32 address) -> u64 {
-    static_assert(Size == Half || Size == Word);  //PI bus will do 32-bit (CPU) or 16-bit (DMA) only
-    if constexpr(Size == Half) {
-      return ((T*)this)->readHalf(address);
-    }
-    if constexpr(Size == Word) {
-      return ((T*)this)->readWord(address);
-    }
-    unreachable;
-  }
-  
-  template<u32 Size>
-  auto write(u32 address, u64 data) -> void {
-    static_assert(Size == Half || Size == Word);  //PI bus will do 32-bit (CPU) or 16-bit (DMA) only
-    if constexpr(Size == Half) {
-      return ((T*)this)->writeHalf(address, data);
-    }
-    if constexpr(Size == Word) {
-      return ((T*)this)->writeWord(address, data);
-    }
-    unreachable;
-  }
-};
-
-template<typename T>
 struct SI {  //A device which is reachable only behind SI
   template<u32 Size>
   auto read(u32 address) -> u64 {
@@ -98,7 +71,7 @@ struct SI {  //A device which is reachable only behind SI
   
   template<u32 Size>
   auto write(u32 address, u64 data) -> void {
-    static_assert(Size == Word);  //PI bus will do 32-bit (CPU/DMA)
+    static_assert(Size == Word);  //SI bus will do 32-bit (CPU/DMA)
     if constexpr(Size == Word) {
       return ((T*)this)->writeWord(address, data);
     }

--- a/ares/n64/n64.hpp
+++ b/ares/n64/n64.hpp
@@ -126,6 +126,7 @@ namespace ares::Nintendo64 {
 
   #include <n64/accuracy.hpp>
   #include <n64/memory/memory.hpp>
+  #include <n64/pi/device.hpp>
   #include <n64/system/system.hpp>
   #include <n64/cartridge/cartridge.hpp>
   #include <n64/cic/cic.hpp>

--- a/ares/n64/n64.hpp
+++ b/ares/n64/n64.hpp
@@ -85,6 +85,7 @@ namespace ares::Nintendo64 {
       SI_BUS_Write,
       RTC_Tick,
       EEPROM_Write,
+      Flash_Complete,
       DD_Clock_Tick,
       DD_MECHA_Response,
       DD_BM_Request,

--- a/ares/n64/pi/bus.hpp
+++ b/ares/n64/pi/bus.hpp
@@ -1,57 +1,71 @@
+inline auto PI::attach(PIDevice& device, u32 priority) -> void {
+  auto it = devices.begin();
+  while(it != devices.end() && it->priority <= priority) ++it;
+  u32 index = it - devices.begin();
+  if(busDevice >= (s32)index) busDevice++;
+  devices.insert(it, {priority, &device});
+}
+
+inline auto PI::detach(PIDevice& device) -> void {
+  for(u32 i = 0; i < devices.size(); i++) {
+    if(devices[i].device != &device) continue;
+    devices.erase(devices.begin() + i);
+    if(busDevice == (s32)i) busDevice = -1;
+    else if(busDevice > (s32)i) busDevice--;
+    return;
+  }
+}
+
+inline auto PI::bsdForAddress(u32 address) -> BSD& {
+  switch(address >> 24) {
+  case 0x05:               return bsd2;
+  case range8(0x08, 0x0F): return bsd2;
+  default:                 return bsd1;
+  }
+}
+
+inline auto PI::busAddress(u32 address) -> void {
+  address &= ~1;
+  io.busLatch = u16(address) << 16 | u16(address);
+  auto& bsd = bsdForAddress(address);
+  busTiming = {bsd.latency, bsd.pulseWidth, bsd.releaseDuration};
+  busDevice = -1;
+  for(u32 i = 0; i < devices.size(); i++) {
+    if(devices[i].device->piAddress(address, busTiming)) {
+      busDevice = i;
+      break;
+    }
+  }
+}
+
+inline auto PI::busReadHalf() -> u16 {
+  if(busDevice >= 0) {
+    if(auto data = devices[busDevice].device->piReadHalf(busTiming)) {
+      io.busLatch = u32(*data) << 16 | *data;
+    }
+  }
+  return io.busLatch;
+}
+
+inline auto PI::busWriteHalf(u16 data) -> void {
+  if(!io.ioBusy) io.busLatch = u32(data) << 16 | data;
+  if(busDevice >= 0) devices[busDevice].device->piWriteHalf(data, busTiming);
+}
+
 inline auto PI::readWord(u32 address, Thread& thread) -> u32 {
   if(address <= 0x046f'ffff) return ioRead(address);
 
-  if (unlikely(io.ioBusy)) {
+  if(unlikely(io.ioBusy)) {
     debug(unusual, "[PI::readWord] PI read to 0x", hex(address, 8L), " will not behave as expected because PI writing is in progress");
     thread.step(writeForceFinish() * 2);
     return io.busLatch;
   }
   thread.step(250 * 2);
-  io.busLatch = busRead<Word>(address);
+  busAddress(address);
+  u32 data = busReadHalf() << 16;
+  io.busLatch = data | busReadHalf();
   io.pbusAddress = (address + 4) & ~1;
   return io.busLatch;
-}
-
-template <u32 Size>
-inline auto PI::busRead(u32 address) -> u32 {
-  static_assert(Size == Half || Size == Word);  //PI bus will do 32-bit (CPU) or 16-bit (DMA) only
-  const u32 unmapped = (address & 0xFFFF) | (address << 16);
-
-  if(address <= 0x04ff'ffff) return unmapped; //Address range not memory mapped, only accessible via DMA
-  if(address <= 0x0500'03ff) {
-    if(_DD()) return dd.c2s.read<Size>(address);
-    return unmapped;
-  }
-  if(address <= 0x0500'04ff) {
-    if(_DD()) return dd.ds.read<Size>(address);
-    return unmapped;
-  }
-  if(address <= 0x0500'057f) {
-    if(_DD()) return dd.read<Size>(address);
-    return unmapped;
-  }
-  if(address <= 0x0500'05bf) {
-    if(_DD()) return dd.ms.read<Size>(address);
-    return unmapped;
-  }
-  if(address <= 0x05ff'ffff) return unmapped;
-  if(address <= 0x063f'ffff) {
-    if(_DD()) return dd.iplrom.read<Size>(address);
-    return unmapped;
-  }
-  if(address <= 0x07ff'ffff) return unmapped;
-  if(address <= 0x0fff'ffff) {
-    if(cartridge.ram  ) return cartridge.ram.read<Size>(address);
-    if(cartridge.flash) return cartridge.flash.read<Size>(address);
-    return unmapped;
-  }
-  if(cartridge.isviewer.enabled() && address >= 0x13ff'0000 && address <= 0x13ff'ffff) {
-    return cartridge.isviewer.read<Size>(address);
-  }
-  if(address <= 0x1000'0000 + cartridge.rom.size - 1) {
-    return cartridge.rom.read<Size>(address);
-  }
-  return unmapped;
 }
 
 inline auto PI::writeWord(u32 address, u32 data, Thread& thread) -> void {
@@ -59,55 +73,12 @@ inline auto PI::writeWord(u32 address, u32 data, Thread& thread) -> void {
 
   if(io.ioBusy) return;
   io.ioBusy = 1;
-  io.busLatch = data;
   io.pbusAddress = (address + 4) & ~1;
   cpu.queueInsert(Queue::PI_BUS_Write, 400);
-  return busWrite<Word>(address, data);
-}
-
-template <u32 Size>
-inline auto PI::busWrite(u32 address, u32 data) -> void {
-  static_assert(Size == Half || Size == Word);  //PI bus will do 32-bit (CPU) or 16-bit (DMA) only
-  if(address <= 0x04ff'ffff) return; //Address range not memory mapped, only accessible via DMA
-  if(address <= 0x0500'03ff) {
-    if(_DD()) return dd.c2s.write<Size>(address, data);
-    return;
-  }
-  if(address <= 0x0500'04ff) {
-    if(_DD()) return dd.ds.write<Size>(address, data);
-    return;
-  }
-  if(address <= 0x0500'057f) {
-    if(_DD()) return dd.write<Size>(address, data);
-    return;
-  }
-  if(address <= 0x0500'05bf) {
-    if(_DD()) return dd.ms.write<Size>(address, data);
-    return;
-  }
-  if(address <= 0x05ff'ffff) return;
-  if(address <= 0x063f'ffff) {
-    if(_DD()) return dd.iplrom.write<Size>(address, data);
-    return;
-  }
-  if(address <= 0x07ff'ffff) return;
-  if(address <= 0x0fff'ffff) {
-    if(cartridge.ram  ) return cartridge.ram.write<Size>(address, data);
-    if(cartridge.flash) return cartridge.flash.write<Size>(address, data);
-    return;
-  }
-  if(address >= 0x13ff'0000 && address <= 0x13ff'ffff) {
-    if(cartridge.isviewer.enabled()) {
-      writeForceFinish(); //Debugging channel for homebrew, be gentle
-      return cartridge.isviewer.write<Size>(address, data);      
-    } else {
-      debug(unhandled, "[PI::busWrite] attempt to write to ISViewer: ROM is too big so ISViewer is disabled");
-    }
-  }
-  if(address <= 0x1000'0000 + cartridge.rom.size - 1) {
-    return cartridge.rom.write<Size>(address, data);
-  }
-  if(address <= 0x7fff'ffff) return;
+  busAddress(address);
+  io.busLatch = data;
+  busWriteHalf(data >> 16);
+  busWriteHalf(data >>  0);
 }
 
 inline auto PI::writeFinished() -> void {

--- a/ares/n64/pi/device.hpp
+++ b/ares/n64/pi/device.hpp
@@ -1,0 +1,37 @@
+struct PIDeviceTiming {
+  n8 latency;
+  n8 pulseWidth;
+  n2 releaseDuration;
+
+  auto fasterThan(const PIDeviceTiming& other) const -> bool {
+    return latency         >= other.latency
+        && pulseWidth      >= other.pulseWidth
+        && releaseDuration >= other.releaseDuration;
+  }
+};
+
+struct PIDevice {
+  virtual auto piAddress(u32 address, PIDeviceTiming timing) -> bool = 0;
+  virtual auto piReadHalf(PIDeviceTiming timing) -> maybe<u16> = 0;
+  virtual auto piWriteHalf(u16 data, PIDeviceTiming timing) -> void = 0;
+};
+
+struct PIDeviceMemory : PIDevice {
+  auto piReadHalf(PIDeviceTiming timing) -> maybe<u16> override {
+    if(piViewOffset >= piView.size()) return nothing;
+    u16 data = *(u16*)&piView[piViewOffset ^ 2];
+    piViewOffset += 2;
+    return data;
+  }
+
+  auto piWriteHalf(u16 data, PIDeviceTiming timing) -> void override {
+    if(piViewOffset >= piView.size()) return;
+    if(piViewWritable) *(u16*)&piView[piViewOffset ^ 2] = data;
+    piViewOffset += 2;
+  }
+
+  std::span<u8> piView;
+  u32 piViewOffset = 0;
+  n1  piViewWritable;
+  PIDeviceTiming min;
+};

--- a/ares/n64/pi/dma.cpp
+++ b/ares/n64/pi/dma.cpp
@@ -1,10 +1,15 @@
 auto PI::dmaRead() -> void {
   io.readLength = (io.readLength | 1) + 1;
 
-  u32 lastCacheline = 0xffff'ffff;
+  auto& bsd = bsdForAddress(io.pbusAddress);
+  u32 pageMask = (1 << (bsd.pageSize + 2)) - 1;
+  busAddress(io.pbusAddress);
+
   for(u32 address = 0; address < io.readLength; address += 2) {
+    u32 cursor = io.pbusAddress + address;
+    if(address && (cursor & pageMask) == 0) busAddress(cursor);
     u16 data = rdram.ram.read<Half>(io.dramAddress + address, RBusDevice::PI_DMA);
-    busWrite<Half>(io.pbusAddress + address, data);
+    busWriteHalf(data);
   }
 }
 
@@ -18,26 +23,34 @@ auto PI::dmaWrite() -> void {
     cpu.recompiler.invalidateRange(io.dramAddress, (length + 1) & ~1);
   }
 
-  while (length > 0) {
+  auto& bsd = bsdForAddress(io.pbusAddress);
+  u32 pageMask = (1 << (bsd.pageSize + 2)) - 1;
+  bool addressSelected = false;
+
+  while(length > 0) {
     i32 misalign = io.dramAddress & 7;
     i32 distEndOfRow = 0x800-(io.dramAddress&0x7ff);
     i32 blockLen = min(maxBlockSize-misalign, distEndOfRow);
     i32 curLen = min(length, blockLen);
 
-    for (int i=0; i<curLen; i+=2) {
-      u16 data = busRead<Half>(io.pbusAddress);
+    for(int i=0; i<curLen; i+=2) {
+      if(!addressSelected || (io.pbusAddress & pageMask) == 0) {
+        busAddress(io.pbusAddress);
+        addressSelected = true;
+      }
+      u16 data = busReadHalf();
       mem[i+0] = data >> 8;
       mem[i+1] = data >> 0;
       io.pbusAddress += 2;
       length -= 2;
     }
 
-    if (firstBlock && curLen < 127-misalign) {
-      for (i32 i = 0; i < curLen-misalign; i++) {
+    if(firstBlock && curLen < 127-misalign) {
+      for(i32 i = 0; i < curLen-misalign; i++) {
         rdram.ram.write<Byte>(io.dramAddress++, mem[i], RBusDevice::PI_DMA);
       }
     } else {
-      for (i32 i = 0; i < curLen-misalign; i+=2) {
+      for(i32 i = 0; i < curLen-misalign; i+=2) {
         rdram.ram.write<Byte>(io.dramAddress++, mem[i+0], RBusDevice::PI_DMA);
         rdram.ram.write<Byte>(io.dramAddress++, mem[i+1], RBusDevice::PI_DMA);
       }
@@ -60,12 +73,7 @@ auto PI::dmaDuration(bool read) -> u32 {
   auto len = read ? io.readLength : io.writeLength;
   len = (len | 1) + 1;
 
-  BSD bsd;
-  switch (io.pbusAddress.bit(24,31)) {
-    case 0x05:               bsd = bsd2; break; 
-    case range8(0x08, 0x0F): bsd = bsd2; break;
-    default:                 bsd = bsd1; break;
-  }
+  auto& bsd = bsdForAddress(io.pbusAddress);
 
   auto pageShift = bsd.pageSize + 2;
   auto pageSize = 1 << pageShift;
@@ -79,19 +87,19 @@ auto PI::dmaDuration(bool read) -> u32 {
   auto numBuffers = 0;
   auto partialBytes = 0;
 
-  if (pbusFirstPage == pbusLastPage) {
-    if (len == 128) numBuffers = 1;
+  if(pbusFirstPage == pbusLastPage) {
+    if(len == 128) numBuffers = 1;
     else partialBytes = len;
   } else {
     bool fullFirst = (pbusFirst & pageMask) == 0;
     bool fullLast  = ((pbusLast + 2) & pageMask) == 0;
 
-    if (fullFirst) numBuffers++;
+    if(fullFirst) numBuffers++;
     else           partialBytes += pageSize - (pbusFirst & pageMask);
-    if (fullLast)  numBuffers++;
+    if(fullLast)  numBuffers++;
     else           partialBytes += (pbusLast & pageMask) + 2;
 
-    if (pbusFirstPage + 1 < pbusLastPage)
+    if(pbusFirstPage + 1 < pbusLastPage)
       numBuffers += (pbusPages - 2) * pageSize / 128;
   }
 

--- a/ares/n64/pi/pi.cpp
+++ b/ares/n64/pi/pi.cpp
@@ -15,6 +15,8 @@ auto PI::load(Node::Object parent) -> void {
 }
 
 auto PI::unload() -> void {
+  devices.clear();
+  busDevice = -1;
   debugger = {};
   node.reset();
 }
@@ -23,6 +25,8 @@ auto PI::power(bool reset) -> void {
   io = {};
   bsd1 = {};
   bsd2 = {};
+  busDevice = -1;
+  busTiming = {};
 }
 
 }

--- a/ares/n64/pi/pi.hpp
+++ b/ares/n64/pi/pi.hpp
@@ -13,34 +13,6 @@ struct PI : Memory::RCP<PI> {
     } tracer;
   } debugger;
 
-  //pi.cpp
-  auto load(Node::Object) -> void;
-  auto unload() -> void;
-  auto power(bool reset) -> void;
-
-  //dma.cpp
-  auto dmaRead() -> void;
-  auto dmaWrite() -> void;
-  auto dmaFinished() -> void;
-  auto dmaDuration(bool read) -> u32;
-
-  //io.cpp
-  auto ioRead(u32 address) -> u32;
-  auto ioWrite(u32 address, u32 data) -> void;
-
-  //bus.hpp
-  auto readWord(u32 address, Thread& thread) -> u32;
-  auto writeWord(u32 address, u32 data, Thread& thread) -> void;
-  auto writeFinished() -> void;
-  auto writeForceFinish() -> u32;
-  template <u32 Size>
-  auto busRead(u32 address) -> u32;
-  template <u32 Size>
-  auto busWrite(u32 address, u32 data) -> void;
-  
-  //serialization.cpp
-  auto serialize(serializer&) -> void;
-
   struct IO {
     n1  dmaBusy;
     n1  ioBusy;
@@ -60,6 +32,45 @@ struct PI : Memory::RCP<PI> {
     n4 pageSize;
     n2 releaseDuration;
   } bsd1, bsd2;
+
+  struct DeviceEntry {
+    u32 priority;
+    PIDevice* device;
+  };
+  std::vector<DeviceEntry> devices;
+
+  s32 busDevice = -1;
+  PIDeviceTiming busTiming;
+
+  //pi.cpp
+  auto load(Node::Object) -> void;
+  auto unload() -> void;
+  auto power(bool reset) -> void;
+
+  //dma.cpp
+  auto dmaRead() -> void;
+  auto dmaWrite() -> void;
+  auto dmaFinished() -> void;
+  auto dmaDuration(bool read) -> u32;
+
+  //io.cpp
+  auto ioRead(u32 address) -> u32;
+  auto ioWrite(u32 address, u32 data) -> void;
+
+  //bus.hpp
+  auto attach(PIDevice& device, u32 priority) -> void;
+  auto detach(PIDevice& device) -> void;
+  auto bsdForAddress(u32 address) -> BSD&;
+  auto busAddress(u32 address) -> void;
+  auto busReadHalf() -> u16;
+  auto busWriteHalf(u16 data) -> void;
+  auto readWord(u32 address, Thread& thread) -> u32;
+  auto writeWord(u32 address, u32 data, Thread& thread) -> void;
+  auto writeFinished() -> void;
+  auto writeForceFinish() -> u32;
+
+  //serialization.cpp
+  auto serialize(serializer&) -> void;
 };
 
 extern PI pi;

--- a/ares/n64/pi/serialization.cpp
+++ b/ares/n64/pi/serialization.cpp
@@ -19,4 +19,9 @@ auto PI::serialize(serializer& s) -> void {
   s(bsd2.pulseWidth);
   s(bsd2.pageSize);
   s(bsd2.releaseDuration);
+
+  s(busDevice);
+  s(busTiming.latency);
+  s(busTiming.pulseWidth);
+  s(busTiming.releaseDuration);
 }

--- a/ares/n64/system/serialization.cpp
+++ b/ares/n64/system/serialization.cpp
@@ -1,4 +1,4 @@
-static const string SerializerVersion = "v152";
+static const string SerializerVersion = "v153";
 
 auto System::serialize(bool synchronize) -> serializer {
   serializer s;

--- a/mia/medium/nintendo-64.cpp
+++ b/mia/medium/nintendo-64.cpp
@@ -769,7 +769,7 @@ auto Nintendo64::analyze(std::vector<u8>& data) -> string {
     if(config.bit(4,7) == 1) {eeprom = 512;}
     if(config.bit(4,7) == 2) {eeprom = 2_KiB;}
     if(config.bit(4,7) == 3) {sram = 32_KiB;}
-    //if(config.bit(4,7) == 4) {sram = 96_KiB;}   //banked SRAM, not supported yet
+    if(config.bit(4,7) == 4) {sram = 96_KiB;}
     if(config.bit(4,7) == 5) {flash = 128_KiB; flashModel = "Unknown";}
     if(config.bit(4,7) == 6) {sram = 128_KiB;}
     if(config.bit(0) == 1)   {rtc = true;}

--- a/mia/medium/nintendo-64.cpp
+++ b/mia/medium/nintendo-64.cpp
@@ -123,6 +123,7 @@ auto Nintendo64::load(string location) -> LoadResult {
   }
   if(auto node = document["game/board/memory(type=Flash,content=Save)"]) {
     Medium::load(node, ".flash");
+    pak->setAttribute("flash/model", node["model"].string());
   }
   if(auto node = document["game/board/memory(type=RTC,content=Save)"]) {
     Medium::load(node, ".rtc");
@@ -279,6 +280,7 @@ auto Nintendo64::analyze(std::vector<u8>& data) -> string {
   u32 eeprom  = 0;      //512_B or 2_KiB
   u32 sram    = 0;      //32_KiB
   u32 flash   = 0;      //128_KiB
+  string flashModel;
 
   //supported peripherals
   bool cpak = false;                 //Controller Pak (port 1)
@@ -452,26 +454,26 @@ auto Nintendo64::analyze(std::vector<u8>& data) -> string {
   if(id == "CDZ") {sram = 96_KiB; rpak = true;}                            //Dezaemon 3D
 
   //128KB Flash
-  if(id == "NCC") {flash = 128_KiB; rpak = true;}                          //Command & Conquer
-  if(id == "NCV") {flash = 128_KiB;}                                       //Cubivore [English translation/patch of Doubutsu Banchou (J)]
-  if(id == "NDA") {flash = 128_KiB; cpak = true;}                          //Derby Stallion 64
-  if(id == "NAF") {flash = 128_KiB; cpak = true; rtc = true;}              //Doubutsu no Mori
-  if(id == "NJF") {flash = 128_KiB; rpak = true;}                          //Jet Force Gemini [Star Twins (J)]
-  if(id == "NKJ") {flash = 128_KiB; rpak = true;}                          //Ken Griffey Jr.'s Slugfest
-  if(id == "NZS") {flash = 128_KiB; rpak = true;}                          //Legend of Zelda: Majora's Mask [Zelda no Densetsu - Mujura no Kamen (J)]
-  if(id == "NM6") {flash = 128_KiB; rpak = true;}                          //Mega Man 64
-  if(id == "NCK") {flash = 128_KiB; rpak = true;}                          //NBA Courtside 2 featuring Kobe Bryant
-  if(id == "NMQ") {flash = 128_KiB; rpak = true;}                          //Paper Mario
-  if(id == "NPN") {flash = 128_KiB;}                                       //Pokemon Puzzle League
-  if(id == "NPF") {flash = 128_KiB;}                                       //Pokemon Snap [Pocket Monsters Snap (J)]
-  if(id == "NPO") {flash = 128_KiB; tpak = true;}                          //Pokemon Stadium
-  if(id == "CP2") {flash = 128_KiB; tpak = true;}                          //Pocket Monsters Stadium 2 (J)
-  if(id == "NP3") {flash = 128_KiB; tpak = true;}                          //Pokemon Stadium 2 [Pocket Monsters Stadium - Kin Gin (J)]
-  if(id == "NRH") {flash = 128_KiB; rpak = true;}                          //Rockman Dash - Hagane no Boukenshin (J)
-  if(id == "NSQ") {flash = 128_KiB; rpak = true;}                          //StarCraft 64
-  if(id == "NT9") {flash = 128_KiB;}                                       //Tigger's Honey Hunt
-  if(id == "NW4") {flash = 128_KiB; cpak = true; rpak = true;}             //WWF No Mercy
-  if(id == "NDP") {flash = 128_KiB;}                                       //Dinosaur Planet (Unlicensed)
+  if(id == "NCC") {flash = 128_KiB; flashModel = "MX29L1100"; rpak = true;}  //Command & Conquer
+  if(id == "NCV") {flash = 128_KiB; flashModel = "Unknown";}                 //Cubivore [English translation/patch of Doubutsu Banchou (J)]
+  if(id == "NDA") {flash = 128_KiB; flashModel = "Unknown";   cpak = true;}  //Derby Stallion 64
+  if(id == "NAF") {flash = 128_KiB; flashModel = "MX29L1100"; cpak = true; rtc = true;}  //Doubutsu no Mori
+  if(id == "NJF") {flash = 128_KiB; flashModel = "MX29L1100"; rpak = true;}  //Jet Force Gemini [Star Twins (J)]
+  if(id == "NKJ") {flash = 128_KiB; flashModel = "Unknown";   rpak = true;}  //Ken Griffey Jr.'s Slugfest
+  if(id == "NZS") {flash = 128_KiB; flashModel = "MX29L1100"; rpak = true;}  //Legend of Zelda: Majora's Mask [Zelda no Densetsu - Mujura no Kamen (J)]
+  if(id == "NM6") {flash = 128_KiB; flashModel = "MX29L1100"; rpak = true;}  //Mega Man 64
+  if(id == "NCK") {flash = 128_KiB; flashModel = "MX29L1100"; rpak = true;}  //NBA Courtside 2 featuring Kobe Bryant
+  if(id == "NMQ") {flash = 128_KiB; flashModel = "Unknown";   rpak = true;}  //Paper Mario
+  if(id == "NPN") {flash = 128_KiB; flashModel = "MX29L1100";}               //Pokemon Puzzle League
+  if(id == "NPF") {flash = 128_KiB; flashModel = "MX29L1100";}               //Pokemon Snap [Pocket Monsters Snap (J)]
+  if(id == "NPO") {flash = 128_KiB; flashModel = "Unknown";   tpak = true;}  //Pokemon Stadium
+  if(id == "CP2") {flash = 128_KiB; flashModel = "Unknown";   tpak = true;}  //Pocket Monsters Stadium 2 (J)
+  if(id == "NP3") {flash = 128_KiB; flashModel = "Unknown";   tpak = true;}  //Pokemon Stadium 2 [Pocket Monsters Stadium - Kin Gin (J)]
+  if(id == "NRH") {flash = 128_KiB; flashModel = "Unknown";   rpak = true;}  //Rockman Dash - Hagane no Boukenshin (J)
+  if(id == "NSQ") {flash = 128_KiB; flashModel = "Unknown";   rpak = true;}  //StarCraft 64
+  if(id == "NT9") {flash = 128_KiB; flashModel = "Unknown";}                 //Tigger's Honey Hunt
+  if(id == "NW4") {flash = 128_KiB; flashModel = "Unknown";   cpak = true; rpak = true;}  //WWF No Mercy
+  if(id == "NDP") {flash = 128_KiB; flashModel = "Unknown";}                 //Dinosaur Planet (Unlicensed)
 
   //Controller Pak
   if(id == "N4W") {cpak = true; rpak = true;}                              //40 Winks (Aftermarket)
@@ -768,7 +770,7 @@ auto Nintendo64::analyze(std::vector<u8>& data) -> string {
     if(config.bit(4,7) == 2) {eeprom = 2_KiB;}
     if(config.bit(4,7) == 3) {sram = 32_KiB;}
     //if(config.bit(4,7) == 4) {sram = 96_KiB;}   //banked SRAM, not supported yet
-    if(config.bit(4,7) == 5) {flash = 128_KiB;}
+    if(config.bit(4,7) == 5) {flash = 128_KiB; flashModel = "Unknown";}
     if(config.bit(4,7) == 6) {sram = 128_KiB;}
     if(config.bit(0) == 1)   {rtc = true;}
 
@@ -877,6 +879,7 @@ auto Nintendo64::analyze(std::vector<u8>& data) -> string {
   s += "      type: Flash\n";
   s +={"      size: 0x", hex(flash), "\n"};
   s += "      content: Save\n";
+  if(flashModel) s +={"      model: ", flashModel, "\n"};
   }
   if(rtc) {
   s += "    memory\n";


### PR DESCRIPTION
PIDevice is now a generic device sitting on the PI bus that is able to reply to addresses in any range. Now each device knows the addresses it is listening to, which is how the hardware works.

PI accesses are only 16-bit wide, and both DMA and CPU I/O are built upon it. There is no more code to mimic the weird access patterns for misaligned addresses or different access sizes, as everything descends naturally from the way the bus works (as it should be).

Open bus is simulated by latching the last value on the bus, which is what happens on hardware.

The second commit rewrites the flash emulation to be vastly more accurate. The previous code was really a quick hack. This new implementation follows modern research available on n64brew.