### PR TITLE
n64: RDRAM-related accuracy improvements

### DIFF
--- a/ares/n64/accuracy.hpp
+++ b/ares/n64/accuracy.hpp
@@ -22,10 +22,6 @@ struct Accuracy {
     static constexpr bool SIMD = !SISD;
   };
 
-  struct RDRAM {
-    static constexpr bool Broadcasting = 0;
-  };
-
   struct PIF {
     // Emulate a region-locked console
     static constexpr bool RegionLock = false;

--- a/ares/n64/cpu/cpu.cpp
+++ b/ares/n64/cpu/cpu.cpp
@@ -176,6 +176,10 @@ auto CPU::instructionPrologue(u64 address, u32 instruction) -> void {
   debugger.instruction(address, instruction);
 }
 
+auto CPU::icacheFillLine(u64 vaddr, u32 paddr) -> void {
+  icache.line(vaddr).fill(paddr, *this);
+}
+
 template<bool Recompiled>
 auto CPU::instructionEpilogue() -> void {
   if constexpr(!Recompiled) {

--- a/ares/n64/cpu/cpu.hpp
+++ b/ares/n64/cpu/cpu.hpp
@@ -46,6 +46,7 @@ struct CPU : Thread {
   auto instructionPrologue(u64 address, u32 instruction) -> void;
   template<bool Recompiled> auto instructionEpilogue() -> void;
   auto raiseCoprocessor1Exception() -> void;
+  auto icacheFillLine(u64 vaddr, u32 paddr) -> void;
 
   auto power(bool reset) -> void;
 
@@ -1057,6 +1058,9 @@ struct CPU : Thread {
 
       auto watchpointsActive() const -> bool { return data.bit(25); }
       auto setWatchpointsActive(bool value) -> void { data.bit(25) = value; }
+
+      auto rdramMapIdentity() const -> bool { return data.bit(26); }
+      auto setRdramMapIdentity(bool value) -> void { data.bit(26) = value; }
 
       n64 data = 0;
     };

--- a/ares/n64/cpu/recompiler-ipu.cpp
+++ b/ares/n64/cpu/recompiler-ipu.cpp
@@ -92,7 +92,8 @@ auto CPU::Recompiler::jitMemoryOpcode(u32 instruction, u32 size, u32 mode,
   }
   if(emitSlowPath || emitStateKey.watchpointsActive() || (require64 && reservedInstruction64())
   || (store && size == Dual && (partialLeft || partialRight) && system.homebrewMode)
-  || (floating && !emitStateKey.coprocessor1Enabled())) {
+  || (floating && !emitStateKey.coprocessor1Enabled())
+  || !emitStateKey.rdramMapIdentity()) {
     return fallback();
   }
 

--- a/ares/n64/cpu/recompiler.cpp
+++ b/ares/n64/cpu/recompiler.cpp
@@ -101,7 +101,8 @@ computeStateKey() includes:
 - privilege and addressing-mode context;
 - floating-point mode and exception-control bits;
 - watchpoint activity;
-- GP/SP-derived predicates used by memory fast paths.
+- GP/SP-derived predicates used by memory fast paths;
+- RDRAM DeviceId identity mapping (direct ram.data access is only safe when true).
 
 Lookup identity uses both stateKey and vaddrPage. Using both is important:
 different virtual mappings can share the same physical cache section, but still
@@ -257,6 +258,7 @@ auto CPU::Recompiler::computeStateKey() const -> u64 {
   stateKey.setSpAligned4((sp & 3) == 0);
   stateKey.setSpAligned8((sp & 7) == 0);
   stateKey.setWatchpointsActive(GDB::server.hasWatchpoints());
+  stateKey.setRdramMapIdentity(rdram.mapIdentity);
   return stateKey;
 }
 
@@ -810,19 +812,23 @@ auto CPU::Recompiler::emit(u64 vaddr, u32 address, u64 stateKey) -> Block* {
       const u32 lineIndex = u32(slow.vaddr >> 5) & 0x1ffu;
       const u32 burst = (slow.icachePaddr & ~0xfffu) | ((lineIndex << 5) & 0xfe0u);
       const u32 tagKey = (slow.icachePaddr & ~0xfffu) | 1u;
-      const bool sdram = Model::Aleck64() && burst > 0xbfff'ffffu;
-      const sljit_sw ramDataField = sdram ? (sljit_sw)(uintptr_t)&aleck64.sdram.data
-                                           : (sljit_sw)(uintptr_t)&rdram.ram.data;
-      const u32 ramByteOff = sdram ? (burst & 0xffffffu) : burst;
-      if(system.homebrewMode) {
-        add64(ProfileIcacheMissesMem, ProfileIcacheMissesMem, imm(1));
-        if(!sdram) add64(mem0(RdramRbusIcacheReadsAddr), mem0(RdramRbusIcacheReadsAddr), imm(ICache));
+      if(!emitStateKey.rdramMapIdentity()) {
+        callf(&CPU::icacheFillLine, imm64(slow.vaddr), imm(slow.icachePaddr));
+      } else {
+        const bool sdram = Model::Aleck64() && burst > 0xbfff'ffffu;
+        const sljit_sw ramDataField = sdram ? (sljit_sw)(uintptr_t)&aleck64.sdram.data
+                                             : (sljit_sw)(uintptr_t)&rdram.ram.data;
+        const u32 ramByteOff = sdram ? (burst & 0xffffffu) : burst;
+        if(system.homebrewMode) {
+          add64(ProfileIcacheMissesMem, ProfileIcacheMissesMem, imm(1));
+          if(!sdram) add64(mem0(RdramRbusIcacheReadsAddr), mem0(RdramRbusIcacheReadsAddr), imm(ICache));
+        }
+        emitCpuStep(96);
+        mov32(IcacheTagKeyMem(lineIndex), imm(tagKey));
+        mov64(reg(1), mem0(ramDataField));
+        mov128(IcacheLineWordsMem(lineIndex, 0x00), mem(reg(1), sljit_sw(ramByteOff + 0x00)));
+        mov128(IcacheLineWordsMem(lineIndex, 0x10), mem(reg(1), sljit_sw(ramByteOff + 0x10)));
       }
-      emitCpuStep(96);
-      mov32(IcacheTagKeyMem(lineIndex), imm(tagKey));
-      mov64(reg(1), mem0(ramDataField));
-      mov128(IcacheLineWordsMem(lineIndex, 0x00), mem(reg(1), sljit_sw(ramByteOff + 0x00)));
-      mov128(IcacheLineWordsMem(lineIndex, 0x10), mem(reg(1), sljit_sw(ramByteOff + 0x10)));
     } else {
       // Generic opcode slow path.
       emitPcMode = slow.runtimePc ? EmitPcMode::Runtime : EmitPcMode::JitTime;

--- a/ares/n64/memory/bus.hpp
+++ b/ares/n64/memory/bus.hpp
@@ -2,8 +2,7 @@ template<u32 Size>
 inline auto Bus::read(u32 address, Thread& thread, RBusDevice device) -> u64 {
   static_assert(Size == Byte || Size == Half || Size == Word || Size == Dual);
 
-  if(address <= 0x03ef'ffff) return rdram.ram.read<Size>(address, device);
-  if(address <= 0x03ff'ffff) return rdram.read<Size>(address, thread);
+  if(address <= 0x03ff'ffff) return mi.readRdram<Size>(address, device, thread);
   if(Size == Dual)           return freezeDualRead(address), 0;
   if(address <= 0x0407'ffff) return rsp.read<Size>(address, thread);
   if(address <= 0x040b'ffff) return rsp.status.read<Size>(address, thread);
@@ -31,21 +30,7 @@ inline auto Bus::readBurst(u32 address, u32 *data, Thread& thread) -> bool {
   if constexpr(Size == DCache) device = RBusDevice::VR4300_DCACHE;
   if constexpr(Size == ICache) device = RBusDevice::VR4300_ICACHE;
 
-  if(address <= 0x03ef'ffff) return rdram.ram.readBurst<Size>(address, data, device), true;
-  if(address <= 0x03ff'ffff) {
-    // FIXME: not hardware validated, no idea of the behavior
-    data[0] = rdram.readWord(address | 0x0, thread);
-    data[1] = 0;
-    data[2] = 0;
-    data[3] = 0;
-    if constexpr(Size == ICache) {
-      data[4] = 0;
-      data[5] = 0;
-      data[6] = 0;
-      data[7] = 0;
-    }
-    return true;
-  }
+  if(address <= 0x03ff'ffff) return mi.readRdramBurst<Size>(address, data, device, thread), true;
 
   if(Model::Aleck64()) {
     if(address <= 0xbfff'ffff) return freezeUncached(address), false;
@@ -62,8 +47,7 @@ inline auto Bus::write(u32 address, u64 data, Thread& thread, RBusDevice device)
     cpu.recompiler.invalidateRange(address, Size);
   }
 
-  if(address <= 0x03ef'ffff) return rdram.ram.write<Size>(address, data, device);
-  if(address <= 0x03ff'ffff) return rdram.write<Size>(address, data, thread);
+  if(address <= 0x03ff'ffff) return mi.writeRdram<Size>(address, data, device, thread);
   if(address <= 0x0407'ffff) return rsp.write<Size>(address, data, thread);
   if(address <= 0x040b'ffff) return rsp.status.write<Size>(address, data, thread);
   if(address <= 0x040f'ffff) return freezeUnmapped(address);
@@ -94,12 +78,7 @@ inline auto Bus::writeBurst(u32 address, u32 *data, Thread& thread) -> bool {
     cpu.recompiler.invalidateRange(address, Size == DCache ? 16 : 32);
   }
 
-  if(address <= 0x03ef'ffff) return rdram.ram.writeBurst<Size>(address, data, device), true;
-  if(address <= 0x03ff'ffff) {
-    // FIXME: not hardware validated, but a good guess
-    rdram.writeWord(address | 0x0, data[0], thread);
-    return true;
-  }
+  if(address <= 0x03ff'ffff) return mi.writeRdramBurst<Size>(address, data, device, thread), true;
 
   if(Model::Aleck64()) {
     if(address <= 0xbfff'ffff) return freezeUncached(address), false;

--- a/ares/n64/mi/bus.hpp
+++ b/ares/n64/mi/bus.hpp
@@ -1,0 +1,133 @@
+template<u32 Size>
+inline auto MI::readRdram(u32 address, RBusDevice device, Thread& thread) -> u64 {
+  if(address <= 0x03ef'ffff) {
+    if(unlikely(io.ebusTestMode) && device == RBusDevice::VR4300_UNCACHED)
+      return rdram.ram.ebusRead<Size>(address);
+    return rdram.ram.read<Size>(address, device);
+  }
+
+  u64 data = rdram.read<Size>(address, thread);
+  if(device == RBusDevice::VR4300_UNCACHED && !io.rdramRegisterSelect && (address & 4)) data = 0;
+  return data;
+}
+
+template<u32 Size>
+inline auto MI::writeRdramRepeat(u32 address, u64 value) -> void {
+  u8 length = io.repeatLength + 1;
+
+  if constexpr(Size == Byte) {
+    value = value & (0xFFFFFFFF >> (24 - (address & 3) * 8));
+    value = (u32)((value << 24) | (value >> 8));
+  } else if constexpr(Size == Half) {
+    value = value & (0xFFFFFFFF >> (16 - (address & 2) * 8));
+    value = (u32)((value << 16) | (value >> 16));
+  }
+  if constexpr(Size != Dual)
+    value = (value << 32) | (u32)value;
+
+  const u32 end = min((address & ~7) + length, rdram.ram.size);
+  if(end <= address) return;
+  length = end - address;
+
+  if(address & 1) {
+    rdram.ram.write<Byte>(address, value >> 56, RBusDevice::VR4300_UNCACHED);
+    value = (value << 8) | (value >> 56);
+    address = (address & ~0x7FF) | ((address + 1) & 0x7FF);
+    length -= 1;
+  }
+  if((address & 2) && length >= 2) {
+    rdram.ram.write<Half>(address, value >> 48, RBusDevice::VR4300_UNCACHED);
+    value = (value << 16) | (value >> 48);
+    address = (address & ~0x7FF) | ((address + 2) & 0x7FF);
+    length -= 2;
+  }
+  if((address & 4) && length >= 4) {
+    rdram.ram.write<Word>(address, value >> 32, RBusDevice::VR4300_UNCACHED);
+    value = (value << 32) | (value >> 32);
+    address = (address & ~0x7FF) | ((address + 4) & 0x7FF);
+    length -= 4;
+  }
+
+  while(length >= 8) {
+    rdram.ram.write<Dual>(address, value, RBusDevice::VR4300_UNCACHED);
+    address = (address & ~0x7FF) | ((address + 8) & 0x7FF);
+    length -= 8;
+  }
+  if(length >= 4) {
+    rdram.ram.write<Word>(address, value >> 32, RBusDevice::VR4300_UNCACHED);
+    value <<= 32;
+    address += 4;
+    length -= 4;
+  }
+  if(length >= 2) {
+    rdram.ram.write<Half>(address, value >> 48, RBusDevice::VR4300_UNCACHED);
+    value <<= 16;
+    address += 2;
+    length -= 2;
+  }
+  if(length == 1)
+    rdram.ram.write<Byte>(address, value >> 56, RBusDevice::VR4300_UNCACHED);
+}
+
+template<u32 Size>
+inline auto MI::writeRdram(u32 address, u64 value, RBusDevice device, Thread& thread) -> void {
+  n1 repeat = 0;
+  if(device == RBusDevice::VR4300_UNCACHED && unlikely(io.repeatMode)) {
+    io.repeatMode = 0;
+    repeat = 1;
+  }
+
+  if(address <= 0x03ef'ffff) {
+    if(repeat) return writeRdramRepeat<Size>(address, value);
+    if(unlikely(io.ebusTestMode) && device == RBusDevice::VR4300_UNCACHED)
+      return rdram.ram.ebusWrite<Size>(address, value);
+    return rdram.ram.write<Size>(address, value, device);
+  }
+
+  if(repeat) {
+    u32 word = value;
+    if constexpr(Size == Byte) word = (u32)value << (24 - 8 * (address & 3));
+    if constexpr(Size == Half) word = (u32)value << (16 - 8 * (address & 2));
+    if constexpr(Size == Dual) word = value >> 32;
+    return rdram.writeWord(address, word, thread, io.repeatLength + 1);
+  }
+  rdram.write<Size>(address, value, thread);
+}
+
+template<u32 Size>
+inline auto MI::readRdramBurst(u32 address, u32* data, RBusDevice device, Thread& thread) -> void {
+  if(unlikely(io.ebusTestMode)) return ebusFreeze();
+
+  if(address <= 0x03ef'ffff) {
+    rdram.ram.readBurst<Size>(address, data, device);
+    return;
+  }
+
+  data[0] = rdram.readWord(address | 0x0, thread);
+  data[1] = 0;
+  data[2] = 0;
+  data[3] = 0;
+  if constexpr(Size == ICache) {
+    data[4] = 0;
+    data[5] = 0;
+    data[6] = 0;
+    data[7] = 0;
+  }
+}
+
+template<u32 Size>
+inline auto MI::writeRdramBurst(u32 address, u32* data, RBusDevice device, Thread& thread) -> void {
+  if(unlikely(io.ebusTestMode)) return ebusFreeze();
+
+  if(address <= 0x03ef'ffff) {
+    rdram.ram.writeBurst<Size>(address, data, device);
+    return;
+  }
+
+  rdram.writeWord(address | 0x0, data[0], thread);
+}
+
+inline auto MI::ebusFreeze() -> void {
+  debug(unusual, "[MI] cached RDRAM access while ebus mode is enabled; console hangs");
+  cpu.scc.sysadFrozen = true;
+}

--- a/ares/n64/mi/io.cpp
+++ b/ares/n64/mi/io.cpp
@@ -3,9 +3,9 @@ auto MI::readWord(u32 address, Thread& thread) -> u32 {
   n32 data;
 
   if(address == 0) {
-    //MI_INIT_MODE
-    data.bit(0,6) = io.initializeLength;
-    data.bit(7)   = io.initializeMode;
+    //MI_MODE
+    data.bit(0,6) = io.repeatLength;
+    data.bit(7)   = io.repeatMode;
     data.bit(8)   = io.ebusTestMode;
     data.bit(9)   = io.rdramRegisterSelect;
   }
@@ -47,17 +47,15 @@ auto MI::writeWord(u32 address, u32 data_, Thread& thread) -> void {
   n32 data = data_;
 
   if(address == 0) {
-    //MI_INIT_MODE
-    io.initializeLength = data.bit(0,6);
-    if(data.bit( 7)) io.initializeMode = 0;
-    if(data.bit( 8)) io.initializeMode = 1;
+    //MI_MODE
+    io.repeatLength = data.bit(0,6);
+    if(data.bit( 7)) io.repeatMode = 0;
+    if(data.bit( 8)) io.repeatMode = 1;
     if(data.bit( 9)) io.ebusTestMode = 0;
     if(data.bit(10)) io.ebusTestMode = 1;
     if(data.bit(11)) mi.lower(MI::IRQ::DP);
     if(data.bit(12)) io.rdramRegisterSelect = 0;
     if(data.bit(13)) io.rdramRegisterSelect = 1;
-
-    if(io.ebusTestMode  ) debug(unimplemented, "[MI::writeWord] ebusTestMode=1");
   }
 
   if(address == 1) {

--- a/ares/n64/mi/mi.hpp
+++ b/ares/n64/mi/mi.hpp
@@ -29,9 +29,14 @@ struct MI : Memory::RCP<MI> {
   //io.cpp
   auto readWord(u32 address, Thread& thread) -> u32;
   auto writeWord(u32 address, u32 data, Thread& thread) -> void;
-  auto initializeMode() -> bool { bool m = io.initializeMode; io.initializeMode = 0; return m; }
-  auto initializeLength() -> n7 { return io.initializeLength; }
-  auto upperMode() const -> bool { return io.rdramRegisterSelect; }
+
+  //bus.hpp
+  template<u32 Size> auto readRdram(u32 address, RBusDevice device, Thread& thread) -> u64;
+  template<u32 Size> auto writeRdram(u32 address, u64 value, RBusDevice device, Thread& thread) -> void;
+  template<u32 Size> auto writeRdramRepeat(u32 address, u64 value) -> void;
+  template<u32 Size> auto readRdramBurst(u32 address, u32* data, RBusDevice device, Thread& thread) -> void;
+  template<u32 Size> auto writeRdramBurst(u32 address, u32* data, RBusDevice device, Thread& thread) -> void;
+  auto ebusFreeze() -> void;
 
   //serialization.cpp
   auto serialize(serializer&) -> void;
@@ -52,8 +57,8 @@ private:
   } irq;
 
   struct IO {
-    n7 initializeLength;
-    n1 initializeMode;
+    n7 repeatLength;
+    n1 repeatMode;
     n1 ebusTestMode;
     n1 rdramRegisterSelect;
   } io;

--- a/ares/n64/mi/mi.hpp
+++ b/ares/n64/mi/mi.hpp
@@ -31,6 +31,7 @@ struct MI : Memory::RCP<MI> {
   auto writeWord(u32 address, u32 data, Thread& thread) -> void;
   auto initializeMode() -> bool { bool m = io.initializeMode; io.initializeMode = 0; return m; }
   auto initializeLength() -> n7 { return io.initializeLength; }
+  auto upperMode() const -> bool { return io.rdramRegisterSelect; }
 
   //serialization.cpp
   auto serialize(serializer&) -> void;

--- a/ares/n64/mi/serialization.cpp
+++ b/ares/n64/mi/serialization.cpp
@@ -12,8 +12,8 @@ auto MI::serialize(serializer& s) -> void {
   s(irq.dp.line);
   s(irq.dp.mask);
 
-  s(io.initializeLength);
-  s(io.initializeMode);
+  s(io.repeatLength);
+  s(io.repeatMode);
   s(io.ebusTestMode);
   s(io.rdramRegisterSelect);
 }

--- a/ares/n64/n64.hpp
+++ b/ares/n64/n64.hpp
@@ -143,5 +143,6 @@ namespace ares::Nintendo64 {
   #include <n64/rsp/rsp.hpp>
   #include <n64/rdp/rdp.hpp>
   #include <n64/memory/bus.hpp>
+  #include <n64/mi/bus.hpp>
   #include <n64/pi/bus.hpp>
 }

--- a/ares/n64/n64.hpp
+++ b/ares/n64/n64.hpp
@@ -118,7 +118,6 @@ namespace ares::Nintendo64 {
     //Virtual devices (internal to Ares)
     ARES_DEBUGGER = NUM_RBUS_HW_DEVICES,
     ARES_JIT,
-    ARES_IPL3,
     ARES_FLASH,
 
     NUM_RBUS_DEVICES,

--- a/ares/n64/rdp/io.cpp
+++ b/ares/n64/rdp/io.cpp
@@ -197,6 +197,12 @@ auto RDP::flushCommands() -> void {
   command.bufferBusy = 1;
   command.pipeBusy = 1;
   command.startGclk = 1;
-  if(command.end > command.current) render();
+  if(command.end > command.current) {
+    if(!mapIdentityWarned && !rdram.mapIdentity) {
+      debug(unusual, "[RDP] started while RDRAM DeviceId map is non-identity");
+      mapIdentityWarned = 1;
+    }
+    render();
+  }
   command.ready = 1;
 }

--- a/ares/n64/rdp/rdp.cpp
+++ b/ares/n64/rdp/rdp.cpp
@@ -60,6 +60,7 @@ auto RDP::power(bool reset) -> void {
   fillRectangle_ = {};
   io.bist = {};
   io.test = {};
+  if(!reset) mapIdentityWarned = 0;
 }
 
 }

--- a/ares/n64/rdp/rdp.hpp
+++ b/ares/n64/rdp/rdp.hpp
@@ -353,6 +353,8 @@ struct RDP : Thread, Memory::RCP<RDP> {
     } test;
 
   } io{*this};
+
+  n1 mapIdentityWarned;
 };
 
 extern RDP rdp;

--- a/ares/n64/rdram/hidden.hpp
+++ b/ares/n64/rdram/hidden.hpp
@@ -1,0 +1,83 @@
+struct HiddenRAM {
+  u8* data = nullptr;
+
+  auto nibble(u32 address) -> u32 {
+    u8* h = &data[address >> 1];
+    return (h[0] & 3) << 2 | (h[1] & 3);
+  }
+
+  auto writeBit(u32 address, n1 value) -> void {
+    u32 shift = 1 - (address & 1);
+    u8& h = data[address >> 1];
+    h = (h & ~(1 << shift)) | (value << shift);
+  }
+
+  template<u32 Size>
+  auto update(u32 address, u64 value) -> void {
+    u8* h = &data[address >> 1];
+    if constexpr(Size == Byte) {
+      if(address & 1) writeBit(address, value & 1);
+      else            writeBit(address, 0);
+    }
+    if constexpr(Size == Half) h[0] = (value & 1) * 3;
+    if constexpr(Size == Word) {
+      u16 packed = (value >> 16 & 1) * 3 | ((value & 1) * 3) << 8;
+      memory::writel<2>(h, packed);
+    }
+    if constexpr(Size == Dual) {
+      u32 packed = (u32)((value >> 48 & 1) * 3) <<  0
+                 | (u32)((value >> 32 & 1) * 3) <<  8
+                 | (u32)((value >> 16 & 1) * 3) << 16
+                 | (u32)((value >>  0 & 1) * 3) << 24;
+      memory::writel<4>(h, packed);
+    }
+  }
+
+  template<u32 Size>
+  auto ebusScatter(u32 address, u64 value) -> void {
+    if constexpr(Size == Byte) {
+      writeBit(address, (address & 3) == 3 ? value & 1 : 0);
+    }
+    if constexpr(Size == Half) {
+      if(address & 2) {
+        writeBit(address + 0, value >> 1 & 1);
+        writeBit(address + 1, value >> 0 & 1);
+      } else {
+        writeBit(address + 0, 0);
+        writeBit(address + 1, 0);
+      }
+    }
+    if constexpr(Size == Word) {
+      writeBit(address + 0, value >> 3 & 1);
+      writeBit(address + 1, value >> 2 & 1);
+      writeBit(address + 2, value >> 1 & 1);
+      writeBit(address + 3, value >> 0 & 1);
+    }
+    if constexpr(Size == Dual) {
+      ebusScatter<Word>(address + 0, value >> 32);
+      ebusScatter<Word>(address + 4, value >>  0);
+    }
+  }
+
+  auto updateWords4(u32 address, const u32* value) -> void {
+    #if ARCHITECTURE_SUPPORTS_SSE4_1
+    __m128i v = _mm_loadu_si128((const __m128i*)value);
+    __m128i m = _mm_and_si128(v, _mm_set1_epi16(1));
+    m = _mm_or_si128(m, _mm_slli_epi16(m, 1));
+    static const __m128i sel = _mm_setr_epi8(2, 0, 6, 4, 10, 8, 14, 12, -1, -1, -1, -1, -1, -1, -1, -1);
+    _mm_storel_epi64((__m128i*)&data[address >> 1], _mm_shuffle_epi8(m, sel));
+    #else
+    u8* h = &data[address >> 1];
+    for(u32 n : range(4)) {
+      h[n * 2 + 0] = (value[n] >> 16 & 1) * 3;
+      h[n * 2 + 1] = (value[n] >>  0 & 1) * 3;
+    }
+    #endif
+  }
+
+  template<u32 Size>
+  auto updateBurst(u32 address, const u32* value) -> void {
+    updateWords4(address, value);
+    if constexpr(Size == ICache) updateWords4(address + 16, value + 4);
+  }
+};

--- a/ares/n64/rdram/io.cpp
+++ b/ares/n64/rdram/io.cpp
@@ -16,11 +16,6 @@ auto RDRAM::readWord(u32 address, Thread& thread) -> u32 {
   }
 
   u32 index = (offset >> 2) & 15;
-  if((index & 1) && !mi.upperMode()) {
-    debugger.io(Read, select, index, 0);
-    return 0;
-  }
-
   auto chip = selectChip(select, false);
   if(!chip) {
     debugger.io(Read, select, index, 0);
@@ -32,11 +27,10 @@ auto RDRAM::readWord(u32 address, Thread& thread) -> u32 {
   return data;
 }
 
-auto RDRAM::writeWord(u32 address, u32 data, Thread& thread) -> void {
+auto RDRAM::writeWord(u32 address, u32 data, Thread& thread, u8 repeatLength) -> void {
   n1 broadcast = address >> 19 & 1;
   u32 select = address >> 10 & 0x1ff;
   u32 offset = address & 0x3ff;
-  n1 repeat = mi.initializeMode();
 
   if(!ri.active()) return;
 
@@ -57,7 +51,7 @@ auto RDRAM::writeWord(u32 address, u32 data, Thread& thread) -> void {
   if(broadcast) {
     for(auto& chip : chips) {
       if(!chip.present) continue;
-      writeRegister(chip, index, data, repeat);
+      writeRegister(chip, index, data, repeatLength);
     }
     debugger.io(Write, 0xff, index, data);
     return;
@@ -66,6 +60,6 @@ auto RDRAM::writeWord(u32 address, u32 data, Thread& thread) -> void {
   auto chip = selectChip(select, false);
   if(!chip) return;
 
-  writeRegister(*chip, index, data, repeat);
+  writeRegister(*chip, index, data, repeatLength);
   debugger.io(Write, chipIndex(chip), index, data);
 }

--- a/ares/n64/rdram/io.cpp
+++ b/ares/n64/rdram/io.cpp
@@ -1,127 +1,71 @@
 auto RDRAM::readWord(u32 address, Thread& thread) -> u32 {
-  u32 chipID = address >> 13 & 3;
-  auto& chip = chips[chipID];
-  address = (address & 0x3ff) >> 2;
-  u32 data = 0;
+  n1 broadcast = address >> 19 & 1;
+  u32 select = address >> 10 & 0x1ff;
+  u32 offset = address & 0x3ff;
 
-  if(address == 0) {
-    //RDRAM_DEVICE_TYPE
-    data = chip.deviceType;
+  if(broadcast || !ri.active()) {
+    debugger.io(Read, select, 0, 0);
+    return 0;
   }
 
-  if(address == 1) {
-    //RDRAM_DEVICE_ID
-    data = chip.deviceID;
+  if(offset >= 0x200) {
+    auto chip = selectChip(select, false);
+    u32 data = chip ? (u32)chip->row : 0;
+    debugger.io(Read, chip ? chipIndex(chip) : select, 10, data);
+    return data;
   }
 
-  if(address == 2) {
-    //RDRAM_DELAY
-    data = chip.delay;
+  u32 index = (offset >> 2) & 15;
+  if((index & 1) && !mi.upperMode()) {
+    debugger.io(Read, select, index, 0);
+    return 0;
   }
 
-  if(address == 3) {
-    //RDRAM_MODE
-    data = chip.mode ^ 0xc0c0c0c0;
+  auto chip = selectChip(select, false);
+  if(!chip) {
+    debugger.io(Read, select, index, 0);
+    return 0;
   }
 
-  if(address == 4) {
-    //RDRAM_REF_INTERVAL
-    data = chip.refreshInterval;
-  }
-
-  if(address == 5) {
-    //RDRAM_REF_ROW
-    data = chip.refreshRow;
-  }
-
-  if(address == 6) {
-    //RDRAM_RAS_INTERVAL
-    data = chip.rasInterval;
-  }
-
-  if(address == 7) {
-    //RDRAM_MIN_INTERVAL
-    data = chip.minInterval;
-  }
-
-  if(address == 8) {
-    //RDRAM_ADDRESS_SELECT
-    data = chip.addressSelect;
-  }
-
-  if(address == 9) {
-    //RDRAM_DEVICE_MANUFACTURER
-    data = chip.deviceManufacturer;
-  }
-
-  if(address == 10) {
-    //RDRAM_CURRENT_CONTROL
-    data = chip.currentControl;
-  }
-
-  debugger.io(Read, chipID, address, data);
+  u32 data = readRegister(*chip, index);
+  debugger.io(Read, chipIndex(chip), index, data);
   return data;
 }
 
 auto RDRAM::writeWord(u32 address, u32 data, Thread& thread) -> void {
-  u32 chipID = address >> 13 & 3;
-  auto& chip = chips[chipID];
-  address = (address & 0x3ff) >> 2;
+  n1 broadcast = address >> 19 & 1;
+  u32 select = address >> 10 & 0x1ff;
+  u32 offset = address & 0x3ff;
+  n1 repeat = mi.initializeMode();
 
-  if(address == 0) {
-    //RDRAM_DEVICE_TYPE
-    chip.deviceType = data;
+  if(!ri.active()) return;
+
+  if(offset >= 0x200) {
+    if(broadcast) {
+      for(auto& chip : chips) {
+        if(chip.present) chip.row = data;
+      }
+    } else if(auto chip = selectChip(select, false)) {
+      chip->row = data;
+    }
+    debugger.io(Write, select, 10, data);
+    return;
   }
 
-  if(address == 1) {
-    //RDRAM_DEVICE_ID
-    chip.deviceID = data;
+  u32 index = (offset >> 2) & 15;
+
+  if(broadcast) {
+    for(auto& chip : chips) {
+      if(!chip.present) continue;
+      writeRegister(chip, index, data, repeat);
+    }
+    debugger.io(Write, 0xff, index, data);
+    return;
   }
 
-  if(address == 2) {
-    //RDRAM_DELAY
-    chip.delay = data;
-  }
+  auto chip = selectChip(select, false);
+  if(!chip) return;
 
-  if(address == 3) {
-    //RDRAM_MODE
-    chip.mode = data;
-  }
-
-  if(address == 4) {
-    //RDRAM_REF_INTERVAL
-    chip.refreshInterval = data;
-  }
-
-  if(address == 5) {
-    //RDRAM_REF_ROW
-    chip.refreshRow = data;
-  }
-
-  if(address == 6) {
-    //RDRAM_RAS_INTERVAL
-    chip.rasInterval = data;
-  }
-
-  if(address == 7) {
-    //RDRAM_MIN_INTERVAL
-    chip.minInterval = data;
-  }
-
-  if(address == 8) {
-    //RDRAM_ADDRESS_SELECT
-    chip.addressSelect = data;
-  }
-
-  if(address == 9) {
-    //RDRAM_DEVICE_MANUFACTURER
-    chip.deviceManufacturer = data;
-  }
-
-  if(address == 10) {
-    //RDRAM_CURRENT_CONTROL
-    chip.currentControl = data;
-  }
-
-  debugger.io(Write, chipID, address, data);
+  writeRegister(*chip, index, data, repeat);
+  debugger.io(Write, chipIndex(chip), index, data);
 }

--- a/ares/n64/rdram/rdram.cpp
+++ b/ares/n64/rdram/rdram.cpp
@@ -11,14 +11,12 @@ auto RDRAM::load(Node::Object parent) -> void {
   node = parent->append<Node::Object>("RDRAM");
 
   if(!system.expansionPak) {
-    //4MB internal
-    ram.allocate(4_MiB); 
+    ram.allocate(4_MiB);
   } else {
-    //4MB internal + 4MB expansion pak
     ram.allocate(4_MiB + 4_MiB);
   }
-  
-  debugger.load(node);                                                                                            
+
+  debugger.load(node);
 }
 
 auto RDRAM::unload() -> void {
@@ -30,9 +28,183 @@ auto RDRAM::unload() -> void {
 auto RDRAM::power(bool reset) -> void {
   if(!reset) {
     ram.fill();
-    for(auto& chip : chips) chip = {};
+    u32 count = system.expansionPak ? 4 : 2;
+    for(u32 n : range(4)) {
+      auto& chip = chips[n];
+      chip = {};
+      chip.present = n < count;
+      if(!chip.present) continue;
+      chip.deviceType = 0xb419'0010;
+      chip.deviceManufacturer = 0x0000'0500;
+      chip.delay = 0x0000'0023;  //WriteDelay=4, WriteBits=3
+      chip.writeDelay = 4;
+      chip.deviceID = 0;
+      chip.deviceIDReg = 0;
+      chip.ccLow = 8 + (random() & 3);
+      chip.ccHigh = 14 + (random() & 3);
+      if(chip.ccHigh <= chip.ccLow) chip.ccHigh = chip.ccLow + 1;
+    }
+    mapIdentity = 0;
   }
   profile = {};
+}
+
+auto RDRAM::decodeDeviceID(u32 value) -> u16 {
+  return (value >> 26 & 0x3f)
+       | (value >> 23 & 1) << 6
+       | (value >>  8 & 0xff) << 7
+       | (value >>  7 & 1) << 15;
+}
+
+auto RDRAM::decodeCCI(u32 mode_) -> n6 {
+  n32 mode = mode_;
+  n6 cci = 0;
+  cci.bit(0) = mode.bit( 6);
+  cci.bit(1) = mode.bit(14);
+  cci.bit(2) = mode.bit(22);
+  cci.bit(3) = mode.bit( 7);
+  cci.bit(4) = mode.bit(15);
+  cci.bit(5) = mode.bit(23);
+  return cci ^ 0x3f;
+}
+
+auto RDRAM::encodeCCI(n6 cci) -> u32 {
+  cci ^= 0x3f;
+  n32 value = 0;
+  value.bit( 6) = cci.bit(0);
+  value.bit(14) = cci.bit(1);
+  value.bit(22) = cci.bit(2);
+  value.bit( 7) = cci.bit(3);
+  value.bit(15) = cci.bit(4);
+  value.bit(23) = cci.bit(5);
+  return value;
+}
+
+auto RDRAM::updateMapping() -> void {
+  mapIdentity = 1;
+  for(u32 n : range(4)) {
+    auto& chip = chips[n];
+    if(!chip.present) continue;
+    if(!chip.enable || chip.deviceID != n * 2 || chip.cci < chip.ccHigh) {
+      mapIdentity = 0;
+      return;
+    }
+  }
+}
+
+auto RDRAM::chipIndex(Chip* chip) -> u32 {
+  return chip - chips;
+}
+
+auto RDRAM::selectChip(u32 select, bool broadcast) -> Chip* {
+  if(broadcast) return nullptr;
+  if(!ri.active()) return nullptr;
+
+  n1 seenDisabled = 0;
+  for(auto& chip : chips) {
+    if(!chip.present) continue;
+    n1 match = (chip.deviceID & ~1) == (select & ~1);
+    if(chip.enable) {
+      if(match) return &chip;
+    } else if(!seenDisabled) {
+      seenDisabled = 1;
+      if(match) return &chip;
+    }
+  }
+  return nullptr;
+}
+
+auto RDRAM::readRegister(Chip& chip, u32 index) -> u32 {
+  if(!chip.enable) return 0;
+  if(index >= 10) return 0;
+
+  u32 data = 0;
+  if(index == 0) data = chip.deviceType;
+  if(index == 1) data = chip.deviceIDReg;
+  if(index == 2) {
+    data = chip.delay;
+    data |= 3 << 24;
+    data |= 3 << 16;
+    data |= 2 <<  8;
+    data |= 3 <<  0;
+  }
+  if(index == 3) {
+    data = chip.mode & ~0x00c0c0c0;
+    n6 cci = chip.autoCurrent ? chip.ccInternal : decodeCCI(chip.mode);
+    data |= encodeCCI(cci);
+    data ^= 0xc0c0'c0c0;
+  }
+  if(index == 4) data = chip.refreshInterval;
+  if(index == 5) data = chip.refreshRow;
+  if(index == 6) data = chip.rasInterval;
+  if(index == 7) data = chip.minInterval;
+  if(index == 8) data = chip.addressSelect;
+  if(index == 9) data = chip.deviceManufacturer;
+  return data;
+}
+
+auto RDRAM::writeRegister(Chip& chip, u32 index, u32 data, bool repeat) -> void {
+  if(index >= 10) return;
+
+  if(chip.writeDelay != 1) {
+    if(repeat && mi.initializeLength() >= 15) {
+      data = data << 16 | data >> 16;
+    } else {
+      return;
+    }
+  }
+
+  if(index == 0) return;
+  if(index == 1) {
+    chip.deviceIDReg = data;
+    chip.deviceID = decodeDeviceID(data);
+  }
+  if(index == 2) {
+    chip.delay = data & 0x3838'1838;
+    chip.writeDelay = chip.delay >> 3 & 7;
+  }
+  if(index == 3) {
+    chip.mode = data;
+    n32 mode = data;
+    chip.enable = mode.bit(25);
+    chip.autoCurrent = mode.bit(31);
+    chip.cci = decodeCCI(data);
+    if(chip.autoCurrent) chip.ccInternal = chip.cci;
+  }
+  if(index == 4) chip.refreshInterval = data;
+  if(index == 5) chip.refreshRow = data;
+  if(index == 6) chip.rasInterval = data;
+  if(index == 7) chip.minInterval = data;
+  if(index == 8) chip.addressSelect = data;
+  if(index == 9) return;
+
+  updateMapping();
+}
+
+auto RDRAM::Writable::translate(u32 address) -> maybe<u32> {
+  if(!ri.active()) return nothing;
+  for(u32 n : range(4)) {
+    auto& chip = self.chips[n];
+    if(!chip.present || !chip.enable) continue;
+    if((chip.deviceID >> 1) != (address >> 21)) continue;
+    return n * 2_MiB + (address & 0x1f'ffff);
+  }
+  return nothing;
+}
+
+auto RDRAM::Writable::degrade(u32 address, u64 value, u32 chipIndex) -> u64 {
+  auto& chip = self.chips[chipIndex];
+  if(chip.cci >= chip.ccHigh) return value;
+  if(chip.cci <= chip.ccLow) return 0;
+
+  u32 span = chip.ccHigh - chip.ccLow;
+  u32 progress = (u32)(chip.cci - chip.ccLow) * 256 / span;
+  u64 result = 0;
+  for(u32 bit : range(64)) {
+    if(!((value >> bit) & 1)) continue;
+    if((random() & 255) < progress) result |= 1ull << bit;
+  }
+  return result;
 }
 
 }

--- a/ares/n64/rdram/rdram.cpp
+++ b/ares/n64/rdram/rdram.cpp
@@ -143,11 +143,11 @@ auto RDRAM::readRegister(Chip& chip, u32 index) -> u32 {
   return data;
 }
 
-auto RDRAM::writeRegister(Chip& chip, u32 index, u32 data, bool repeat) -> void {
+auto RDRAM::writeRegister(Chip& chip, u32 index, u32 data, u8 repeatLength) -> void {
   if(index >= 10) return;
 
   if(chip.writeDelay != 1) {
-    if(repeat && mi.initializeLength() >= 15) {
+    if(repeatLength >= 16) {
       data = data << 16 | data >> 16;
     } else {
       return;

--- a/ares/n64/rdram/rdram.hpp
+++ b/ares/n64/rdram/rdram.hpp
@@ -3,15 +3,52 @@
 struct RDRAM : Memory::RCP<RDRAM> {
   Node::Object node;
 
+  struct Chip {
+    n1  present;
+    n1  enable;
+    n1  autoCurrent;
+    n16 deviceID;
+    n3  writeDelay;
+    n6  cci;
+    n6  ccInternal;
+    n6  ccLow;
+    n6  ccHigh;
+    n32 deviceType;
+    n32 deviceIDReg;
+    n32 delay;
+    n32 mode;
+    n32 refreshInterval;
+    n32 refreshRow;
+    n32 rasInterval;
+    n32 minInterval;
+    n32 addressSelect;
+    n32 deviceManufacturer;
+    n32 currentControl;
+    n32 row;
+  };
+
   struct Writable : public Memory::Writable {
     RDRAM& self;
 
     Writable(RDRAM& self) : self(self) {}
 
+    auto translate(u32 address) -> maybe<u32>;
+    auto degrade(u32 address, u64 value, u32 chipIndex) -> u64;
+
     template<u32 Size>
     auto read(u32 address, RBusDevice device) -> u64 {
-      if (address >= size) return 0;
-      if (unlikely(system.homebrewMode)) {
+      if(unlikely(!self.mapIdentity)) {
+        auto mapped = translate(address);
+        if(!mapped) {
+          if(device < RBusDevice::NUM_RBUS_HW_DEVICES) ri.ackError();
+          return 0;
+        }
+        u32 chipIndex = mapped() / 2_MiB;
+        u64 value = Memory::Writable::read<Size>(mapped());
+        return degrade(mapped(), value, chipIndex);
+      }
+      if(address >= size) return 0;
+      if(unlikely(system.homebrewMode)) {
         self.debugger.readWord(address, Size, device);
         self.profile.metrics[(u32)device].reads += Size;
       }
@@ -31,58 +68,67 @@ struct RDRAM : Memory::RCP<RDRAM> {
         value = (value << 32) | (u32) value;
 
       const u32 end = min((address & ~7) + length, size);
-      if (end <= address)
-        return;
+      if(end <= address) return;
 
       length = end - address;
 
-      if (address & 1) {
+      if(address & 1) {
         Memory::Writable::write<Byte>(address, value >> 56);
         value = (value << 8) | (value >> 56);
         address = (address & ~0x7FF) | ((address + 1) & 0x7FF);
         length -= 1;
       }
-      if ((address & 2) && length >= 2) {
+      if((address & 2) && length >= 2) {
         Memory::Writable::write<Half>(address, value >> 48);
         value = (value << 16) | (value >> 48);
         address = (address & ~0x7FF) | ((address + 2) & 0x7FF);
         length -= 2;
       }
-      if ((address & 4) && length >= 4) {
+      if((address & 4) && length >= 4) {
         Memory::Writable::write<Word>(address, value >> 32);
         value = (value << 32) | (value >> 32);
         address = (address & ~0x7FF) | ((address + 4) & 0x7FF);
         length -= 4;
       }
 
-      while (length >= 8) {
+      while(length >= 8) {
         Memory::Writable::write<Dual>(address, value);
         address = (address & ~0x7FF) | ((address + 8) & 0x7FF);
         length -= 8;
       }
-      if (length >= 4) {
+      if(length >= 4) {
         Memory::Writable::write<Word>(address, value >> 32);
         value <<= 32;
         address += 4;
         length -= 4;
       }
-      if (length >= 2) {
+      if(length >= 2) {
         Memory::Writable::write<Half>(address, value >> 48);
         value <<= 16;
         address += 2;
         length -= 2;
       }
-      if (length == 1)
+      if(length == 1)
         Memory::Writable::write<Byte>(address, value >> 56);
     }
 
     template<u32 Size>
     auto write(u32 address, u64 value, RBusDevice device) -> void {
-      if (address >= size) return;
-      if (unlikely(system.homebrewMode)) {
+      if(unlikely(!self.mapIdentity)) {
+        auto mapped = translate(address);
+        if(!mapped) {
+          if(device < RBusDevice::NUM_RBUS_HW_DEVICES) ri.ackError();
+          mi.initializeMode();
+          return;
+        }
+        address = mapped();
+      } else {
+        if(address >= size) return;
+      }
+      if(unlikely(system.homebrewMode)) {
         self.debugger.writeWord(address, Size, value, device);
       }
-      if (unlikely(mi.initializeMode())) {
+      if(unlikely(mi.initializeMode())) {
         u32 len = mi.initializeLength() + 1;
         writeRepeat<Size>(address, value, len);
         if(unlikely(system.homebrewMode)) {
@@ -98,15 +144,24 @@ struct RDRAM : Memory::RCP<RDRAM> {
 
     template<u32 Size>
     auto writeBurst(u32 address, u32 *value, RBusDevice device) -> void {
-      if (address >= size) return;
-      if (unlikely(system.homebrewMode)) {
+      if(unlikely(!self.mapIdentity)) {
+        auto mapped = translate(address);
+        if(!mapped) {
+          if(device < RBusDevice::NUM_RBUS_HW_DEVICES) ri.ackError();
+          return;
+        }
+        address = mapped();
+      } else {
+        if(address >= size) return;
+      }
+      if(unlikely(system.homebrewMode)) {
         self.profile.metrics[(u32)device].writes += Size;
       }
       Memory::Writable::write<Word>(address | 0x00, value[0]);
       Memory::Writable::write<Word>(address | 0x04, value[1]);
       Memory::Writable::write<Word>(address | 0x08, value[2]);
       Memory::Writable::write<Word>(address | 0x0c, value[3]);
-      if (Size == ICache) {
+      if(Size == ICache) {
         Memory::Writable::write<Word>(address | 0x10, value[4]);
         Memory::Writable::write<Word>(address | 0x14, value[5]);
         Memory::Writable::write<Word>(address | 0x18, value[6]);
@@ -116,20 +171,41 @@ struct RDRAM : Memory::RCP<RDRAM> {
 
     template<u32 Size>
     auto readBurst(u32 address, u32 *value, RBusDevice device) -> void {
-      if (address >= size) {
-        value[0] = value[1] = value[2] = value[3] = 0;
-        if (Size == ICache)
-          value[4] = value[5] = value[6] = value[7] = 0;
+      if(unlikely(!self.mapIdentity)) {
+        auto mapped = translate(address);
+        if(!mapped) {
+          if(device < RBusDevice::NUM_RBUS_HW_DEVICES) ri.ackError();
+          value[0] = value[1] = value[2] = value[3] = 0;
+          if(Size == ICache) value[4] = value[5] = value[6] = value[7] = 0;
+          return;
+        }
+        u32 chipIndex = mapped() / 2_MiB;
+        address = mapped();
+        value[0] = degrade(address | 0x00, Memory::Writable::read<Word>(address | 0x00), chipIndex);
+        value[1] = degrade(address | 0x04, Memory::Writable::read<Word>(address | 0x04), chipIndex);
+        value[2] = degrade(address | 0x08, Memory::Writable::read<Word>(address | 0x08), chipIndex);
+        value[3] = degrade(address | 0x0c, Memory::Writable::read<Word>(address | 0x0c), chipIndex);
+        if(Size == ICache) {
+          value[4] = degrade(address | 0x10, Memory::Writable::read<Word>(address | 0x10), chipIndex);
+          value[5] = degrade(address | 0x14, Memory::Writable::read<Word>(address | 0x14), chipIndex);
+          value[6] = degrade(address | 0x18, Memory::Writable::read<Word>(address | 0x18), chipIndex);
+          value[7] = degrade(address | 0x1c, Memory::Writable::read<Word>(address | 0x1c), chipIndex);
+        }
         return;
       }
-      if (unlikely(system.homebrewMode)) {
+      if(address >= size) {
+        value[0] = value[1] = value[2] = value[3] = 0;
+        if(Size == ICache) value[4] = value[5] = value[6] = value[7] = 0;
+        return;
+      }
+      if(unlikely(system.homebrewMode)) {
         self.profile.metrics[(u32)device].reads += Size;
       }
       value[0] = Memory::Writable::read<Word>(address | 0x00);
       value[1] = Memory::Writable::read<Word>(address | 0x04);
       value[2] = Memory::Writable::read<Word>(address | 0x08);
       value[3] = Memory::Writable::read<Word>(address | 0x0c);
-      if (Size == ICache) {
+      if(Size == ICache) {
         value[4] = Memory::Writable::read<Word>(address | 0x10);
         value[5] = Memory::Writable::read<Word>(address | 0x14);
         value[6] = Memory::Writable::read<Word>(address | 0x18);
@@ -175,7 +251,7 @@ struct RDRAM : Memory::RCP<RDRAM> {
       case RBusDevice::DP_DRAW:         return "DP Draw";
       case RBusDevice::ARES_DEBUGGER:   return "Ares Debugger";
       case RBusDevice::ARES_JIT:        return "Ares JIT";
-      case RBusDevice::ARES_IPL3:       return "Ares IPL3";
+      case RBusDevice::ARES_FLASH:      return "Ares Flash";
       default:                          return "Unknown";
     }
   }
@@ -184,7 +260,7 @@ struct RDRAM : Memory::RCP<RDRAM> {
     u64 reads, writes;
     auto total() const -> u64 { return reads + writes; }
   };
-  
+
   struct Profile {
     Metric metrics[(u32)RBusDevice::NUM_RBUS_DEVICES];
 
@@ -201,6 +277,14 @@ struct RDRAM : Memory::RCP<RDRAM> {
   auto load(Node::Object) -> void;
   auto unload() -> void;
   auto power(bool reset) -> void;
+  auto updateMapping() -> void;
+  auto decodeDeviceID(u32 value) -> u16;
+  auto decodeCCI(u32 mode) -> n6;
+  auto encodeCCI(n6 cci) -> u32;
+  auto selectChip(u32 select, bool broadcast) -> Chip*;
+  auto chipIndex(Chip* chip) -> u32;
+  auto readRegister(Chip& chip, u32 index) -> u32;
+  auto writeRegister(Chip& chip, u32 index, u32 data, bool repeat) -> void;
 
   //io.cpp
   auto readWord(u32 address, Thread& thread) -> u32;
@@ -209,19 +293,8 @@ struct RDRAM : Memory::RCP<RDRAM> {
   //serialization.cpp
   auto serialize(serializer&) -> void;
 
-  struct Chip {
-    n32 deviceType;
-    n32 deviceID;
-    n32 delay;
-    n32 mode;
-    n32 refreshInterval;
-    n32 refreshRow;
-    n32 rasInterval;
-    n32 minInterval;
-    n32 addressSelect;
-    n32 deviceManufacturer;
-    n32 currentControl;
-  } chips[4];
+  Chip chips[4];
+  n1 mapIdentity = 0;
 };
 
 extern RDRAM rdram;

--- a/ares/n64/rdram/rdram.hpp
+++ b/ares/n64/rdram/rdram.hpp
@@ -1,5 +1,7 @@
 //RAMBUS RAM
 
+#include <n64/rdram/hidden.hpp>
+
 struct RDRAM : Memory::RCP<RDRAM> {
   Node::Object node;
 
@@ -56,60 +58,26 @@ struct RDRAM : Memory::RCP<RDRAM> {
     }
 
     template<u32 Size>
-    auto writeRepeat(u32 address, u64 value, u8 length) -> void {
-      if constexpr(Size == Byte) {
-        value = value & (0xFFFFFFFF >> (24 - (address & 3) * 8));
-        value = (u32)((value << 24) | (value >> 8));
-      } else if constexpr(Size == Half) {
-        value = value & (0xFFFFFFFF >> (16 - (address & 2) * 8));
-        value = (u32)((value << 16) | (value >> 16));
-      }
-      if constexpr(Size != Dual)
-        value = (value << 32) | (u32) value;
-
-      const u32 end = min((address & ~7) + length, size);
-      if(end <= address) return;
-
-      length = end - address;
-
-      if(address & 1) {
-        Memory::Writable::write<Byte>(address, value >> 56);
-        value = (value << 8) | (value >> 56);
-        address = (address & ~0x7FF) | ((address + 1) & 0x7FF);
-        length -= 1;
-      }
-      if((address & 2) && length >= 2) {
-        Memory::Writable::write<Half>(address, value >> 48);
-        value = (value << 16) | (value >> 48);
-        address = (address & ~0x7FF) | ((address + 2) & 0x7FF);
-        length -= 2;
-      }
-      if((address & 4) && length >= 4) {
-        Memory::Writable::write<Word>(address, value >> 32);
-        value = (value << 32) | (value >> 32);
-        address = (address & ~0x7FF) | ((address + 4) & 0x7FF);
-        length -= 4;
+    auto ebusRead(u32 address) -> u64 {
+      u32 mapped = address;
+      if(unlikely(!self.mapIdentity)) {
+        auto m = translate(address);
+        if(!m) {
+          ri.ackError();
+          return 0;
+        }
+        mapped = m();
+      } else {
+        if(address >= size) return 0;
       }
 
-      while(length >= 8) {
-        Memory::Writable::write<Dual>(address, value);
-        address = (address & ~0x7FF) | ((address + 8) & 0x7FF);
-        length -= 8;
-      }
-      if(length >= 4) {
-        Memory::Writable::write<Word>(address, value >> 32);
-        value <<= 32;
-        address += 4;
-        length -= 4;
-      }
-      if(length >= 2) {
-        Memory::Writable::write<Half>(address, value >> 48);
-        value <<= 16;
-        address += 2;
-        length -= 2;
-      }
-      if(length == 1)
-        Memory::Writable::write<Byte>(address, value >> 56);
+      u32 word = self.hidden.nibble(mapped & ~3);
+      if constexpr(Size == Byte) return word >> (24 - 8 * (mapped & 3)) & 0xff;
+      if constexpr(Size == Half) return word >> (16 - 8 * (mapped & 2)) & 0xffff;
+      if constexpr(Size == Word) return word;
+      if constexpr(Size == Dual)
+        return (u64)self.hidden.nibble(mapped + 0) << 32 | self.hidden.nibble(mapped + 4);
+      unreachable;
     }
 
     template<u32 Size>
@@ -118,7 +86,6 @@ struct RDRAM : Memory::RCP<RDRAM> {
         auto mapped = translate(address);
         if(!mapped) {
           if(device < RBusDevice::NUM_RBUS_HW_DEVICES) ri.ackError();
-          mi.initializeMode();
           return;
         }
         address = mapped();
@@ -127,19 +94,30 @@ struct RDRAM : Memory::RCP<RDRAM> {
       }
       if(unlikely(system.homebrewMode)) {
         self.debugger.writeWord(address, Size, value, device);
+        self.profile.metrics[(u32)device].writes += Size;
       }
-      if(unlikely(mi.initializeMode())) {
-        u32 len = mi.initializeLength() + 1;
-        writeRepeat<Size>(address, value, len);
-        if(unlikely(system.homebrewMode)) {
-          self.profile.metrics[(u32)device].writes += len;
+      Memory::Writable::write<Size>(address, value);
+      self.hidden.update<Size>(address, value);
+    }
+
+    template<u32 Size>
+    auto ebusWrite(u32 address, u64 value) -> void {
+      if(unlikely(!self.mapIdentity)) {
+        auto mapped = translate(address);
+        if(!mapped) {
+          ri.ackError();
+          return;
         }
+        address = mapped();
       } else {
-        Memory::Writable::write<Size>(address, value);
-        if(unlikely(system.homebrewMode)) {
-          self.profile.metrics[(u32)device].writes += Size;
-        }
+        if(address >= size) return;
       }
+      if(unlikely(system.homebrewMode)) {
+        self.debugger.writeWord(address, Size, value, RBusDevice::VR4300_UNCACHED);
+        self.profile.metrics[(u32)RBusDevice::VR4300_UNCACHED].writes += Size;
+      }
+      Memory::Writable::write<Size>(address, value);
+      self.hidden.ebusScatter<Size>(address, value);
     }
 
     template<u32 Size>
@@ -167,6 +145,7 @@ struct RDRAM : Memory::RCP<RDRAM> {
         Memory::Writable::write<Word>(address | 0x18, value[6]);
         Memory::Writable::write<Word>(address | 0x1c, value[7]);
       }
+      self.hidden.updateBurst<Size>(address, value);
     }
 
     template<u32 Size>
@@ -284,16 +263,17 @@ struct RDRAM : Memory::RCP<RDRAM> {
   auto selectChip(u32 select, bool broadcast) -> Chip*;
   auto chipIndex(Chip* chip) -> u32;
   auto readRegister(Chip& chip, u32 index) -> u32;
-  auto writeRegister(Chip& chip, u32 index, u32 data, bool repeat) -> void;
+  auto writeRegister(Chip& chip, u32 index, u32 data, u8 repeatLength = 0) -> void;
 
   //io.cpp
   auto readWord(u32 address, Thread& thread) -> u32;
-  auto writeWord(u32 address, u32 data, Thread& thread) -> void;
+  auto writeWord(u32 address, u32 data, Thread& thread, u8 repeatLength = 0) -> void;
 
   //serialization.cpp
   auto serialize(serializer&) -> void;
 
   Chip chips[4];
+  HiddenRAM hidden;
   n1 mapIdentity = 0;
 };
 

--- a/ares/n64/rdram/serialization.cpp
+++ b/ares/n64/rdram/serialization.cpp
@@ -1,8 +1,18 @@
 auto RDRAM::serialize(serializer& s) -> void {
   s(ram);
+  s(mapIdentity);
   for(auto& chip : chips) {
-    s(chip.deviceType);
+    s(chip.present);
+    s(chip.enable);
+    s(chip.autoCurrent);
     s(chip.deviceID);
+    s(chip.writeDelay);
+    s(chip.cci);
+    s(chip.ccInternal);
+    s(chip.ccLow);
+    s(chip.ccHigh);
+    s(chip.deviceType);
+    s(chip.deviceIDReg);
     s(chip.delay);
     s(chip.mode);
     s(chip.refreshInterval);
@@ -12,5 +22,6 @@ auto RDRAM::serialize(serializer& s) -> void {
     s(chip.addressSelect);
     s(chip.deviceManufacturer);
     s(chip.currentControl);
+    s(chip.row);
   }
 }

--- a/ares/n64/ri/debugger.cpp
+++ b/ares/n64/ri/debugger.cpp
@@ -10,8 +10,8 @@ auto RI::Debugger::io(bool mode, u32 address, u32 data) -> void {
     "RI_SELECT",
     "RI_REFRESH",
     "RI_LATENCY",
-    "RI_RERROR",
-    "RI_WERROR",
+    "RI_ERROR",
+    "RI_BANK_STATUS",
   };
 
   if(unlikely(tracer.io->enabled())) {

--- a/ares/n64/ri/io.cpp
+++ b/ares/n64/ri/io.cpp
@@ -13,25 +13,17 @@ auto RI::readWord(u32 address, Thread& thread) -> u32 {
   }
 
   if(address == 2) {
-    //RI_CURRENT_LOAD
-    data = io.currentLoad;
+    //RI_CURRENT_LOAD (write-only; unintended read returns mixed bits)
+    data.bit(0) = io.error.bit(0);
+    data.bit(1) = 1;
+    data.bit(2) = 1;
+    data.bit(3) = io.mode.bit(3);
+    data.bit(4) = io.select.bit(4);
   }
 
   if(address == 3) {
     //RI_SELECT
     data = io.select;
-    if constexpr(!Accuracy::RDRAM::Broadcasting) {
-      //this register is read by IPL3 to check if RDRAM initialization should be
-      //skipped. if we are forcing it to be skipped, we should also consume
-      //enough cycles to not inadvertently speed up the boot process.
-      //Wave Race 64 Shindou Pak Taiou Version will freeze on the N64 logo if
-      //the SCC count register, which increments at half the CPU clock rate, has
-      //too small a value.
-      //after a cold boot on real hardware with no expansion pak and using the
-      //CIC-NUS-6102 IPL3, upon reaching the test ROM's entry point the count
-      //register was measured to be ~0x1184000.
-      cpu.step(17'641'000 * 2);
-    }
   }
 
   if(address == 4) {
@@ -45,13 +37,13 @@ auto RI::readWord(u32 address, Thread& thread) -> u32 {
   }
 
   if(address == 6) {
-    //RI_RERROR
-    data = io.readError;
+    //RI_ERROR
+    data = io.error;
   }
 
   if(address == 7) {
-    //RI_WERROR
-    data = io.writeError;
+    //RI_BANK_STATUS
+    data = io.bankStatus;
   }
 
   debugger.io(Read, address, data);
@@ -75,6 +67,7 @@ auto RI::writeWord(u32 address, u32 data_, Thread& thread) -> void {
   if(address == 2) {
     //RI_CURRENT_LOAD
     io.currentLoad = data;
+    io.currentLoaded = 1;
   }
 
   if(address == 3) {
@@ -93,13 +86,13 @@ auto RI::writeWord(u32 address, u32 data_, Thread& thread) -> void {
   }
 
   if(address == 6) {
-    //RI_RERROR
-    io.readError = data;
+    //RI_ERROR
+    io.error = 0;
   }
 
   if(address == 7) {
-    //RI_WERROR
-    io.writeError = data;
+    //RI_BANK_STATUS
+    io.bankStatus = 0x00ff;
   }
 
   debugger.io(Write, address, data);

--- a/ares/n64/ri/ri.cpp
+++ b/ares/n64/ri/ri.cpp
@@ -18,17 +18,18 @@ auto RI::unload() -> void {
 }
 
 auto RI::power(bool reset) -> void {
-  io = {};
-  if constexpr(!Accuracy::RDRAM::Broadcasting) {
-    //simulate PIF ROM RDRAM power-on self test
-    io.mode    = 0x0e;
-    io.config  = 0x40;
-    io.select  = 0x14;
-    io.refresh = 0x0006'3634;
+  if(!reset) {
+    io = {};
+    refreshWarned = 0;
+  }
+}
 
-    //store RDRAM size result into memory
-    rdram.ram.write<Word>(0x318, rdram.ram.size, RBusDevice::ARES_IPL3);  //CIC-NUS-6102
-    rdram.ram.write<Word>(0x3f0, rdram.ram.size, RBusDevice::ARES_IPL3);  //CIC-NUS-6105
+auto RI::checkRefresh() -> void {
+  if(refreshWarned) return;
+  if(!system.homebrewMode) return;
+  if(!io.refresh.bit(17)) {
+    debug(unusual, "[RI] automatic RDRAM refresh is not enabled");
+    refreshWarned = 1;
   }
 }
 

--- a/ares/n64/ri/ri.hpp
+++ b/ares/n64/ri/ri.hpp
@@ -17,6 +17,9 @@ struct RI : Memory::RCP<RI> {
   auto load(Node::Object) -> void;
   auto unload() -> void;
   auto power(bool reset) -> void;
+  auto active() const -> bool { return io.currentLoaded && io.select == 0x14; }
+  auto ackError() -> void { io.error.bit(0) = 1; }
+  auto checkRefresh() -> void;
 
   //io.cpp
   auto readWord(u32 address, Thread& thread) -> u32;
@@ -32,9 +35,12 @@ struct RI : Memory::RCP<RI> {
     n32 select;
     n32 refresh;
     n32 latency;
-    n32 readError;
-    n32 writeError;
+    n32 error;
+    n32 bankStatus;
+    n1  currentLoaded;
   } io;
+
+  n1 refreshWarned;
 };
 
 extern RI ri;

--- a/ares/n64/ri/serialization.cpp
+++ b/ares/n64/ri/serialization.cpp
@@ -5,6 +5,8 @@ auto RI::serialize(serializer& s) -> void {
   s(io.select);
   s(io.refresh);
   s(io.latency);
-  s(io.readError);
-  s(io.writeError);
+  s(io.error);
+  s(io.bankStatus);
+  s(io.currentLoaded);
+  s(refreshWarned);
 }

--- a/ares/n64/system/serialization.cpp
+++ b/ares/n64/system/serialization.cpp
@@ -1,4 +1,4 @@
-static const string SerializerVersion = "v152";
+static const string SerializerVersion = "v153";
 
 auto System::serialize(bool synchronize) -> serializer {
   serializer s;
@@ -37,6 +37,7 @@ auto System::unserialize(serializer& s) -> bool {
 }
 
 auto System::serialize(serializer& s, bool synchronize) -> void {
+  s(random);
   s(queue);
   s(cartridge);
   s(controllerPort1);

--- a/ares/n64/system/system.cpp
+++ b/ares/n64/system/system.cpp
@@ -35,6 +35,7 @@ auto option(string name, string value) -> bool {
   vulkan.outputUpscale = vulkan.supersampleScanout ? 1 : vulkan.internalUpscale;
   #endif
   if(name == "Homebrew Mode") system.homebrewMode = value.boolean();
+  if(name == "Deterministic Entropy") system.deterministicEntropy = value.boolean();
   if(name == "Recompiler") {
     if constexpr(Accuracy::CPU::Recompiler) {
       cpu.recompiler.enabled = value.boolean();
@@ -64,6 +65,7 @@ auto option(string name, string value) -> bool {
 
 System system;
 Queue queue;
+Random random;
 #include "serialization.cpp"
 
 auto System::game() -> string {
@@ -426,6 +428,15 @@ auto System::save() -> void {
 
 auto System::power(bool reset) -> void {
   for(auto& setting : node->find<Node::Setting::Setting>()) setting->setLatch();
+
+  if(!reset) {
+    if(deterministicEntropy) {
+      random.entropy(Random::Entropy::High);
+      random.seed((n64)0);
+    } else {
+      random.entropy(Random::Entropy::High);
+    }
+  }
 
   if constexpr(Accuracy::CPU::Recompiler || Accuracy::RSP::Recompiler) {
     ares::Memory::FixedAllocator::get().release();

--- a/ares/n64/system/system.hpp
+++ b/ares/n64/system/system.hpp
@@ -2,6 +2,7 @@ struct System {
   Node::System node;
   VFS::Pak pak;
   bool homebrewMode = false;
+  bool deterministicEntropy = false;
   bool expansionPak = true;
   u8 configuredControllerPakBankCount = 1;
   u8 controllerPakBankCount = 1;
@@ -48,6 +49,7 @@ private:
 };
 
 extern System system;
+extern Random random;
 
 auto Model::Nintendo64() -> bool { return system.model() == System::Model::Nintendo64; }
 auto Model::Aleck64() -> bool { return system.model() == System::Model::Aleck64; }

--- a/ares/n64/vi/vi.cpp
+++ b/ares/n64/vi/vi.cpp
@@ -94,6 +94,7 @@ auto VI::main() -> void {
         #endif
         refreshed = true;
         screen->frame();
+        ri.checkRefresh();
       }
 
       if(io.halfLinesPerField.bit(0)) { // progressive

--- a/ares/n64/vulkan/vulkan.cpp
+++ b/ares/n64/vulkan/vulkan.cpp
@@ -56,17 +56,21 @@ auto Vulkan::load(Node::Object) -> bool {
     if (!implementation) {
       platform->status("Vulkan init failed: No RDP rendering support");
       vulkan.enable = false;
+      rdram.hidden.data = nullptr;
     } else {
       platform->status("Vulkan Enabled: using paraLLEl-RDP");
+      rdram.hidden.data = (u8*)implementation->processor->begin_read_hidden_rdram();
     }
   } else {
     platform->status("Vulkan Disabled: No RDP rendering support");
+    rdram.hidden.data = nullptr;
   }
 
   return true;
 }
 
 auto Vulkan::unload() -> void {
+  rdram.hidden.data = nullptr;
   if (implementation) delete implementation;
   implementation = nullptr;
 }
@@ -226,7 +230,7 @@ Vulkan::Implementation::Implementation(u8* data, u32 size) {
   device.set_context(context);
   device.init_frame_contexts(3);
 
-  ::RDP::CommandProcessorFlags flags = 0;
+  ::RDP::CommandProcessorFlags flags = ::RDP::COMMAND_PROCESSOR_FLAG_HOST_VISIBLE_HIDDEN_RDRAM_BIT;
   switch(vulkan.internalUpscale) {
   case 2: flags |= ::RDP::COMMAND_PROCESSOR_FLAG_UPSCALING_2X_BIT; break;
   case 4: flags |= ::RDP::COMMAND_PROCESSOR_FLAG_UPSCALING_4X_BIT; break;

--- a/ares/sfc/system/system.cpp
+++ b/ares/sfc/system/system.cpp
@@ -18,6 +18,7 @@ auto load(Node::System& node, string name) -> bool {
 
 auto option(string name, string value) -> bool {
   if(name == "Pixel Accuracy") ppu.setAccurate(value.boolean());
+  if(name == "Deterministic Entropy") system.deterministicEntropy = value.boolean();
   return true;
 }
 
@@ -130,6 +131,7 @@ auto System::power(bool reset) -> void {
   for(auto& setting : node->find<Node::Setting::Setting>()) setting->setLatch();
 
   random.entropy(Random::Entropy::Low);
+  if(deterministicEntropy) random.seed((n64)0);
 
   cpu.power(reset);
   smp.power(reset);

--- a/ares/sfc/system/system.hpp
+++ b/ares/sfc/system/system.hpp
@@ -1,6 +1,7 @@
 struct System {
   Node::System node;
   VFS::Pak pak;
+  bool deterministicEntropy = false;
 
   struct Controls {
     Node::Object node;

--- a/desktop-ui/emulator/arcade.cpp
+++ b/desktop-ui/emulator/arcade.cpp
@@ -163,6 +163,7 @@ auto Arcade::load() -> LoadResult {
     ares::Nintendo64::option("Disable Video Interface Processing", settings.nintendo64.disableVideoInterfaceProcessing);
     ares::Nintendo64::option("Weave Deinterlacing", settings.nintendo64.weaveDeinterlacing);
     ares::Nintendo64::option("Homebrew Mode", settings.developer.homebrewMode);
+    ares::Nintendo64::option("Deterministic Entropy", settings.developer.deterministicEntropy);
     ares::Nintendo64::option("Recompiler", !settings.developer.forceInterpreter);
 
     return successful;

--- a/desktop-ui/emulator/nintendo-64.cpp
+++ b/desktop-ui/emulator/nintendo-64.cpp
@@ -114,6 +114,7 @@ auto Nintendo64::load() -> LoadResult {
   ares::Nintendo64::option("Disable Video Interface Processing", settings.nintendo64.disableVideoInterfaceProcessing);
   ares::Nintendo64::option("Weave Deinterlacing", settings.nintendo64.weaveDeinterlacing);
   ares::Nintendo64::option("Homebrew Mode", settings.developer.homebrewMode);
+  ares::Nintendo64::option("Deterministic Entropy", settings.developer.deterministicEntropy);
   ares::Nintendo64::option("Recompiler", !settings.developer.forceInterpreter);
   ares::Nintendo64::option("Expansion Pak", settings.nintendo64.expansionPak);
   ares::Nintendo64::option("Controller Pak Banks", settings.nintendo64.controllerPakBankString);

--- a/desktop-ui/emulator/nintendo-64dd.cpp
+++ b/desktop-ui/emulator/nintendo-64dd.cpp
@@ -89,6 +89,7 @@ auto Nintendo64DD::load() -> LoadResult {
   ares::Nintendo64::option("Disable Video Interface Processing", settings.nintendo64.disableVideoInterfaceProcessing);
   ares::Nintendo64::option("Weave Deinterlacing", settings.nintendo64.weaveDeinterlacing);
   ares::Nintendo64::option("Homebrew Mode", settings.developer.homebrewMode);
+  ares::Nintendo64::option("Deterministic Entropy", settings.developer.deterministicEntropy);
   ares::Nintendo64::option("Recompiler", !settings.developer.forceInterpreter);
   ares::Nintendo64::option("Expansion Pak", settings.nintendo64.expansionPak);
   ares::Nintendo64::option("Controller Pak Banks", settings.nintendo64.controllerPakBankString);

--- a/desktop-ui/emulator/super-famicom.cpp
+++ b/desktop-ui/emulator/super-famicom.cpp
@@ -121,6 +121,7 @@ auto SuperFamicom::load() -> LoadResult {
   if(result != successful) return result;
 
   ares::SuperFamicom::option("Pixel Accuracy", settings.video.pixelAccuracy);
+  ares::SuperFamicom::option("Deterministic Entropy", settings.developer.deterministicEntropy);
 
   auto region = Emulator::region();
   if(!ares::SuperFamicom::load(root, {"[Nintendo] Super Famicom (", region, ")"})) return otherError;

--- a/desktop-ui/settings/developer.cpp
+++ b/desktop-ui/settings/developer.cpp
@@ -51,6 +51,12 @@ auto DeveloperSettings::construct() -> void {
   homebrewModeLayout.setAlignment(0.5).setPadding(12_sx, 0);
     homebrewModeHint.setText("Activate system-specific features to help homebrew developers").setFont(Font().setSize(7.0)).setForegroundColor(SystemColor::Sublabel);
 
+  deterministicEntropy.setText("Deterministic Entropy").setChecked(settings.developer.deterministicEntropy).onToggle([&] {
+    settings.developer.deterministicEntropy = deterministicEntropy.checked();
+  });
+  deterministicEntropyLayout.setAlignment(0.5).setPadding(12_sx, 0);
+    deterministicEntropyHint.setText("Seed hardware RNG to zero for reproducible power-on state").setFont(Font().setSize(7.0)).setForegroundColor(SystemColor::Sublabel);
+
   forceInterpreter.setText("Force Interpreter").setChecked(settings.developer.forceInterpreter).onToggle([&] {
     settings.developer.forceInterpreter = forceInterpreter.checked();
   });

--- a/desktop-ui/settings/settings.cpp
+++ b/desktop-ui/settings/settings.cpp
@@ -120,6 +120,7 @@ auto Settings::process(bool load) -> void {
   bind(boolean, "Developer/DebugServerEnabled", developer.debugServerEnabled);
   bind(boolean, "Developer/DebugServerUseIPv4", developer.debugServerUseIPv4);
   bind(boolean, "Developer/HomebrewMode", developer.homebrewMode);
+  bind(boolean, "Developer/DeterministicEntropy", developer.deterministicEntropy);
   bind(boolean, "Developer/ForceInterpreter", developer.forceInterpreter);
 
   bind(boolean, "Nintendo64/ExpansionPak", nintendo64.expansionPak);

--- a/desktop-ui/settings/settings.hpp
+++ b/desktop-ui/settings/settings.hpp
@@ -105,6 +105,7 @@ struct Settings : Markup::Node {
     bool debugServerEnabled = false; // if enabled, server starts with ares
     bool debugServerUseIPv4 = false; // forces IPv4 over IPv6
     bool homebrewMode = false;
+    bool deterministicEntropy = false;
     bool forceInterpreter = false;
   } developer;
 
@@ -435,6 +436,9 @@ struct DeveloperSettings : VerticalLayout {
   HorizontalLayout homebrewModeLayout{this, Size{~0, 0}, 5};
     CheckLabel homebrewMode{&homebrewModeLayout, Size{0, 0}, 5};
     Label homebrewModeHint{&homebrewModeLayout, Size{~0, layoutVertSize}};
+  HorizontalLayout deterministicEntropyLayout{this, Size{~0, 0}, 5};
+    CheckLabel deterministicEntropy{&deterministicEntropyLayout, Size{0, 0}, 5};
+    Label deterministicEntropyHint{&deterministicEntropyLayout, Size{~0, layoutVertSize}};
   HorizontalLayout forceInterpreterLayout{this, Size{~0, 0}, 5};
     CheckLabel forceInterpreter{&forceInterpreterLayout, Size{0, 0}, 5};
     Label forceInterpreterHint{&forceInterpreterLayout, Size{0, layoutVertSize}};


### PR DESCRIPTION
* Implement full RDRAM chip configuration. Ares now fully runs IPL3s including chip calibration. As a side effect, libdragon IPL3 is now able to collect true entropy during this phase.
* Add a developer option to fix the entropy seed to simplify debugging. This is also hooked up to sfc, the only other core using entropy.
* Implement access to RDRAM hidden bits (both read and write), with coherency with RDP. The most common codepaths (cache writes updating hidden bits) are optimized with SIMD.

<img width="320" alt="Screenshot 2026-07-23 alle 02 10 35" src="https://github.com/user-attachments/assets/f5bcbdd7-0e41-465d-9cad-8d94e038f1bf" />
<img width="320" alt="Screenshot 2026-07-23 alle 02 10 22" src="https://github.com/user-attachments/assets/eba216c3-f4f5-4b81-a9eb-c42e74814fdf" />

<img width="812" height="594" alt="Screenshot 2026-07-23 alle 02 16 33" src="https://github.com/user-attachments/assets/2e162362-7fe2-4b91-bfb1-bbfdd66474e2" />

