### PR TITLE
n64: add graphics debugger to inspect frame rendering

### DIFF
--- a/ares/CMakeLists.txt
+++ b/ares/CMakeLists.txt
@@ -104,6 +104,7 @@ target_sources(
   PRIVATE
     ares/node/debugger/debugger.hpp
     ares/node/debugger/graphics.hpp
+    ares/node/debugger/graphics-frame.hpp
     ares/node/debugger/memory.hpp
     ares/node/debugger/properties.hpp
     ares/node/debugger/tracer/tracer.hpp

--- a/ares/ares/node/debugger/graphics-frame.hpp
+++ b/ares/ares/node/debugger/graphics-frame.hpp
@@ -1,0 +1,65 @@
+struct GraphicsFrame : Debugger {
+  DeclareClass(GraphicsFrame, "debugger.graphics.frame")
+
+  struct Image {
+    u32 width = 0;
+    u32 height = 0;
+    std::vector<u32> pixels;
+  };
+
+  GraphicsFrame(string name = {}) : Debugger(name) {}
+
+  auto requestCapture() const -> void { if(_requestCapture) _requestCapture(); }
+  auto captureValid() const -> bool { return _captureValid ? _captureValid() : false; }
+  auto commandCount() const -> u32 { return _commandCount ? _commandCount() : 0; }
+  auto commandText(u32 index) const -> string { return _commandText ? _commandText(index) : string{}; }
+  //Decoded operands for the command, summarized on one line.
+  auto commandArguments(u32 index) const -> string { return _commandArguments ? _commandArguments(index) : string{}; }
+  auto commandDetail(u32 index) const -> string { return _commandDetail ? _commandDetail(index) : string{}; }
+  auto commandOpcode(u32 index) const -> u32 { return _commandOpcode ? _commandOpcode(index) : 0; }
+  auto commandType(u32 index) const -> u32 { return _commandType ? _commandType(index) : 0; }
+  auto views() const -> std::vector<string> { return _views ? _views() : std::vector<string>{}; }
+  //Command indices worth a scrollback entry: sync commands whose rendered
+  //buffers differ from the previous entry's.
+  auto ticks() const -> std::vector<u32> { return _ticks ? _ticks() : std::vector<u32>{}; }
+  auto render(u32 command, u32 view) const -> Image { return _render ? _render(command, view) : Image{}; }
+  auto state(u32 command) const -> string { return _state ? _state(command) : string{}; }
+  auto summary() const -> string { return _summary ? _summary() : string{}; }
+
+  auto setRequestCapture(std::function<void ()> callback) -> void { _requestCapture = callback; }
+  auto setCaptureValid(std::function<bool ()> callback) -> void { _captureValid = callback; }
+  auto setCommandCount(std::function<u32 ()> callback) -> void { _commandCount = callback; }
+  auto setCommandText(std::function<string (u32)> callback) -> void { _commandText = callback; }
+  auto setCommandArguments(std::function<string (u32)> callback) -> void { _commandArguments = callback; }
+  auto setCommandDetail(std::function<string (u32)> callback) -> void { _commandDetail = callback; }
+  auto setCommandOpcode(std::function<u32 (u32)> callback) -> void { _commandOpcode = callback; }
+  auto setCommandType(std::function<u32 (u32)> callback) -> void { _commandType = callback; }
+  auto setViews(std::function<std::vector<string> ()> callback) -> void { _views = callback; }
+  auto setTicks(std::function<std::vector<u32> ()> callback) -> void { _ticks = callback; }
+  auto setRender(std::function<Image (u32, u32)> callback) -> void { _render = callback; }
+  auto setState(std::function<string (u32)> callback) -> void { _state = callback; }
+  auto setSummary(std::function<string ()> callback) -> void { _summary = callback; }
+
+  auto serialize(string& output, string depth) -> void override {
+    Debugger::serialize(output, depth);
+  }
+
+  auto unserialize(Markup::Node node) -> void override {
+    Debugger::unserialize(node);
+  }
+
+private:
+  std::function<void ()> _requestCapture;
+  std::function<bool ()> _captureValid;
+  std::function<u32 ()> _commandCount;
+  std::function<string (u32)> _commandText;
+  std::function<string (u32)> _commandArguments;
+  std::function<string (u32)> _commandDetail;
+  std::function<u32 (u32)> _commandOpcode;
+  std::function<u32 (u32)> _commandType;
+  std::function<std::vector<string> ()> _views;
+  std::function<std::vector<u32> ()> _ticks;
+  std::function<Image (u32, u32)> _render;
+  std::function<string (u32)> _state;
+  std::function<string ()> _summary;
+};

--- a/ares/ares/node/node.hpp
+++ b/ares/ares/node/node.hpp
@@ -36,6 +36,7 @@ namespace ares::Core {
     struct Debugger;
     struct Memory;
     struct Graphics;
+    struct GraphicsFrame;
     struct Properties;
     namespace Tracer {
       struct Tracer;
@@ -83,6 +84,7 @@ namespace ares::Node {
     using Debugger       = std::shared_ptr<Core::Debugger::Debugger>;
     using Memory         = std::shared_ptr<Core::Debugger::Memory>;
     using Graphics       = std::shared_ptr<Core::Debugger::Graphics>;
+    using GraphicsFrame  = std::shared_ptr<Core::Debugger::GraphicsFrame>;
     using Properties     = std::shared_ptr<Core::Debugger::Properties>;
     namespace Tracer {
       using Tracer       = std::shared_ptr<Core::Debugger::Tracer::Tracer>;
@@ -137,6 +139,7 @@ namespace ares::Core {
     #include <ares/node/debugger/debugger.hpp>
     #include <ares/node/debugger/memory.hpp>
     #include <ares/node/debugger/graphics.hpp>
+    #include <ares/node/debugger/graphics-frame.hpp>
     #include <ares/node/debugger/properties.hpp>
     namespace Tracer {
       #include <ares/node/debugger/tracer/tracer.hpp>

--- a/ares/n64/CMakeLists.txt
+++ b/ares/n64/CMakeLists.txt
@@ -228,6 +228,8 @@ ares_add_sources(
     n64
   INCLUDED #
     rdp/debugger.cpp
+    rdp/capture.cpp
+    rdp/capture.hpp
     rdp/io.cpp
     rdp/rdp.hpp
     rdp/render.cpp

--- a/ares/n64/n64.hpp
+++ b/ares/n64/n64.hpp
@@ -11,6 +11,8 @@
 #include <nall/recompiler/generic/generic.hpp>
 #include <component/processor/sm5k/sm5k.hpp>
 #include <functional>
+#include <atomic>
+#include <cstring>
 #include <span>
 #include <vector>
 

--- a/ares/n64/rdp/capture.cpp
+++ b/ares/n64/rdp/capture.cpp
@@ -1,0 +1,1279 @@
+auto RDP::Debugger::requestCapture() -> void {
+  if(!capture) capture = std::make_unique<Capture>();
+  capture->ready.store(false, std::memory_order_relaxed);
+  capture->armedFields = 0;
+  capture->activeFields = 0;
+  capture->armed.store(true, std::memory_order_release);
+}
+
+auto RDP::Debugger::captureReady() const -> bool {
+  return capture && capture->ready.load(std::memory_order_acquire);
+}
+
+auto RDP::Debugger::captureActive() const -> bool {
+  return capture && capture->active;
+}
+
+auto RDP::Debugger::frameCapture() const -> const RDPFrameCapture* {
+  return captureReady() ? &capture->frame : nullptr;
+}
+
+auto RDP::Debugger::captureCommandCount() const -> u32 {
+  if(auto frame = frameCapture()) return frame->commandOffsets.size();
+  return 0;
+}
+
+//Opcode names, normalized: the eight triangle opcodes and both texture rectangle
+//opcodes differ only in which operands follow, which the argument summary states,
+//so they share one name and align down the command list as one kind of command.
+static const char* commandNameTable[64] = {
+  "No Operation", "Invalid 01", "Invalid 02", "Invalid 03",
+  "Invalid 04", "Invalid 05", "Invalid 06", "Invalid 07",
+  "Triangle", "Triangle", "Triangle", "Triangle",
+  "Triangle", "Triangle", "Triangle", "Triangle",
+  "Invalid 10", "Invalid 11", "Invalid 12", "Invalid 13",
+  "Invalid 14", "Invalid 15", "Invalid 16", "Invalid 17",
+  "Invalid 18", "Invalid 19", "Invalid 1a", "Invalid 1b",
+  "Invalid 1c", "Invalid 1d", "Invalid 1e", "Invalid 1f",
+  "Invalid 20", "Invalid 21", "Invalid 22", "Invalid 23",
+  "Texture Rectangle", "Texture Rectangle", "Sync Load", "Sync Pipe",
+  "Sync Tile", "Sync Full", "Set Key GB", "Set Key R",
+  "Set Convert", "Set Scissor", "Set Primitive Depth", "Set Other Modes",
+  "Load TLUT", "Invalid 31", "Set Tile Size", "Load Block",
+  "Load Tile", "Set Tile", "Fill Rectangle", "Set Fill Color",
+  "Set Fog Color", "Set Blend Color", "Set Primitive Color", "Set Environment Color",
+  "Set Combine Mode", "Set Texture Image", "Set Mask Image", "Set Color Image",
+};
+
+static const std::vector<string> imageFormatNames = {
+  "RGBA", "YUV", "CI", "IA", "I", "?5", "?6", "?7"
+};
+static const std::vector<string> imageSizeNames = {"4bpp", "8bpp", "16bpp", "32bpp"};
+static const std::vector<string> cycleNames = {"1-Cycle", "2-Cycle", "Copy", "Fill"};
+static const std::vector<string> zModeNames = {
+  "Opaque", "Interpenetrating", "Transparent", "Decal"
+};
+static const std::vector<string> coverageNames = {"Clamp", "Wrap", "Zap", "Save"};
+static const std::vector<string> rgbDitherNames = {
+  "Magic Square", "Bayer", "Noise", "None"
+};
+static const std::vector<string> alphaDitherNames = {
+  "Pattern", "Inverse Pattern", "Noise", "None"
+};
+
+//Colour combiner input mnemonics; the four operand classes index different tables.
+static const std::vector<string> combineSubA = {
+  "COMBINED", "TEXEL0", "TEXEL1", "PRIM", "SHADE", "ENV", "1", "NOISE"
+};
+static const std::vector<string> combineSubB = {
+  "COMBINED", "TEXEL0", "TEXEL1", "PRIM", "SHADE", "ENV", "CENTER", "K4"
+};
+static const std::vector<string> combineMul = {
+  "COMBINED", "TEXEL0", "TEXEL1", "PRIM", "SHADE", "ENV", "SCALE", "COMBINED_A",
+  "TEXEL0_A", "TEXEL1_A", "PRIM_A", "SHADE_A", "ENV_A", "LOD_FRAC", "PRIM_LOD_FRAC", "K5"
+};
+static const std::vector<string> combineAdd = {
+  "COMBINED", "TEXEL0", "TEXEL1", "PRIM", "SHADE", "ENV", "1", "0"
+};
+static const std::vector<string> combineAlpha = {
+  "COMBINED", "TEXEL0", "TEXEL1", "PRIM", "SHADE", "ENV", "1", "0"
+};
+static const std::vector<string> combineAlphaMul = {
+  "LOD_FRAC", "TEXEL0", "TEXEL1", "PRIM", "SHADE", "ENV", "PRIM_LOD_FRAC", "0"
+};
+
+//Blender operands. Each of the four multiplexers holds one selection per cycle,
+//the two packed adjacently, cycle 0 in the higher pair of bits.
+static const std::vector<string> blendP = {"IN", "MEM", "BLEND", "FOG"};
+static const std::vector<string> blendA = {"IN_A", "FOG_A", "SHADE_A", "0"};
+static const std::vector<string> blendM = {"IN", "MEM", "BLEND", "FOG"};
+static const std::vector<string> blendB = {"1-A", "MEM_A", "1", "0"};
+
+static auto combineName(const std::vector<string>& names, u32 index) -> string {
+  return index < names.size() ? names[index] : string("0");
+}
+
+//(A - B) * C + D
+static auto combineEquation(
+  const std::vector<string>& a, u32 ai, const std::vector<string>& b, u32 bi,
+  const std::vector<string>& c, u32 ci, const std::vector<string>& d, u32 di
+) -> string {
+  return {
+    "(", combineName(a, ai), " - ", combineName(b, bi), ") * ",
+    combineName(c, ci), " + ", combineName(d, di)
+  };
+}
+
+//P * A + M * B, for one blender cycle.
+static auto blendEquation(u64 modes, u32 cycle) -> string {
+  return {
+    combineName(blendP, modes >> 30 - cycle * 2 & 3), " * ",
+    combineName(blendA, modes >> 26 - cycle * 2 & 3), " + ",
+    combineName(blendM, modes >> 22 - cycle * 2 & 3), " * ",
+    combineName(blendB, modes >> 18 - cycle * 2 & 3)
+  };
+}
+
+//Set_Other_Modes bits that read as plain on/off switches. Only the set ones are
+//named, so the result is short for the modes a game actually uses.
+static auto otherModesFlags(u64 modes) -> string {
+  string flags;
+  auto flag = [&](u32 bit, string_view name) {
+    if(modes >> bit & 1) flags.append(flags ? " " : "", name);
+  };
+  flag(55, "atomic"); flag(51, "persp"); flag(50, "detail"); flag(49, "sharpen");
+  flag(48, "lod"); flag(47, "tlut"); flag(46, "tlut_ia"); flag(45, "sample_2x2");
+  flag(44, "mid_texel"); flag(43, "bilerp0"); flag(42, "bilerp1");
+  flag(41, "convert_one"); flag(40, "key");
+  flag(14, "force_blend"); flag(13, "alpha_cvg"); flag(12, "cvg_x_alpha");
+  flag( 7, "color_on_cvg"); flag(6, "image_read"); flag(5, "z_update");
+  flag( 4, "z_compare"); flag(3, "aa"); flag(2, "z_prim");
+  flag( 1, "dither_alpha"); flag(0, "alpha_compare");
+  return flags ? flags : string{"none"};
+}
+
+//Fixed point formatting. Field widths vary by command: screen coordinates are
+//10.2, texture rectangle coordinates 10.5 with 5.10 steps, triangle coefficients
+//16.16 and Load_Block's dxt 1.11.
+static auto signExtend(u64 value, u32 bits) -> s64 {
+  u64 sign = 1ull << bits - 1;
+  return (s64)(value & sign * 2 - 1) - (s64)((value & sign) * 2);
+}
+
+static auto formatFixed(s64 value, u32 fractionBits, u32 digits) -> string {
+  bool negative = value < 0;
+  u64 magnitude = negative ? (u64)-value : (u64)value;
+  u64 one = 1ull << fractionBits;
+  u64 scale = 1;
+  for(u32 digit : range(digits)) scale *= 10;
+  u64 integer = magnitude >> fractionBits;
+  u64 fraction = ((magnitude & one - 1) * scale + (one >> 1)) >> fractionBits;
+  if(fraction >= scale) integer++, fraction -= scale;
+  string text{negative ? "-" : "", integer};
+  if(digits) text.append(".", pad(string{fraction}, digits, '0'));
+  return text;
+}
+
+//Screen coordinates, as carried by scissor, rectangle and tile commands.
+static auto formatFixed102(u32 value) -> string {
+  return formatFixed(value & 0xfff, 2, 2);
+}
+
+static auto formatRGBA32(u32 color) -> string {
+  return {
+    "r ", color >> 24 & 255, "  g ", color >> 16 & 255,
+    "  b ", color >> 8 & 255, "  a ", color & 255
+  };
+}
+
+static auto formatRGBA16(u32 pixel) -> string {
+  return {
+    "r ", pixel >> 11 & 31, "  g ", pixel >> 6 & 31,
+    "  b ", pixel >> 1 & 31, "  a ", pixel & 1
+  };
+}
+
+//A captured command is a run of 32-bit words, two per 64-bit RDP command word:
+//word 2n holds bits 63..32 of command word n and word 2n+1 bits 31..0. The field
+//positions below match render.cpp's fetch routines, which are the authority on
+//the encoding.
+struct DecodedCommand {
+  string name;       //normalized opcode name
+  string arguments;  //one line operand summary, shown beside the name
+  string fields;     //label\tvalue pairs, one per line, for the detail pane
+};
+
+static auto decodeCommand(const std::vector<u32>& words) -> DecodedCommand {
+  DecodedCommand decoded;
+  if(words.empty()) return decoded;
+
+  auto word = [&](u32 index) -> u32 { return index < words.size() ? words[index] : 0; };
+  auto qword = [&](u32 index) -> u64 {
+    return (u64)word(index * 2) << 32 | word(index * 2 + 1);
+  };
+  //One 16-bit field of a triangle coefficient block: `pair` selects the 64-bit
+  //word within the block, `slot` the channel (R/G/B/A, or S/T/W) inside it.
+  auto half = [&](u32 base, u32 pair, u32 slot) -> u32 {
+    u32 value = word(base + pair * 2 + (slot >> 1));
+    return slot & 1 ? value & 0xffff : value >> 16;
+  };
+  //Coefficients are split across an integer block and a fraction block; a
+  //coefficient is the two halves joined into one 16.16 value.
+  auto coefficient = [&](u32 base, u32 integerPair, u32 fractionPair, u32 slot) -> s32 {
+    return (s32)(half(base, integerPair, slot) << 16 | half(base, fractionPair, slot));
+  };
+
+  string arguments;
+  auto argument = [&](const string& text) {
+    if(text) arguments.append(arguments ? "  " : "", text);
+  };
+  string fields;
+  auto field = [&](const string& label, const string& value) {
+    fields.append(label, "\t", value, "\n");
+  };
+
+  u64 op = qword(0);
+  u32 opcode = op >> 56 & 63;
+  decoded.name = commandNameTable[opcode];
+
+  switch(opcode) {
+
+  case 0x08: case 0x09: case 0x0a: case 0x0b:
+  case 0x0c: case 0x0d: case 0x0e: case 0x0f: {
+    bool zbuffer = opcode & 1, texture = opcode & 2, shade = opcode & 4;
+    string kind;
+    if(shade) kind.append(kind ? " " : "", "shade");
+    if(texture) kind.append(kind ? " " : "", "tex");
+    if(zbuffer) kind.append(kind ? " " : "", "zbuf");
+    if(!kind) kind = "flat";
+
+    u32 tile = op >> 48 & 7;
+    u32 level = op >> 51 & 7;
+    bool major = op >> 55 & 1;
+    //The three scanline bounds are 11.2; the edges they belong to are 16.16.
+    s64 yl = signExtend(op >> 32, 14);
+    s64 ym = signExtend(op >> 16, 14);
+    s64 yh = signExtend(op >>  0, 14);
+    s32 xl = word(2), dxldy = word(3);
+    s32 xh = word(4), dxhdy = word(5);
+    s32 xm = word(6), dxmdy = word(7);
+
+    argument(kind);
+    if(texture) argument({"tile ", tile});
+    if(level) argument({"level ", level});
+    argument({"y ", formatFixed(yh, 2, 2), " -> ", formatFixed(yl, 2, 2)});
+    argument({"x ", formatFixed(xh, 16, 2), " -> ", formatFixed(xl, 16, 2)});
+
+    field("Kind", kind);
+    field("Tile", {tile});
+    field("Level", {level});
+    field("Major Edge", major ? "left" : "right");
+    field("Scanlines", {
+      "YH ", formatFixed(yh, 2, 2), "   YM ", formatFixed(ym, 2, 2),
+      "   YL ", formatFixed(yl, 2, 2)
+    });
+    field("Edge Hi", {"X ", formatFixed(xh, 16, 4), "   dxdy ", formatFixed(dxhdy, 16, 4)});
+    field("Edge Mid", {"X ", formatFixed(xm, 16, 4), "   dxdy ", formatFixed(dxmdy, 16, 4)});
+    field("Edge Lo", {"X ", formatFixed(xl, 16, 4), "   dxdy ", formatFixed(dxldy, 16, 4)});
+
+    u32 base = 8;
+    if(shade) {
+      static const char* channels[4] = {"R", "G", "B", "A"};
+      auto block = [&](u32 integerPair, u32 fractionPair) -> string {
+        string text;
+        for(u32 slot : range(4)) {
+          text.append(slot ? "  " : "", channels[slot], " ", pad(
+            formatFixed(coefficient(base, integerPair, fractionPair, slot), 16, 2), -9L
+          ));
+        }
+        return text.strip();
+      };
+      field("Shade", block(0, 2));
+      field("Shade dx", block(1, 3));
+      field("Shade de", block(4, 6));
+      field("Shade dy", block(5, 7));
+      base += 16;
+    }
+    if(texture) {
+      static const char* channels[3] = {"S", "T", "W"};
+      auto block = [&](u32 integerPair, u32 fractionPair) -> string {
+        string text;
+        for(u32 slot : range(3)) {
+          text.append(slot ? "  " : "", channels[slot], " ", pad(
+            formatFixed(coefficient(base, integerPair, fractionPair, slot), 16, 3), -11L
+          ));
+        }
+        return text.strip();
+      };
+      field("Texture", block(0, 2));
+      field("Texture dx", block(1, 3));
+      field("Texture de", block(4, 6));
+      field("Texture dy", block(5, 7));
+      base += 16;
+    }
+    if(zbuffer) {
+      field("Depth", {"Z ", formatFixed((s32)word(base), 16, 4)});
+      field("Depth dx", formatFixed((s32)word(base + 1), 16, 4));
+      field("Depth de", formatFixed((s32)word(base + 2), 16, 4));
+      field("Depth dy", formatFixed((s32)word(base + 3), 16, 4));
+    }
+  } break;
+
+  case 0x24: case 0x25:    //Texture_Rectangle, Texture_Rectangle_Flip
+  case 0x36: {             //Fill_Rectangle
+    bool textured = opcode != 0x36;
+    //The RDP names the lower right corner "lo" and the upper left "hi"; they are
+    //printed here in the order they read on screen.
+    u32 xl = op >> 44 & 0xfff, yl = op >> 32 & 0xfff;
+    u32 tile = op >> 24 & 7;
+    u32 xh = op >> 12 & 0xfff, yh = op >> 0 & 0xfff;
+    string rectangle{
+      formatFixed102(xh), ",", formatFixed102(yh), " -> ",
+      formatFixed102(xl), ",", formatFixed102(yl)
+    };
+
+    if(opcode == 0x25) argument("flip");
+    if(textured) argument({"tile ", tile});
+    argument(rectangle);
+    field("Rectangle", rectangle);
+    field("Size", {
+      formatFixed((s32)xl - (s32)xh, 2, 2), " x ",
+      formatFixed((s32)yl - (s32)yh, 2, 2), " pixels"
+    });
+    if(textured) {
+      s64 s = signExtend(word(2) >> 16, 16), t = signExtend(word(2), 16);
+      s64 dsdx = signExtend(word(3) >> 16, 16), dtdy = signExtend(word(3), 16);
+      argument({"st ", formatFixed(s, 5, 2), ",", formatFixed(t, 5, 2)});
+      argument({"d ", formatFixed(dsdx, 10, 3), "/", formatFixed(dtdy, 10, 3)});
+      field("Tile", {tile});
+      field("Texture", {"S ", formatFixed(s, 5, 3), "   T ", formatFixed(t, 5, 3)});
+      field("Texture Step", {
+        "dsdx ", formatFixed(dsdx, 10, 4), "   dtdy ", formatFixed(dtdy, 10, 4)
+      });
+      if(opcode == 0x25) field("Orientation", "flipped: S runs down, T across");
+    }
+  } break;
+
+  case 0x26: field("Effect", "stalls until pending texture loads have landed"); break;
+  case 0x27: field("Effect", "stalls until the pipeline has drained"); break;
+  case 0x28: field("Effect", "stalls until pending tile writes have landed"); break;
+  case 0x29: field("Effect", "ends the command list and raises the DP interrupt"); break;
+
+  case 0x2a: {  //Set_Key_GB
+    field("Green", {
+      "width ", op >> 44 & 0xfff, "   center ", op >> 24 & 255, "   scale ", op >> 16 & 255
+    });
+    field("Blue", {
+      "width ", op >> 32 & 0xfff, "   center ", op >> 8 & 255, "   scale ", op >> 0 & 255
+    });
+    argument({"g ", op >> 24 & 255, "/", op >> 16 & 255, "  b ", op >> 8 & 255, "/", op & 255});
+  } break;
+
+  case 0x2b: {  //Set_Key_R
+    field("Red", {
+      "width ", op >> 16 & 0xfff, "   center ", op >> 8 & 255, "   scale ", op >> 0 & 255
+    });
+    argument({"r ", op >> 8 & 255, "/", op & 255});
+  } break;
+
+  case 0x2c: {  //Set_Convert
+    //Six 9-bit signed YUV coefficients packed end to end.
+    string text;
+    for(u32 index : range(6)) {
+      text.append(index ? "  " : "", "K", index, " ",
+        signExtend(op >> 45 - index * 9, 9));
+    }
+    argument(text);
+    field("Coefficients", text);
+  } break;
+
+  case 0x2d: {  //Set_Scissor
+    string scissor{
+      formatFixed102(op >> 44), ",", formatFixed102(op >> 32), " -> ",
+      formatFixed102(op >> 12), ",", formatFixed102(op >> 0)
+    };
+    argument(scissor);
+    field("Scissor", scissor);
+    if(op >> 25 & 1) {
+      argument({"field ", op >> 24 & 1 ? "odd" : "even"});
+      field("Interlace", {"keep ", op >> 24 & 1 ? "odd" : "even", " lines"});
+    }
+  } break;
+
+  case 0x2e: {  //Set_Prim_Depth
+    argument({"z ", op >> 16 & 0xffff, "  dz ", op & 0xffff});
+    field("Depth", {op >> 16 & 0xffff});
+    field("Delta", {op & 0xffff});
+  } break;
+
+  case 0x2f: {  //Set_Other_Modes
+    argument(cycleNames[op >> 52 & 3]);
+    argument(otherModesFlags(op));
+    field("Cycle Type", cycleNames[op >> 52 & 3]);
+    field("Z Mode", zModeNames[op >> 10 & 3]);
+    field("Coverage", coverageNames[op >> 8 & 3]);
+    field("RGB Dither", rgbDitherNames[op >> 38 & 3]);
+    field("Alpha Dither", alphaDitherNames[op >> 36 & 3]);
+    field("Blender 0", blendEquation(op, 0));
+    field("Blender 1", blendEquation(op, 1));
+    field("Flags", otherModesFlags(op));
+  } break;
+
+  case 0x30:    //Load_TLUT
+  case 0x32:    //Set_Tile_Size
+  case 0x34: {  //Load_Tile
+    u32 tile = op >> 24 & 7;
+    //Load_TLUT counts palette entries rather than addressing texels, but shares
+    //the encoding: its bounds are entry indices scaled by four.
+    string bounds{
+      formatFixed102(op >> 44), ",", formatFixed102(op >> 32), " -> ",
+      formatFixed102(op >> 12), ",", formatFixed102(op >> 0)
+    };
+    argument({"tile ", tile});
+    argument(bounds);
+    field("Tile", {tile});
+    field(opcode == 0x30 ? "Entries" : "Texels", bounds);
+    if(opcode == 0x30) {
+      field("Palette Range", {
+        (op >> 44 & 0xfff) >> 2, " -> ", (op >> 12 & 0xfff) >> 2
+      });
+    }
+  } break;
+
+  case 0x33: {  //Load_Block
+    u32 tile = op >> 24 & 7;
+    u32 texels = (op >> 12 & 0xfff) + 1;
+    argument({"tile ", tile});
+    argument({"s ", op >> 44 & 0xfff, "  t ", op >> 32 & 0xfff});
+    argument({texels, " texels"});
+    argument({"dxt ", formatFixed(op & 0xfff, 11, 4)});
+    field("Tile", {tile});
+    field("Origin", {"S ", op >> 44 & 0xfff, "   T ", op >> 32 & 0xfff});
+    field("Texels", {texels});
+    //dxt is the TMEM row advance per texel; zero loads one continuous row.
+    field("Row Step", {formatFixed(op & 0xfff, 11, 6), " (dxt)"});
+  } break;
+
+  case 0x35: {  //Set_Tile
+    u32 tile = op >> 24 & 7;
+    u32 format = op >> 53 & 7, size = op >> 51 & 3;
+    string clamp;
+    clamp.append(op >> 9 & 1 ? "C" : op >> 8 & 1 ? "M" : "-");
+    clamp.append(op >> 19 & 1 ? "C" : op >> 18 & 1 ? "M" : "-");
+
+    argument({"tile ", tile});
+    argument({imageFormatNames[format], " ", imageSizeNames[size]});
+    argument({"TMEM ", hex((op >> 32 & 0x1ff) * 8, 4L)});
+    argument({"line ", (op >> 41 & 0x1ff) * 8});
+    if(op >> 20 & 15) argument({"pal ", op >> 20 & 15});
+    if(clamp != "--") argument({"cm ", clamp});
+
+    field("Tile", {tile});
+    field("Format", {imageFormatNames[format], " ", imageSizeNames[size]});
+    field("TMEM Address", hex((op >> 32 & 0x1ff) * 8, 4L));
+    field("Line Width", {(op >> 41 & 0x1ff) * 8, " bytes"});
+    field("Palette", {op >> 20 & 15});
+    field("Mask", {"S ", op >> 4 & 15, "   T ", op >> 14 & 15});
+    field("Shift", {"S ", op >> 0 & 15, "   T ", op >> 10 & 15});
+    field("Clamp / Mirror", {
+      "S ", op >> 9 & 1 ? "clamp" : op >> 8 & 1 ? "mirror" : "wrap",
+      "   T ", op >> 19 & 1 ? "clamp" : op >> 18 & 1 ? "mirror" : "wrap"
+    });
+  } break;
+
+  case 0x37: {  //Set_Fill_Color
+    //In fill mode the register is written to the framebuffer verbatim, so at
+    //16bpp it is a pair of pixels and at 32bpp a single RGBA colour.
+    u32 color = op & 0xffff'ffff;
+    argument(hex(color, 8L));
+    field("Raw", hex(color, 8L));
+    field("As RGBA32", formatRGBA32(color));
+    if((color >> 16) == (color & 0xffff)) {
+      field("As RGBA16", formatRGBA16(color & 0xffff));
+      argument({"rgba16 x2 ", formatRGBA16(color & 0xffff)});
+    } else {
+      field("As RGBA16", {
+        "even ", formatRGBA16(color >> 16), "   odd ", formatRGBA16(color & 0xffff)
+      });
+    }
+  } break;
+
+  case 0x38:    //Set_Fog_Color
+  case 0x39:    //Set_Blend_Color
+  case 0x3a:    //Set_Prim_Color
+  case 0x3b: {  //Set_Env_Color
+    u32 color = op & 0xffff'ffff;
+    argument(formatRGBA32(color));
+    field("Color", formatRGBA32(color));
+    field("Raw", hex(color, 8L));
+    if(opcode == 0x3a) {
+      argument({"lod ", op >> 40 & 31, "/", op >> 32 & 255});
+      field("LOD", {
+        "minimum ", op >> 40 & 31, "   fraction ", op >> 32 & 255
+      });
+    }
+  } break;
+
+  case 0x3c: {  //Set_Combine
+    string rgb0 = combineEquation(
+      combineSubA, op >> 52 & 15, combineSubB, op >> 28 & 15,
+      combineMul,  op >> 47 & 31, combineAdd,  op >> 15 & 7);
+    argument(rgb0);
+    field("RGB 0", rgb0);
+    field("Alpha 0", combineEquation(
+      combineAlpha, op >> 44 & 7, combineAlpha,    op >> 12 & 7,
+      combineAlphaMul, op >> 41 & 7, combineAlpha, op >>  9 & 7));
+    field("RGB 1", combineEquation(
+      combineSubA, op >> 37 & 15, combineSubB, op >> 24 & 15,
+      combineMul,  op >> 32 & 31, combineAdd,  op >>  6 & 7));
+    field("Alpha 1", combineEquation(
+      combineAlpha, op >> 21 & 7, combineAlpha,    op >>  3 & 7,
+      combineAlphaMul, op >> 18 & 7, combineAlpha, op >>  0 & 7));
+  } break;
+
+  case 0x3d:    //Set_Texture_Image
+  case 0x3f: {  //Set_Color_Image
+    u32 format = op >> 53 & 7, size = op >> 51 & 3;
+    u32 width = (op >> 32 & 1023) + 1;
+    u32 address = op & 0x03ff'ffff;
+    argument(hex(address, 8L));
+    argument({imageFormatNames[format], " ", imageSizeNames[size]});
+    argument({"width ", width});
+    field("Address", hex(address, 8L));
+    field("Format", {imageFormatNames[format], " ", imageSizeNames[size]});
+    field("Width", {width, " pixels"});
+  } break;
+
+  case 0x3e: {  //Set_Mask_Image
+    u32 address = op & 0x03ff'ffff;
+    argument(hex(address, 8L));
+    field("Address", hex(address, 8L));
+    field("Note", "depth buffer; shape follows the color image");
+  } break;
+
+  }
+
+  decoded.arguments = arguments;
+  decoded.fields = fields;
+  return decoded;
+}
+
+auto RDP::Debugger::capturedCommandWords(u32 index) const -> const std::vector<u32>* {
+  auto frame = frameCapture();
+  if(!frame || index >= frame->commandOffsets.size()) return nullptr;
+  auto& words = frame->packets[frame->commandOffsets[index]].words;
+  return words.empty() ? nullptr : &words;
+}
+
+auto RDP::Debugger::captureCommandText(u32 index) const -> string {
+  auto words = capturedCommandWords(index);
+  if(!words) return {};
+  return decodeCommand(*words).name;
+}
+
+auto RDP::Debugger::captureCommandArguments(u32 index) const -> string {
+  auto words = capturedCommandWords(index);
+  if(!words) return {};
+  return decodeCommand(*words).arguments;
+}
+
+auto RDP::Debugger::captureCommandOpcode(u32 index) const -> u32 {
+  auto words = capturedCommandWords(index);
+  return words ? (*words)[0] >> 24 & 63 : 0;
+}
+
+auto RDP::Debugger::captureCommandType(u32 index) const -> u32 {
+  auto frame = frameCapture();
+  if(!frame || index >= frame->commandOffsets.size()) return 0;
+  auto& words = frame->packets[frame->commandOffsets[index]].words;
+  if(words.empty()) return 0;
+  u32 opcode = words[0] >> 24 & 63;
+  if(opcode >= 0x08 && opcode <= 0x0f) return 1;  //triangle
+  if(opcode == 0x24 || opcode == 0x25 || opcode == 0x36) return 1;  //rectangle
+  if(opcode == 0x30 || (opcode >= 0x32 && opcode <= 0x35)) return 2;  //load
+  if(opcode >= 0x26 && opcode <= 0x29) return 3;  //sync
+  return 4;  //state
+}
+
+auto RDP::Debugger::captureCommandDetail(u32 index) const -> string {
+  auto words = capturedCommandWords(index);
+  if(!words) return {};
+  auto decoded = decodeCommand(*words);
+
+  string output{
+    decoded.name, "   opcode 0x", hex((*words)[0] >> 24 & 63, 2L),
+    "   ", words->size(), " words\n\n"
+  };
+  for(auto& line : nall::split(decoded.fields, "\n")) {
+    if(!line) continue;
+    auto pair = nall::split(line, "\t", 1L);
+    output.append(pad(pair[0], -18L), pair.size() > 1 ? pair[1] : string{}, "\n");
+  }
+
+  //The raw words stay available below the decode, one 64-bit command word per
+  //line, which is how the encoding is documented.
+  output.append("\n");
+  for(u32 offset = 0; offset < words->size(); offset += 2) {
+    output.append(hex(offset * 4, 4L), "  ", hex((*words)[offset], 8L), " ",
+      offset + 1 < words->size() ? hex((*words)[offset + 1], 8L) : string{}, "\n");
+  }
+  return output;
+}
+
+auto RDP::Debugger::captureSummary() const -> string {
+  auto frame = frameCapture();
+  if(!frame) return "No completed capture.";
+
+  u32 diffs = 0;
+  u64 diffBytes = 0;
+  u32 viWrites = 0;
+  u32 scanouts = 0;
+  for(auto& packet : frame->packets) {
+    if(packet.type == RDPFrameCapture::Packet::Type::DramDiff) {
+      diffs++;
+      diffBytes += packet.bytes.size();
+    }
+    if(packet.type == RDPFrameCapture::Packet::Type::ViRegister) viWrites++;
+    if(packet.type == RDPFrameCapture::Packet::Type::Scanout) scanouts++;
+  }
+
+  return {
+    "Commands: ", frame->commandOffsets.size(),
+    "   Packets: ", frame->packets.size(),
+    "   DRAM diffs: ", diffs, " (", diffBytes / 1_KiB, " KiB)",
+    "   VI writes: ", viWrites,
+    "   Scanouts: ", scanouts
+  };
+}
+
+auto RDP::Debugger::captureViews() const -> std::vector<string> {
+  #if defined(VULKAN)
+  if(vulkan.enable) return {"Color", "Depth", "Coverage", "Tiles"};
+  #endif
+  return {};
+}
+
+//Decodes one tile descriptor's texels out of the replayed TMEM. Two separate address
+//transforms apply, both mirroring parallel-rdp/shaders/texture.h:
+//  * odd texel rows are stored with their two 32-bit halves swapped (byte offset ^ 4),
+//  * parallel-RDP keeps TMEM as native-endian 16-bit words at swizzled indices, so a
+//    byte view of the buffer needs (byte offset ^ 3) to read TMEM's big-endian bytes.
+//Both are folded into readByte, so readHalf composes big-endian halfwords as usual.
+auto RDP::Debugger::renderCaptureTile(
+  const u8* tmem, const RDPCaptureState& state, u32 tileIndex
+) const -> Core::Debugger::GraphicsFrame::Image {
+  Core::Debugger::GraphicsFrame::Image image;
+  auto& tile = state.tiles[tileIndex];
+  if(!tile.set || !tmem) return image;
+
+  u32 width  = tile.s1 >= tile.s0 ? ((tile.s1 - tile.s0) >> 2) + 1 : 0;
+  u32 height = tile.t1 >= tile.t0 ? ((tile.t1 - tile.t0) >> 2) + 1 : 0;
+  if(width <= 1 && height <= 1) return image;  //no Set_Tile_Size seen
+  width = min(width, 512u);
+  height = min(height, 512u);
+
+  u32 base = tile.address * 8;
+  u32 stride = tile.line * 8;
+  bool tlutIA = state.otherModes >> 46 & 1;
+
+  //RGBA32 splits its texels across both halves of TMEM and TLUT'd formats keep the
+  //palette in the high half, so in both cases texel addresses wrap at 0x7ff.
+  u32 addressMask = tile.size == 3 || tile.format == 2 ? 0x7ff : 0xfff;
+
+  auto readByte = [&](u32 offset) -> u8 { return tmem[(offset & 0xfff) ^ 3]; };
+  auto readHalf = [&](u32 offset) -> u16 {
+    return readByte(offset) << 8 | readByte(offset + 1);
+  };
+  auto fromRGBA16 = [](u16 pixel) -> u32 {
+    return rdpDecodeRGBA16(pixel);
+  };
+  auto fromGray = [](u8 intensity) -> u32 {
+    return rdpDecodeGray(intensity);
+  };
+  //TLUT entries live in the high half of TMEM, each replicated across 8 bytes.
+  auto fromTLUT = [&](u32 index) -> u32 {
+    u16 entry = readHalf(0x800 + index * 8);
+    return tlutIA ? fromGray(entry >> 8) : fromRGBA16(entry);
+  };
+
+  image.width = width;
+  image.height = height;
+  image.pixels.resize(width * height, 0xff000000);
+
+  for(u32 y : range(height)) {
+    u32 row = base + y * stride;
+    u32 swap = y & 1 ? 4 : 0;
+    for(u32 x : range(width)) {
+      u32 color = 0xff000000;
+      u32 wide = ((row + x * 2) & addressMask) ^ swap;
+      u32 narrow = ((row + x) & addressMask) ^ swap;
+      if(tile.size == 3 && tile.format == 0) {          //RGBA32: RG low, BA high
+        u16 rg = readHalf(wide);
+        u16 ba = readHalf(wide + 0x800);
+        color = 0xff000000 | (rg >> 8) << 16 | (rg & 0xff) << 8 | (ba >> 8);
+      } else if(tile.size == 2 && tile.format == 0) {   //RGBA16
+        color = fromRGBA16(readHalf(wide));
+      } else if(tile.size == 2 && tile.format == 3) {   //IA16
+        color = fromGray(readHalf(wide) >> 8);
+      } else if(tile.size == 1 && tile.format == 2) {   //CI8
+        color = fromTLUT(readByte(narrow));
+      } else if(tile.size == 1 && tile.format == 3) {   //IA8
+        color = fromGray((readByte(narrow) >> 4) * 17);
+      } else if(tile.size == 1 && tile.format == 4) {   //I8
+        color = fromGray(readByte(narrow));
+      } else if(tile.size == 0) {                       //4bpp
+        u8 byte = readByte(((row + x / 2) & addressMask) ^ swap);
+        u8 nibble = x & 1 ? byte & 15 : byte >> 4;
+        if(tile.format == 2) color = fromTLUT(tile.palette << 4 | nibble);
+        else if(tile.format == 3) color = fromGray((nibble >> 1) * 36);
+        else color = fromGray(nibble * 17);
+      }
+      image.pixels[y * width + x] = color;
+    }
+  }
+  return image;
+}
+
+//Latches one state-setting command. words[0] holds command bits 63..32 and
+//words[1] bits 31..0, so a command bit N >= 32 is words[0] bit N-32.
+static auto applyStateCommand(RDPCaptureState& state, const u32* words, u32 wordCount) -> void {
+  if(wordCount < 2) return;
+  u32 opcode = words[0] >> 24 & 63;
+  u32 hi = words[0], lo = words[1];
+
+  switch(opcode) {
+  case 0x2a:  //Set_Key_GB
+    state.keyGB = lo;
+    break;
+  case 0x2b:  //Set_Key_R
+    state.keyR = lo;
+    break;
+  case 0x2c:  //Set_Convert
+    state.convert = (u64)hi << 32 | lo;
+    break;
+  case 0x2d:  //Set_Scissor
+    state.scissorX0 = hi >> 12 & 0xfff;
+    state.scissorY0 = hi >>  0 & 0xfff;
+    state.scissorField = lo >> 25 & 1;
+    state.scissorOdd = lo >> 24 & 1;
+    state.scissorX1 = lo >> 12 & 0xfff;
+    state.scissorY1 = lo >>  0 & 0xfff;
+    break;
+  case 0x2e:  //Set_Prim_Depth
+    state.primDepthZ = lo >> 16 & 0xffff;
+    state.primDepthDZ = lo >> 0 & 0xffff;
+    break;
+  case 0x2f:  //Set_Other_Modes
+    state.otherModes = (u64)hi << 32 | lo;
+    break;
+  case 0x32: {  //Set_Tile_Size
+    auto& tile = state.tiles[lo >> 24 & 7];
+    tile.s0 = hi >> 12 & 0xfff;
+    tile.t0 = hi >>  0 & 0xfff;
+    tile.s1 = lo >> 12 & 0xfff;
+    tile.t1 = lo >>  0 & 0xfff;
+    tile.set = true;
+    break;
+  }
+  case 0x35: {  //Set_Tile
+    auto& tile = state.tiles[lo >> 24 & 7];
+    tile.format = hi >> 21 & 7;
+    tile.size = hi >> 19 & 3;
+    tile.line = hi >> 9 & 0x1ff;
+    tile.address = hi >> 0 & 0x1ff;
+    tile.palette = lo >> 20 & 15;
+    tile.clampT = lo >> 19 & 1;
+    tile.mirrorT = lo >> 18 & 1;
+    tile.maskT = lo >> 14 & 15;
+    tile.shiftT = lo >> 10 & 15;
+    tile.clampS = lo >> 9 & 1;
+    tile.mirrorS = lo >> 8 & 1;
+    tile.maskS = lo >> 4 & 15;
+    tile.shiftS = lo >> 0 & 15;
+    tile.set = true;
+    break;
+  }
+  case 0x37:  //Set_Fill_Color
+    state.fillColor = lo;
+    break;
+  case 0x38:  //Set_Fog_Color
+    state.fogColor = lo;
+    break;
+  case 0x39:  //Set_Blend_Color
+    state.blendColor = lo;
+    break;
+  case 0x3a:  //Set_Prim_Color
+    state.primMinLevel = hi >> 8 & 31;
+    state.primLevelFraction = hi >> 0 & 0xff;
+    state.primColor = lo;
+    break;
+  case 0x3b:  //Set_Env_Color
+    state.envColor = lo;
+    break;
+  case 0x3c:  //Set_Combine
+    state.combine = (u64)hi << 32 | lo;
+    break;
+  case 0x3d:  //Set_Texture_Image
+    state.textureFormat = hi >> 21 & 7;
+    state.textureSize = hi >> 19 & 3;
+    state.textureWidth = (hi & 1023) + 1;
+    state.textureAddress = lo & 0x03ff'ffff;
+    break;
+  case 0x3e:  //Set_Mask_Image
+    state.depthAddress = lo & 0x03ff'ffff;
+    break;
+  case 0x3f:  //Set_Color_Image
+    state.colorFormat = hi >> 21 & 7;
+    state.colorSize = hi >> 19 & 3;
+    state.colorWidth = (hi & 1023) + 1;
+    state.colorAddress = lo & 0x03ff'ffff;
+    break;
+  }
+}
+
+auto RDP::Debugger::captureStateAt(u32 command) const -> RDPCaptureState {
+  RDPCaptureState state;
+  auto frame = frameCapture();
+  if(!frame) return state;
+
+  for(auto& words : frame->initialCommands) {
+    applyStateCommand(state, words.data(), words.size());
+  }
+
+  u32 commandIndex = 0;
+  for(auto& packet : frame->packets) {
+    if(packet.type != RDPFrameCapture::Packet::Type::Commands) continue;
+    applyStateCommand(state, packet.words.data(), packet.words.size());
+    if(commandIndex++ == command) break;
+  }
+  return state;
+}
+
+auto RDP::Debugger::captureStateText(u32 command) const -> string {
+  auto frame = frameCapture();
+  if(!frame) return "No completed capture.";
+  auto state = captureStateAt(command);
+  auto modes = state.otherModes;
+  auto combine = state.combine;
+
+  //One field/value pair per line, tab separated; the frontend splits this into a
+  //two column table.
+  string text;
+  auto row = [&](const string& name, const string& value) {
+    text.append(name, "\t", value, "\n");
+  };
+
+  string scissor{
+    formatFixed102(state.scissorX0), ", ", formatFixed102(state.scissorY0), "  ->  ",
+    formatFixed102(state.scissorX1), ", ", formatFixed102(state.scissorY1)
+  };
+  if(state.scissorField) scissor.append("  field ", state.scissorOdd ? "odd" : "even");
+
+  row("Color Image", {hex(state.colorAddress, 8L), "  ",
+    imageFormatNames[state.colorFormat], " ", imageSizeNames[state.colorSize],
+    "  width ", state.colorWidth});
+  row("Depth Image", hex(state.depthAddress, 8L));
+  row("Texture Image", {hex(state.textureAddress, 8L), "  ",
+    imageFormatNames[state.textureFormat], " ", imageSizeNames[state.textureSize],
+    "  width ", state.textureWidth});
+  row("Scissor", scissor);
+
+  row("Cycle Type", cycleNames[modes >> 52 & 3]);
+  row("Z Mode", zModeNames[modes >> 10 & 3]);
+  row("Coverage", coverageNames[modes >> 8 & 3]);
+  row("Blender 0", blendEquation(modes, 0));
+  row("Blender 1", blendEquation(modes, 1));
+  row("Other Modes", hex(modes & 0x00ff'ffff'ffff'ffffull, 14L));
+  row("Flags", otherModesFlags(modes));
+
+  row("Combine RGB 0", combineEquation(
+    combineSubA, combine >> 52 & 15, combineSubB, combine >> 28 & 15,
+    combineMul,  combine >> 47 & 31, combineAdd,  combine >> 15 & 7));
+  row("Combine Alpha 0", combineEquation(
+    combineAlpha, combine >> 44 & 7, combineAlpha,    combine >> 12 & 7,
+    combineAlphaMul, combine >> 41 & 7, combineAlpha, combine >>  9 & 7));
+  row("Combine RGB 1", combineEquation(
+    combineSubA, combine >> 37 & 15, combineSubB, combine >> 24 & 15,
+    combineMul,  combine >> 32 & 31, combineAdd,  combine >>  6 & 7));
+  row("Combine Alpha 1", combineEquation(
+    combineAlpha, combine >> 21 & 7, combineAlpha,    combine >>  3 & 7,
+    combineAlphaMul, combine >> 18 & 7, combineAlpha, combine >>  0 & 7));
+
+  row("Fill Color", hex(state.fillColor, 8L));
+  row("Fog Color", hex(state.fogColor, 8L));
+  row("Blend Color", hex(state.blendColor, 8L));
+  row("Primitive Color", {hex(state.primColor, 8L),
+    "   LOD ", state.primMinLevel, "/", state.primLevelFraction});
+  row("Environment Color", hex(state.envColor, 8L));
+  row("Primitive Depth", {"z ", state.primDepthZ, "  dz ", state.primDepthDZ});
+  row("Key R / GB", {hex(state.keyR, 8L), " / ", hex(state.keyGB, 8L)});
+  row("Convert", hex(state.convert & 0x00ff'ffff'ffff'ffffull, 14L));
+
+  for(u32 index : range(8)) {
+    auto& tile = state.tiles[index];
+    if(!tile.set) continue;
+    string clamp;
+    clamp.append(tile.clampS ? "C" : tile.mirrorS ? "M" : "-");
+    clamp.append(tile.clampT ? "C" : tile.mirrorT ? "M" : "-");
+    row({"Tile ", index}, {
+      pad(string{imageFormatNames[tile.format], " ", imageSizeNames[tile.size]}, -11L),
+      "  TMEM ", hex(tile.address * 8, 4L),
+      "  line ", pad(string{tile.line * 8}, -4L),
+      "  pal ", tile.palette,
+      "  mask ", tile.maskS, "/", tile.maskT,
+      "  shift ", tile.shiftS, "/", tile.shiftT,
+      "  cm ", clamp,
+      "  ", formatFixed102(tile.s0), ", ", formatFixed102(tile.t0),
+      " -> ", formatFixed102(tile.s1), ", ", formatFixed102(tile.t1)
+    });
+  }
+
+  #if defined(VULKAN)
+  if(auto error = vulkan.replayCrashed()) row("Replay RDP Crash", error);
+  #endif
+  return text;
+}
+
+static auto hashBytes(u64 hash, const void* data, u64 size) -> u64 {
+  auto bytes = (const u8*)data;
+  for(u64 offset = 0; offset < size; offset++) {
+    hash = (hash ^ bytes[offset]) * 0x0000'0100'0000'01b3ull;  //FNV-1a
+  }
+  return hash;
+}
+
+//Games emit a sync around nearly every state change, so most syncs in a capture
+//see the same image as the one before them. A scrollback entry is only useful
+//where something observable changed, which is decided by hashing the color,
+//depth and coverage buffers as they stand at each sync: the capture is replayed
+//once from beginning to end and a sync is kept when its hash differs from the
+//last kept one. Replaying to every sync in turn costs one GPU flush per sync, so
+//the result is cached for the lifetime of the capture.
+auto RDP::Debugger::captureTicks() -> std::vector<u32> {
+  auto frame = frameCapture();
+  if(!frame) return {};
+  if(tickIdentifier == frame->identifier) return tickCommands;
+  tickIdentifier = frame->identifier;
+  tickCommands.clear();
+
+  #if defined(VULKAN)
+  if(!vulkan.enable) return tickCommands;
+
+  RDPCaptureState state;
+  for(auto& words : frame->initialCommands) {
+    applyStateCommand(state, words.data(), words.size());
+  }
+
+  u64 previousHash = 0;
+  bool havePrevious = false;
+  u32 commandIndex = 0;
+  for(auto& packet : frame->packets) {
+    if(packet.type != RDPFrameCapture::Packet::Type::Commands) continue;
+    u32 index = commandIndex++;
+    if(packet.words.empty()) continue;
+    applyStateCommand(state, packet.words.data(), packet.words.size());
+
+    u32 opcode = packet.words[0] >> 24 & 63;
+    if(opcode < 0x26 || opcode > 0x29) continue;  //Sync Load/Pipe/Tile/Full
+    if(!vulkan.replay(*frame, index)) continue;
+    auto memory = vulkan.replayRdram();
+    if(!memory) continue;
+    auto hidden = vulkan.replayHiddenRdram();
+
+    u32 width = max(1u, state.colorWidth);
+    u32 height = min(480u, (state.scissorY1 > state.scissorY0
+      ? state.scissorY1 - state.scissorY0 + 3 : 4) >> 2);
+    u32 bytesPerPixel = state.colorSize == 3 ? 4 : state.colorSize == 2 ? 2 : 1;
+
+    //The buffer descriptions are hashed alongside their contents so that
+    //retargeting to an identically shaped buffer still counts as a change.
+    u32 description[7] = {
+      state.colorAddress, state.colorFormat, state.colorSize,
+      width, height, state.depthAddress, (u32)(state.otherModes >> 8 & 3)
+    };
+    u64 hash = hashBytes(0xcbf2'9ce4'8422'2325ull, description, sizeof(description));
+
+    auto hashRegion = [&](u64 address, u64 size, const u8* data, u64 dataSize) {
+      if(!data || address >= dataSize) return;
+      hash = hashBytes(hash, data + address, min(size, dataSize - address));
+    };
+    u64 pixels = (u64)width * height;
+    hashRegion(state.colorAddress, pixels * bytesPerPixel, memory->data, memory->size);
+    hashRegion(state.depthAddress, pixels * 2, memory->data, memory->size);
+    hashRegion(state.colorAddress / 2, pixels * bytesPerPixel / 2, hidden, memory->size / 2);
+
+    if(havePrevious && hash == previousHash) continue;
+    previousHash = hash;
+    havePrevious = true;
+    tickCommands.push_back(index);
+  }
+  #endif
+  return tickCommands;
+}
+
+auto RDP::Debugger::renderCapture(
+  u32 command, u32 view
+) -> Core::Debugger::GraphicsFrame::Image {
+  Core::Debugger::GraphicsFrame::Image image;
+  auto frame = frameCapture();
+  #if !defined(VULKAN)
+  return image;
+  #else
+  if(!frame || !vulkan.replay(*frame, command)) return image;
+
+  auto state = captureStateAt(command);
+
+  //All eight tile descriptors composited into one image on a fixed 4x2 grid, so a
+  //tile's position identifies it without needing per-cell labels.
+  if(view == 3) {
+    auto tmem = vulkan.replayTMEM();
+    if(!tmem) return image;
+
+    Core::Debugger::GraphicsFrame::Image tiles[8];
+    u32 cellWidth = 0, cellHeight = 0;
+    for(u32 index : range(8)) {
+      tiles[index] = renderCaptureTile(tmem, state, index);
+      cellWidth = max(cellWidth, tiles[index].width);
+      cellHeight = max(cellHeight, tiles[index].height);
+    }
+    if(!cellWidth || !cellHeight) return image;
+
+    static constexpr u32 columns = 4, rows = 2;
+    image.width = columns * (cellWidth + 1) + 1;
+    image.height = rows * (cellHeight + 1) + 1;
+    image.pixels.resize(image.width * image.height, 0xff303030);  //gutters
+
+    for(u32 index : range(8)) {
+      u32 originX = (index % columns) * (cellWidth + 1) + 1;
+      u32 originY = (index / columns) * (cellHeight + 1) + 1;
+      for(u32 y : range(cellHeight)) {
+        for(u32 x : range(cellWidth)) {
+          bool inside = x < tiles[index].width && y < tiles[index].height;
+          image.pixels[(originY + y) * image.width + originX + x] =
+            inside ? tiles[index].pixels[y * tiles[index].width + x] : 0xff000000;
+        }
+      }
+    }
+    return image;
+  }
+
+  auto memory = vulkan.replayRdram();
+  auto hidden = vulkan.replayHiddenRdram();
+  if(!memory) return image;
+  //Crop to the scissor rectangle on both axes. Scissor coordinates are 10.2 fixed
+  //point; the buffer's row stride stays colorWidth regardless of the crop.
+  u32 stride = max(1u, state.colorWidth);
+  auto region = rdpImageRegion(
+    stride, state.scissorX0, state.scissorY0, state.scissorX1, state.scissorY1
+  );
+  u32 sourceX = region.x;
+  u32 sourceY = region.y;
+  image.width = region.width;
+  image.height = region.height;
+  image.pixels.resize(image.width * image.height, 0xff000000);
+
+  //The replay RDRAM uses the same word-swapped layout as real RDRAM, so read it
+  //through the same accessors rather than indexing the raw bytes.
+  auto readByte = [&](u64 address) -> u8 {
+    if(address >= memory->size) return 0;
+    return memory->read<Byte>(address);
+  };
+  auto readHalf = [&](u64 address) -> u16 {
+    if(address + 2 > memory->size) return 0;
+    return memory->read<Half>(address);
+  };
+  auto readWord = [&](u64 address) -> u32 {
+    if(address + 4 > memory->size) return 0;
+    return memory->read<Word>(address);
+  };
+  u32 minimumDepth = 0x3ffff;
+  u32 maximumDepth = 0;
+  if(view == 1) {
+    for(u32 y : range(image.height)) {
+      for(u32 x : range(image.width)) {
+        u64 sourceIndex = (u64)(y + sourceY) * stride + (x + sourceX);
+        u16 encoded = readHalf(state.depthAddress + sourceIndex * 2) >> 2;
+        if(encoded == 0x3fff) continue;
+        u32 depth = rdpDecompressDepth(encoded);
+        minimumDepth = min(minimumDepth, depth);
+        maximumDepth = max(maximumDepth, depth);
+      }
+    }
+  }
+
+  for(u32 y : range(image.height)) {
+    for(u32 x : range(image.width)) {
+      u64 outputIndex = (u64)y * image.width + x;
+      u64 sourceIndex = (u64)(y + sourceY) * stride + (x + sourceX);
+      if(view == 0) {
+        if(state.colorSize == 2 && state.colorFormat == 0) {
+          u16 pixel = readHalf(state.colorAddress + sourceIndex * 2);
+          image.pixels[outputIndex] = rdpDecodeRGBA16(pixel);
+        } else if(state.colorSize == 3 && state.colorFormat == 0) {
+          image.pixels[outputIndex] = 0xff000000
+            | readWord(state.colorAddress + sourceIndex * 4) >> 8;
+        } else if(state.colorSize == 1 && (state.colorFormat == 2 || state.colorFormat == 4)) {
+          u64 address = state.colorAddress + sourceIndex;
+          if(address < memory->size) {
+            u8 intensity = readByte(address);
+            image.pixels[outputIndex] =
+              rdpDecodeGray(intensity);
+          }
+        }
+      }
+      if(view == 1) {
+        u16 encoded = readHalf(state.depthAddress + sourceIndex * 2) >> 2;
+        u8 intensity = 0;
+        if(encoded != 0x3fff) {
+          u32 depth = rdpDecompressDepth(encoded);
+          u32 range = maximumDepth - minimumDepth;
+          intensity = range ? 255 - (depth - minimumDepth) * 223 / range : 255;
+        }
+        image.pixels[outputIndex] =
+          rdpDecodeGray(intensity);
+      }
+      if(view == 2 && hidden) {
+        u64 colorAddress = state.colorAddress + sourceIndex * 2;
+        u64 hiddenAddress = colorAddress >> 1;
+        if(colorAddress + 2 <= memory->size
+        && hiddenAddress < memory->size / 2) {
+          u16 color = readHalf(colorAddress);
+          u8 coverage = (color & 1) << 2 | (hidden[hiddenAddress] & 3);
+          u8 intensity = coverage * 255 / 7;
+          image.pixels[outputIndex] =
+            rdpDecodeGray(intensity);
+        }
+      }
+    }
+  }
+  return image;
+  #endif
+}
+
+auto RDP::Debugger::resetCapture() -> void {
+  capture = std::make_unique<Capture>();
+  presentBuffer = ~0u;
+  tickIdentifier = 0;
+  tickCommands.clear();
+  cachedCommands.clear();
+  cachedCommands.resize(80);
+  cachedCommandSequence = 0;
+}
+
+auto RDP::Debugger::beginCapture() -> void {
+  capture->ready.store(false, std::memory_order_relaxed);
+  capture->frame = {};
+  capture->frame.identifier = nextCaptureIdentifier++;
+  #if defined(VULKAN)
+  vulkan.synchronize();
+  if(vulkan.enable) {
+    //Kept in parallel-RDP's native layout: it is handed straight back to set_tmem().
+    capture->frame.tmem.resize(4_KiB);
+    if(!vulkan.copyTMEM(capture->frame.tmem.data(), 4_KiB)) capture->frame.tmem.clear();
+  }
+  #endif
+  capture->frame.rdram.assign(rdram.ram.data, rdram.ram.data + rdram.ram.size);
+  capture->shadowRdram = capture->frame.rdram;
+  if(rdram.hidden.data) {
+    capture->frame.hiddenRdram.assign(
+      rdram.hidden.data, rdram.hidden.data + rdram.ram.size / 2
+    );
+  }
+  std::vector<const CachedCommand*> orderedState;
+  for(auto& command : cachedCommands) {
+    if(command.sequence) orderedState.push_back(&command);
+  }
+  std::sort(orderedState.begin(), orderedState.end(), [](auto lhs, auto rhs) {
+    return lhs->sequence < rhs->sequence;
+  });
+  for(auto command : orderedState) {
+    capture->frame.initialCommands.push_back(command->words);
+  }
+  capture->active = true;
+  capture->inCommandList = false;
+  capture->activeFields = 0;
+  for(u32 address : range(14)) {
+    captureViRegister(address, vi.readWord(address * 4, vi));
+  }
+}
+
+auto RDP::Debugger::endCapture() -> void {
+  commandBatch();
+  capture->active = false;
+  capture->shadowRdram.clear();
+  capture->ready.store(true, std::memory_order_release);
+}
+
+auto RDP::Debugger::presentBoundary(u32 origin) -> void {
+  u32 buffer = origin >> 12;
+  if(buffer == presentBuffer) return;
+  presentBuffer = buffer;
+  if(!capture) return;
+
+  if(capture->active) {
+    if(capture->frame.commandOffsets.empty()) return;
+    endCapture();
+    return;
+  }
+
+  if(!capture->armed.exchange(false, std::memory_order_acquire)) return;
+  beginCapture();
+}
+
+auto RDP::Debugger::frameBoundary() -> void {
+  if(!capture) return;
+  static constexpr u32 fallbackFields = 4;
+
+  if(capture->active) {
+    if(capture->frame.commandOffsets.empty()) {
+      beginCapture();
+      return;
+    }
+    if(++capture->activeFields >= fallbackFields) endCapture();
+    return;
+  }
+
+  if(!capture->armed.load(std::memory_order_acquire)) return;
+  if(++capture->armedFields < fallbackFields) return;
+  if(!capture->armed.exchange(false, std::memory_order_acquire)) return;
+  beginCapture();
+}
+
+auto RDP::Debugger::commandBatch() -> void {
+  if(!capture || !capture->active) return;
+  if(capture->inCommandList) return;
+  capture->inCommandList = true;
+
+  #if defined(VULKAN)
+  if(vulkan.enable) vulkan.synchronize();
+  #endif
+
+  static constexpr u32 blockSize = 4_KiB;
+  for(u32 address = 0; address < rdram.ram.size; address += blockSize) {
+    u32 size = min(blockSize, rdram.ram.size - address);
+    if(std::memcmp(
+      rdram.ram.data + address, capture->shadowRdram.data() + address, size
+    ) == 0) continue;
+
+    RDPFrameCapture::Packet packet;
+    packet.type = RDPFrameCapture::Packet::Type::DramDiff;
+    packet.address = address;
+    packet.bytes.assign(rdram.ram.data + address, rdram.ram.data + address + size);
+    capture->frame.packets.push_back(std::move(packet));
+    std::memcpy(
+      capture->shadowRdram.data() + address, rdram.ram.data + address, size
+    );
+  }
+}
+
+auto RDP::Debugger::captureCommand(const u32* words, u32 wordCount) -> void {
+  if(!capture || !capture->active) return;
+
+  capture->frame.commandOffsets.push_back(capture->frame.packets.size());
+  RDPFrameCapture::Packet packet;
+  packet.type = RDPFrameCapture::Packet::Type::Commands;
+  packet.words.assign(words, words + wordCount);
+  capture->frame.packets.push_back(std::move(packet));
+
+  if((words[0] >> 24 & 63) == 0x29) capture->inCommandList = false;
+}
+
+auto RDP::Debugger::captureViRegister(u32 address, u32 value) -> void {
+  if(!capture || !capture->active) return;
+
+  RDPFrameCapture::Packet packet;
+  packet.type = RDPFrameCapture::Packet::Type::ViRegister;
+  packet.address = address;
+  packet.value = value;
+  capture->frame.packets.push_back(std::move(packet));
+}
+
+auto RDP::Debugger::captureScanout(bool field) -> void {
+  if(!capture || !capture->active) return;
+
+  commandBatch();
+  RDPFrameCapture::Packet packet;
+  packet.type = RDPFrameCapture::Packet::Type::Scanout;
+  packet.value = field;
+  capture->frame.packets.push_back(std::move(packet));
+}

--- a/ares/n64/rdp/capture.hpp
+++ b/ares/n64/rdp/capture.hpp
@@ -1,0 +1,100 @@
+#pragma once
+
+//Length of each RDP opcode in 64-bit command words. Shared by both command
+//consumers so capture boundaries cannot differ between renderers.
+inline constexpr u32 rdpCommandLength(u32 opcode) {
+  constexpr u8 lengths[64] = {
+    1, 1, 1, 1, 1, 1, 1, 1, 4, 6,12,14,12,14,20,22,
+    1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+    1, 1, 1, 1, 2, 2, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+    1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+  };
+  return lengths[opcode & 63];
+}
+
+inline constexpr u32 rdpDecodeRGBA16(u16 pixel) {
+  u8 r = pixel >> 11 & 31; r = r << 3 | r >> 2;
+  u8 g = pixel >>  6 & 31; g = g << 3 | g >> 2;
+  u8 b = pixel >>  1 & 31; b = b << 3 | b >> 2;
+  return 0xff000000 | r << 16 | g << 8 | b;
+}
+
+inline constexpr u32 rdpDecodeGray(u8 intensity) {
+  return 0xff000000 | intensity << 16 | intensity << 8 | intensity;
+}
+
+inline constexpr u32 rdpDecompressDepth(u16 encoded) {
+  u32 exponent = encoded >> 11;
+  u32 mantissa = encoded & 0x7ff;
+  u32 shift = exponent < 6 ? 6 - exponent : 0;
+  return (mantissa << shift) + 0x40000 - (0x40000 >> exponent);
+}
+
+struct RDPImageRegion {
+  u32 x = 0;
+  u32 y = 0;
+  u32 width = 1;
+  u32 height = 1;
+};
+
+inline auto rdpImageRegion(
+  u32 stride, u32 x0, u32 y0, u32 x1, u32 y1
+) -> RDPImageRegion {
+  RDPImageRegion region;
+  stride = stride ? stride : 1;
+  region.x = min(stride - 1, x0 >> 2);
+  region.y = y0 >> 2;
+  region.width = x1 > x0 ? (x1 - x0 + 3) >> 2 : stride;
+  region.width = max(1u, min(region.width, stride - region.x));
+  region.height = y1 > y0 ? (y1 - y0 + 3) >> 2 : 1;
+  region.height = min(480u, max(1u, region.height));
+  return region;
+}
+
+struct RDPFrameCapture {
+  u64 identifier = 0;
+
+  struct Packet {
+    enum class Type : u32 { Commands, DramDiff, ViRegister, Scanout };
+
+    Type type = Type::Commands;
+    u32 address = 0;
+    u32 value = 0;
+    std::vector<u32> words;
+    std::vector<u8> bytes;
+  };
+
+  std::vector<u8> rdram;
+  std::vector<u8> hiddenRdram;
+  std::vector<u8> tmem;
+  std::vector<std::vector<u32>> initialCommands;
+  std::vector<Packet> packets;
+  std::vector<u32> commandOffsets;
+};
+
+//RDP register file as of a given command, latched by replaying the state-setting
+//commands of a capture. Decoded from the command words rather than read back
+//from parallel-RDP, so it reports what the game wrote.
+struct RDPCaptureState {
+  struct Tile {
+    u32  format = 0, size = 0, line = 0, address = 0, palette = 0;
+    u32  maskS = 0, shiftS = 0, maskT = 0, shiftT = 0;
+    bool clampS = false, mirrorS = false, clampT = false, mirrorT = false;
+    u32  s0 = 0, t0 = 0, s1 = 0, t1 = 0;  //10.2 fixed point
+    bool set = false;
+  };
+
+  u32 colorAddress = 0, colorFormat = 0, colorSize = 0, colorWidth = 1;
+  u32 depthAddress = 0;
+  u32 textureAddress = 0, textureFormat = 0, textureSize = 0, textureWidth = 1;
+  u32 scissorX0 = 0, scissorY0 = 0, scissorX1 = 0, scissorY1 = 4;  //10.2
+  bool scissorField = false, scissorOdd = false;
+  u64 otherModes = 0;
+  u64 combine = 0;
+  u32 fillColor = 0, fogColor = 0, blendColor = 0, primColor = 0, envColor = 0;
+  u32 primMinLevel = 0, primLevelFraction = 0;
+  u32 primDepthZ = 0, primDepthDZ = 0;
+  u32 keyR = 0, keyGB = 0;
+  u64 convert = 0;
+  Tile tiles[8];
+};

--- a/ares/n64/rdp/debugger.cpp
+++ b/ares/n64/rdp/debugger.cpp
@@ -1,6 +1,186 @@
 auto RDP::Debugger::load(Node::Object parent) -> void {
+  capture = std::make_unique<Capture>();
+  cachedCommands.resize(80);
+  frame = parent->append<Node::Debugger::GraphicsFrame>("RDP Frame");
+  frame->setRequestCapture([&] { requestCapture(); });
+  frame->setCaptureValid([&] { return captureReady(); });
+  frame->setCommandCount([&] { return captureCommandCount(); });
+  frame->setCommandText([&](u32 index) { return captureCommandText(index); });
+  frame->setCommandArguments([&](u32 index) { return captureCommandArguments(index); });
+  frame->setCommandDetail([&](u32 index) { return captureCommandDetail(index); });
+  frame->setCommandOpcode([&](u32 index) { return captureCommandOpcode(index); });
+  frame->setCommandType([&](u32 index) { return captureCommandType(index); });
+  frame->setViews([&] { return captureViews(); });
+  frame->setTicks([&] { return captureTicks(); });
+  frame->setRender([&](u32 command, u32 view) { return renderCapture(command, view); });
+  frame->setState([&](u32 command) { return captureStateText(command); });
+  frame->setSummary([&] { return captureSummary(); });
+
+  graphics.color = parent->append<Node::Debugger::Graphics>("RDP Color Image");
+  graphics.depth = parent->append<Node::Debugger::Graphics>("RDP Depth Buffer");
+  graphics.coverage = parent->append<Node::Debugger::Graphics>("RDP Coverage");
+  updateGraphicsSize();
+
+  auto imageCapture = [&](u32 view) -> std::vector<u32> {
+    #if defined(VULKAN)
+    vulkan.synchronize();
+    #endif
+    updateGraphicsSize();
+    u32 width = graphics.color->width();
+    u32 height = graphics.color->height();
+    std::vector<u32> output(width * height, 0xff000000);
+    u32 base = view == 1 ? rdp.set.mask.dramAddress : rdp.set.color.dramAddress;
+    //The views are cropped to the scissor rectangle, but the buffer's row stride is
+    //still the full color image width.
+    u32 stride = max(1u, (u32)rdp.set.color.width + 1);
+    auto region = rdpImageRegion(
+      stride, rdp.scissor.x.hi, rdp.scissor.y.hi,
+      rdp.scissor.x.lo, rdp.scissor.y.lo
+    );
+    u32 sourceX = region.x;
+    u32 sourceY = region.y;
+    u32 minimumDepth = 0x3ffff;
+    u32 maximumDepth = 0;
+    if(view == 1) {
+      for(u32 y : range(height)) {
+        for(u32 x : range(width)) {
+          u64 sourceIndex = (u64)(y + sourceY) * stride + (x + sourceX);
+          u64 address = base + sourceIndex * 2;
+          if(address + 2 > rdram.ram.size) continue;
+          u16 encoded = rdram.ram.read<Half>(address, RBusDevice::ARES_DEBUGGER) >> 2;
+          if(encoded == 0x3fff) continue;  //cleared far plane
+          u32 depth = rdpDecompressDepth(encoded);
+          minimumDepth = min(minimumDepth, depth);
+          maximumDepth = max(maximumDepth, depth);
+        }
+      }
+    }
+
+    for(u32 y : range(height)) {
+      for(u32 x : range(width)) {
+        u64 index = (u64)y * width + x;
+        u64 sourceIndex = (u64)(y + sourceY) * stride + (x + sourceX);
+        if(view == 0) {
+          u32 format = rdp.set.color.format;
+          u32 size = rdp.set.color.size;
+          if(size == 2) {
+            u64 address = base + sourceIndex * 2;
+            if(address + 2 > rdram.ram.size || format != 0) continue;
+            u16 pixel = rdram.ram.read<Half>(address, RBusDevice::ARES_DEBUGGER);
+            output[index] = rdpDecodeRGBA16(pixel);
+          } else if(size == 3) {
+            u64 address = base + sourceIndex * 4;
+            if(address + 4 > rdram.ram.size || format != 0) continue;
+            output[index] = 0xff000000
+              | rdram.ram.read<Word>(address, RBusDevice::ARES_DEBUGGER) >> 8;
+          } else if(size == 1 && (format == 2 || format == 4)) {
+            u64 address = base + sourceIndex;
+            if(address >= rdram.ram.size) continue;
+            u8 intensity = rdram.ram.read<Byte>(address, RBusDevice::ARES_DEBUGGER);
+            output[index] = rdpDecodeGray(intensity);
+          }
+        } else if(view == 1) {
+          u64 address = base + sourceIndex * 2;
+          if(address + 2 > rdram.ram.size) continue;
+          //RDP Z is a 14-bit inverted floating-point value; the low two bits
+          //belong to compressed delta-Z.
+          u16 encoded = rdram.ram.read<Half>(address, RBusDevice::ARES_DEBUGGER) >> 2;
+          u8 intensity = 0;
+          if(encoded != 0x3fff) {
+            u32 depth = rdpDecompressDepth(encoded);
+            u32 range = maximumDepth - minimumDepth;
+            intensity = range ? 255 - (depth - minimumDepth) * 223 / range : 255;
+          }
+          output[index] = rdpDecodeGray(intensity);
+        } else {
+          u64 address = (base + sourceIndex * 2) >> 1;
+          if(!rdram.hidden.data || address >= rdram.ram.size / 2) continue;
+          u8 coverage = 7;
+          if(rdp.set.color.size == 2) {
+            u64 colorAddress = base + sourceIndex * 2;
+            if(colorAddress + 2 > rdram.ram.size) continue;
+            u16 color = rdram.ram.read<Half>(colorAddress, RBusDevice::ARES_DEBUGGER);
+            coverage = (color & 1) << 2 | (rdram.hidden.data[address] & 3);
+          } else if(rdp.set.color.size == 3) {
+            u64 colorAddress = base + sourceIndex * 4;
+            if(colorAddress + 4 > rdram.ram.size) continue;
+            u32 color = rdram.ram.read<Word>(colorAddress, RBusDevice::ARES_DEBUGGER);
+            coverage = (color & 0xff) >> 5;
+          }
+          u8 intensity = coverage * 255 / 7;
+          output[index] = rdpDecodeGray(intensity);
+        }
+      }
+    }
+    return output;
+  };
+  graphics.color->setCapture([=] { return imageCapture(0); });
+  graphics.depth->setCapture([=] { return imageCapture(1); });
+  graphics.coverage->setCapture([=] { return imageCapture(2); });
+
+  //No fixed-format TMEM image views: TMEM has no inherent width, format or origin —
+  //only a tile descriptor gives it one, so the frame debugger's Tiles view is the only
+  //place it can be decoded correctly. The hex view below stays; it makes no such claim.
+  tmem = parent->append<Node::Debugger::Memory>("RDP TMEM");
+  tmem->setSize(4_KiB);
+  tmem->setRead([&](u32 address) -> u8 {
+    #if defined(VULKAN)
+    return vulkan.readTMEM(address);
+    #else
+    return 0;
+    #endif
+  });
+
   tracer.command = parent->append<Node::Debugger::Tracer::Notification>("Command", "RDP");
   tracer.io = parent->append<Node::Debugger::Tracer::Notification>("I/O", "RDP");
+}
+
+auto RDP::Debugger::updateGraphicsSize() -> void {
+  if(!graphics.color) return;
+  //The struct names identify the high and low command-word halves, not the
+  //numeric ordering of the coordinates. The first endpoint is normally smaller.
+  u32 stride = max(1u, (u32)rdp.set.color.width + 1);
+  auto region = rdpImageRegion(
+    stride, rdp.scissor.x.hi, rdp.scissor.y.hi,
+    rdp.scissor.x.lo, rdp.scissor.y.lo
+  );
+  graphics.color->setSize(region.width, region.height);
+  graphics.depth->setSize(region.width, region.height);
+  graphics.coverage->setSize(region.width, region.height);
+}
+
+//The Vulkan renderer consumes the command list before the software decoder sees it.
+//Shadow the small amount of state needed by the live graphics nodes here.
+auto RDP::Debugger::observeCommand(u32 code, const u32* words, u32 wordCount) -> void {
+  u32 cacheIndex = code;
+  bool cache = (code >= 0x2a && code <= 0x2f) || (code >= 0x37 && code <= 0x3f);
+  if(code == 0x32) cache = true, cacheIndex = 64 + (words[1] >> 24 & 7);
+  if(code == 0x35) cache = true, cacheIndex = 72 + (words[1] >> 24 & 7);
+  if(cache) {
+    auto& command = cachedCommands[cacheIndex];
+    command.sequence = ++cachedCommandSequence;
+    command.words.assign(words, words + wordCount);
+  }
+
+  if(code == 0x2d) {
+    rdp.scissor.x.hi = words[0] >> 12 & 0xfff;
+    rdp.scissor.y.hi = words[0] >>  0 & 0xfff;
+    rdp.scissor.field = words[1] >> 25 & 1;
+    rdp.scissor.odd = words[1] >> 24 & 1;
+    rdp.scissor.x.lo = words[1] >> 12 & 0xfff;
+    rdp.scissor.y.lo = words[1] >>  0 & 0xfff;
+    updateGraphicsSize();
+  }
+  if(code == 0x3e) {
+    rdp.set.mask.dramAddress = words[1] & 0x03ff'ffff;
+  }
+  if(code == 0x3f) {
+    rdp.set.color.format = words[0] >> 21 & 7;
+    rdp.set.color.size = words[0] >> 19 & 3;
+    rdp.set.color.width = words[0] & 1023;
+    rdp.set.color.dramAddress = words[1] & 0x03ff'ffff;
+    updateGraphicsSize();
+  }
 }
 
 auto RDP::Debugger::command(string_view message) -> void {

--- a/ares/n64/rdp/rdp.cpp
+++ b/ares/n64/rdp/rdp.cpp
@@ -6,6 +6,7 @@ RDP rdp;
 #include "render.cpp"
 #include "io.cpp"
 #include "debugger.cpp"
+#include "capture.cpp"
 #include "serialization.cpp"
 
 auto RDP::load(Node::Object parent) -> void {
@@ -61,6 +62,7 @@ auto RDP::power(bool reset) -> void {
   io.bist = {};
   io.test = {};
   if(!reset) mapIdentityWarned = 0;
+  debugger.resetCapture();
 }
 
 }

--- a/ares/n64/rdp/rdp.hpp
+++ b/ares/n64/rdp/rdp.hpp
@@ -1,4 +1,5 @@
 //Reality Display Processor
+#include <n64/rdp/capture.hpp>
 
 struct RDP : Thread, Memory::RCP<RDP> {
   Node::Object node;
@@ -9,6 +10,79 @@ struct RDP : Thread, Memory::RCP<RDP> {
     auto command(string_view) -> void;
     auto ioDPC(bool mode, u32 address, u32 data) -> void;
     auto ioDPS(bool mode, u32 address, u32 data) -> void;
+    auto updateGraphicsSize() -> void;
+    auto observeCommand(u32 code, const u32* words, u32 wordCount) -> void;
+
+    //capture.cpp
+    auto requestCapture() -> void;
+    auto captureActive() const -> bool;
+    auto captureReady() const -> bool;
+    auto frameBoundary() -> void;
+    auto presentBoundary(u32 origin) -> void;
+    auto beginCapture() -> void;
+    auto endCapture() -> void;
+    auto commandBatch() -> void;
+    auto captureCommand(const u32* words, u32 wordCount) -> void;
+    auto captureViRegister(u32 address, u32 value) -> void;
+    auto captureScanout(bool field) -> void;
+    auto resetCapture() -> void;
+    auto frameCapture() const -> const RDPFrameCapture*;
+    auto captureCommandCount() const -> u32;
+    auto capturedCommandWords(u32 index) const -> const std::vector<u32>*;
+    auto captureCommandText(u32 index) const -> string;
+    auto captureCommandArguments(u32 index) const -> string;
+    auto captureCommandDetail(u32 index) const -> string;
+    auto captureCommandOpcode(u32 index) const -> u32;
+    auto captureCommandType(u32 index) const -> u32;
+    auto captureSummary() const -> string;
+    auto captureStateAt(u32 command) const -> RDPCaptureState;
+    auto captureStateText(u32 command) const -> string;
+    auto captureViews() const -> std::vector<string>;
+    auto captureTicks() -> std::vector<u32>;
+    auto renderCapture(u32 command, u32 view) -> Core::Debugger::GraphicsFrame::Image;
+    auto renderCaptureTile(
+      const u8* tmem, const RDPCaptureState& state, u32 tile
+    ) const -> Core::Debugger::GraphicsFrame::Image;
+
+    struct Capture {
+      std::atomic<bool> armed = false;
+      std::atomic<bool> ready = false;
+      bool active = false;
+      //Set once a command list has been diffed; cleared by Sync Full. RDRAM is
+      //only sampled between command lists, where the RDP is idle.
+      bool inCommandList = false;
+      //Fields seen while armed and while capturing, counted only to drive the
+      //fallback for content that never presents a different framebuffer.
+      u32 armedFields = 0;
+      u32 activeFields = 0;
+      RDPFrameCapture frame;
+      std::vector<u8> shadowRdram;
+    };
+    std::unique_ptr<Capture> capture;
+    u64 nextCaptureIdentifier = 1;
+    //Framebuffer the VI is presenting, in 4 KiB units; changes mark a buffer flip.
+    u32 presentBuffer = ~0u;
+
+    //captureTicks() replays the whole capture, so its result is cached against
+    //the capture it was computed from.
+    u64 tickIdentifier = 0;
+    std::vector<u32> tickCommands;
+
+    struct CachedCommand {
+      u64 sequence = 0;
+      std::vector<u32> words;
+    };
+    std::vector<CachedCommand> cachedCommands;
+    u64 cachedCommandSequence = 0;
+
+    struct Graphics {
+      Node::Debugger::Graphics color;
+      Node::Debugger::Graphics depth;
+      Node::Debugger::Graphics coverage;
+    } graphics;
+
+    Node::Debugger::Memory tmem;
+    Node::Debugger::GraphicsFrame frame;
 
     struct Tracer {
       Node::Debugger::Tracer::Notification command;

--- a/ares/n64/rdp/render.cpp
+++ b/ares/n64/rdp/render.cpp
@@ -190,6 +190,18 @@ auto RDP::render() -> void {
   };
 
   while(command.current < command.end) {
+    if(unlikely(debugger.captureActive())) {
+      u32 commandAddress = command.current;
+      u32 firstWord = memory.read<Word>(commandAddress);
+      u32 wordCount = rdpCommandLength(firstWord >> 24) * 2;
+      std::vector<u32> capturedWords(wordCount);
+      for(u32 index : range(wordCount)) {
+        capturedWords[index] = memory.read<Word>(commandAddress + index * 4);
+      }
+      debugger.commandBatch();
+      debugger.captureCommand(capturedWords.data(), capturedWords.size());
+    }
+
     u64 op = fetch();
     auto opCode = op >> 56 & 0x3f;
 
@@ -350,6 +362,7 @@ auto RDP::render() -> void {
       scissor.odd   = n1 (op >> 24);
       scissor.x.lo  = n12(op >> 12);
       scissor.y.lo  = n12(op >>  0);
+      debugger.updateGraphicsSize();
       setScissor();
     } break;
 
@@ -546,6 +559,7 @@ auto RDP::render() -> void {
       set.color.size        = n2 (op >> 51);
       set.color.width       = n10(op >> 32);
       set.color.dramAddress = n26(op >>  0);
+      debugger.updateGraphicsSize();
       setColorImage();
     } break;
 

--- a/ares/n64/rdram/debugger.cpp
+++ b/ares/n64/rdram/debugger.cpp
@@ -29,6 +29,13 @@ auto RDRAM::Debugger::load(Node::Object parent) -> void {
     }
   });
 
+  memory.hidden = parent->append<Node::Debugger::Memory>("RDP Hidden RDRAM");
+  memory.hidden->setSize(rdram.ram.size / 2);
+  memory.hidden->setRead([&](u32 address) -> u8 {
+    if(!rdram.hidden.data || address >= rdram.ram.size / 2) return 0;
+    return rdram.hidden.data[address];
+  });
+
   tracer.io = parent->append<Node::Debugger::Tracer::Notification>("I/O", "RDRAM");
 }
 

--- a/ares/n64/rdram/rdram.hpp
+++ b/ares/n64/rdram/rdram.hpp
@@ -208,6 +208,7 @@ struct RDRAM : Memory::RCP<RDRAM> {
     struct Memory {
       Node::Debugger::Memory ram;
       Node::Debugger::Memory dcache;
+      Node::Debugger::Memory hidden;
     } memory;
 
     struct Tracer {

--- a/ares/n64/vi/debugger.cpp
+++ b/ares/n64/vi/debugger.cpp
@@ -1,5 +1,43 @@
 auto VI::Debugger::load(Node::Object parent) -> void {
+  framebuffer = parent->append<Node::Debugger::Graphics>("VI Framebuffer");
+  updateGraphicsSize();
+  framebuffer->setCapture([&]() -> std::vector<u32> {
+    updateGraphicsSize();
+    u32 width = framebuffer->width();
+    u32 height = framebuffer->height();
+    std::vector<u32> output(width * height, 0xff000000);
+    if(vi.io.colorDepth != 2 && vi.io.colorDepth != 3) return output;
+
+    u32 bytesPerPixel = vi.io.colorDepth == 2 ? 2 : 4;
+    u32 base = vi.io.dramAddress;
+    for(u32 y : range(height)) {
+      for(u32 x : range(width)) {
+        u64 address = (u64)base + ((u64)y * width + x) * bytesPerPixel;
+        if(address + bytesPerPixel > rdram.ram.size) continue;
+        if(vi.io.colorDepth == 2) {
+          u16 pixel = rdram.ram.read<Half>(address, RBusDevice::ARES_DEBUGGER);
+          u8 r = pixel >> 11 & 31; r = r << 3 | r >> 2;
+          u8 g = pixel >>  6 & 31; g = g << 3 | g >> 2;
+          u8 b = pixel >>  1 & 31; b = b << 3 | b >> 2;
+          output[y * width + x] = 0xff000000 | r << 16 | g << 8 | b;
+        } else {
+          u32 pixel = rdram.ram.read<Word>(address, RBusDevice::ARES_DEBUGGER);
+          output[y * width + x] = 0xff000000 | pixel >> 8;
+        }
+      }
+    }
+    return output;
+  });
+
   tracer.io = parent->append<Node::Debugger::Tracer::Notification>("I/O", "VI");
+}
+
+auto VI::Debugger::updateGraphicsSize() -> void {
+  if(!framebuffer) return;
+  u32 width = max(1u, (u32)vi.io.width);
+  u32 lines = vi.io.vend >= vi.io.vstart ? vi.io.vend - vi.io.vstart : 0;
+  u32 height = min(480u, (u32)(((u64)lines * vi.io.yscale + 2047) >> 11));
+  framebuffer->setSize(width, max(1u, height));
 }
 
 auto VI::Debugger::io(bool mode, u32 address, u32 data) -> void {

--- a/ares/n64/vi/io.cpp
+++ b/ares/n64/vi/io.cpp
@@ -99,6 +99,7 @@ auto VI::readWord(u32 address, Thread& thread) -> u32 {
 auto VI::writeWord(u32 address, u32 data_, Thread& thread) -> void {
   address = (address & 0x3f) >> 2;
   n32 data = data_;
+  rdp.debugger.captureViRegister(address, data);
 
   #if defined(VULKAN)
   if (vulkan.enable) vulkan.writeWord(address, data);
@@ -120,6 +121,10 @@ auto VI::writeWord(u32 address, u32 data_, Thread& thread) -> void {
   if(address == 1) {
     //VI_DRAM_ADDRESS
     io.dramAddress = data.bit(0,23);
+    //Presenting a framebuffer delimits one frame's rendering from the next; the
+    //capture window is taken from here rather than from scanout. Reported after
+    //the register is latched so a capture starting here snapshots the new origin.
+    rdp.debugger.presentBoundary(io.dramAddress);
   }
 
   if(address == 2) {
@@ -192,5 +197,6 @@ auto VI::writeWord(u32 address, u32 data_, Thread& thread) -> void {
     io.ysubpixel = data.bit(16,27);
   }
 
+  debugger.updateGraphicsSize();
   debugger.io(Write, address, data);
 }

--- a/ares/n64/vi/vi.cpp
+++ b/ares/n64/vi/vi.cpp
@@ -86,12 +86,14 @@ auto VI::main() -> void {
       }
 
       if(io.vcounter == io.vstart >> 1) {
+        rdp.debugger.captureScanout(io.field);
         #if defined(VULKAN)
         if (vulkan.enable) {
           gpuOutputValid = vulkan.scanoutAsync(io.field);
           vulkan.frame();
         }
         #endif
+        rdp.debugger.frameBoundary();
         refreshed = true;
         screen->frame();
         ri.checkRefresh();

--- a/ares/n64/vi/vi.hpp
+++ b/ares/n64/vi/vi.hpp
@@ -8,6 +8,9 @@ struct VI : Thread, Memory::RCP<VI> {
     //debugger.cpp
     auto load(Node::Object) -> void;
     auto io(bool mode, u32 address, u32 data) -> void;
+    auto updateGraphicsSize() -> void;
+
+    Node::Debugger::Graphics framebuffer;
 
     struct Tracer {
       Node::Debugger::Tracer::Notification io;

--- a/ares/n64/vulkan/parallel-rdp/parallel-rdp/rdp_device.cpp
+++ b/ares/n64/vulkan/parallel-rdp/parallel-rdp/rdp_device.cpp
@@ -1036,6 +1036,14 @@ void *CommandProcessor::get_tmem()
 	return device.map_host_buffer(*tmem, MEMORY_ACCESS_READ_BIT);
 }
 
+void CommandProcessor::set_tmem(const void *data, size_t size)
+{
+	size = std::min(size, size_t(0x1000));
+	auto *mapped = device.map_host_buffer(*tmem, MEMORY_ACCESS_WRITE_BIT);
+	memcpy(mapped, data, size);
+	device.unmap_host_buffer(*tmem, MEMORY_ACCESS_WRITE_BIT);
+}
+
 void CommandProcessor::idle()
 {
 	flush();

--- a/ares/n64/vulkan/parallel-rdp/parallel-rdp/rdp_device.hpp
+++ b/ares/n64/vulkan/parallel-rdp/parallel-rdp/rdp_device.hpp
@@ -145,6 +145,7 @@ public:
 	size_t get_rdram_size() const;
 	size_t get_hidden_rdram_size() const;
 	void *get_tmem();
+	void set_tmem(const void *data, size_t size);
 
 	// Sets VI register
 	void set_vi_register(VIRegister reg, uint32_t value);

--- a/ares/n64/vulkan/vulkan.cpp
+++ b/ares/n64/vulkan/vulkan.cpp
@@ -20,15 +20,29 @@ struct Vulkan::Implementation {
   ::Vulkan::Context context;
   ::Vulkan::Device device;
   ::RDP::CommandProcessor* processor = nullptr;
+  u8* tmem = nullptr;
+  ::Vulkan::Context replayContext;
+  ::Vulkan::Device replayDevice;
+  bool replayDeviceInitialized = false;
+  ::RDP::CommandProcessor* replayProcessor = nullptr;
+  Memory::Writable replayRam;
+  const u8* replayHidden = nullptr;
+  const u8* replayTmem = nullptr;
+  u64 replayIdentifier = 0;
+  u32 replayPacket = 0;
+  i32 replayCommand = -1;
   atomic<const char*> crash_error = nullptr;
+  atomic<const char*> replayCrashError = nullptr;
 
+  //Messages are static literals from rdp_renderer.cpp, so storing the pointer
+  //is safe across threads.
   struct Validation : public ::RDP::ValidationInterface {
-    Implementation& self;
-    Validation(Implementation& i) : self(i) {}
+    atomic<const char*>& target;
+    Validation(atomic<const char*>& target) : target(target) {}
     void report_rdp_crash(::RDP::ValidationError err, const char *msg) override {
-      self.crash_error = msg;
+      target = msg;
     }
-  } validator{*this};
+  } validator{crash_error}, replayValidator{replayCrashError};
 
   //commands are u64 words, but the backend uses u32 swapped words.
   //size and offset are in u64 words.
@@ -78,13 +92,6 @@ auto Vulkan::unload() -> void {
 auto Vulkan::render() -> bool {
   if(!implementation) return false;
 
-  static constexpr u32 commandLength[64] = {
-    1, 1, 1, 1, 1, 1, 1, 1, 4, 6,12,14,12,14,20,22,
-    1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-    1, 1, 1, 1, 2, 2, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-    1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-  };
-
   auto& command = rdp.command;
 
   u32 current = command.current & ~7;
@@ -117,7 +124,7 @@ auto Vulkan::render() -> bool {
   while(queueOffset < queueSize) {
     u32 op = buffer[queueOffset * 2];
     u32 code = op >> 24 & 63;
-    u32 length = commandLength[code];
+    u32 length = rdpCommandLength(code);
 
     if(queueOffset + length > queueSize) {
       //partial command, keep data around for next processing call
@@ -125,7 +132,12 @@ auto Vulkan::render() -> bool {
       return true;
     }
 
+    if(unlikely(rdp.debugger.captureActive())) {
+      rdp.debugger.commandBatch();
+      rdp.debugger.captureCommand(buffer + queueOffset * 2, length * 2);
+    }
     if(code >= 8) {
+      rdp.debugger.observeCommand(code, buffer + queueOffset * 2, length * 2);
       implementation->processor->enqueue_command(length * 2, buffer + queueOffset * 2);
     }
 
@@ -224,13 +236,165 @@ auto Vulkan::crashed() -> const char* {
   return nullptr;
 }
 
+auto Vulkan::synchronize() -> void {
+  if(implementation && implementation->processor) {
+    implementation->processor->idle();
+  }
+}
+
+//parallel-RDP holds TMEM as an array of native-endian 16-bit words whose index is
+//swizzled the same way RDRAM is: logical 16-bit word N lives at index N^1. Reading
+//that buffer as bytes on a little-endian host therefore needs a byte address XOR 3
+//to recover TMEM's own big-endian byte order (compare the "index ^= 3" / "index ^= 1"
+//in parallel-rdp/shaders/texture.h). address here is a logical TMEM byte address.
+auto Vulkan::readTMEM(u32 address) -> u8 {
+  if(!implementation || !implementation->tmem || address >= 4_KiB) return 0;
+  return implementation->tmem[address ^ 3];
+}
+
+//Verbatim copy of the TMEM buffer in parallel-RDP's own layout, for seeding a replay
+//processor through set_tmem(). Anything meant for display wants readTMEM() instead.
+auto Vulkan::copyTMEM(u8* target, u32 size) -> bool {
+  if(!implementation || !implementation->tmem) return false;
+  memory::copy(target, implementation->tmem, min(size, 4_KiB));
+  return true;
+}
+
+auto Vulkan::replay(const RDPFrameCapture& capture, u32 targetCommand) -> bool {
+  if(!implementation || targetCommand >= capture.commandOffsets.size()) return false;
+  auto& impl = *implementation;
+
+  bool restart = !impl.replayProcessor
+    || impl.replayIdentifier != capture.identifier
+    || (i32)targetCommand < impl.replayCommand;
+  if(restart) {
+    if(!impl.replayDeviceInitialized) {
+      if(!impl.replayContext.init_instance_and_device(nullptr, 0, nullptr, 0, 0)) return false;
+      impl.replayDevice.set_context(impl.replayContext);
+      impl.replayDevice.init_frame_contexts(3);
+      impl.replayDeviceInitialized = true;
+    }
+
+    //The processor owns GPU-side renderer state but its complete RDP register
+    //state can be overwritten by initialCommands. Keep it alive when scrubbing
+    //backward; reconstructing it is expensive and emits backend initialization
+    //messages every time.
+    bool recreate = !impl.replayProcessor || impl.replayRam.size != capture.rdram.size();
+    if(recreate) {
+      delete impl.replayProcessor;
+      impl.replayProcessor = nullptr;
+      impl.replayRam.allocate(capture.rdram.size());
+      auto flags = ::RDP::CommandProcessorFlags(
+        ::RDP::COMMAND_PROCESSOR_FLAG_HOST_VISIBLE_HIDDEN_RDRAM_BIT |
+        ::RDP::COMMAND_PROCESSOR_FLAG_HOST_VISIBLE_TMEM_BIT
+      );
+      impl.replayProcessor = new ::RDP::CommandProcessor(
+        impl.replayDevice, impl.replayRam.data, 0, impl.replayRam.size,
+        impl.replayRam.size / 2, flags
+      );
+      if(!impl.replayProcessor->device_is_supported()) {
+        delete impl.replayProcessor;
+        impl.replayProcessor = nullptr;
+        return false;
+      }
+      impl.replayProcessor->set_validation_interface(&impl.replayValidator);
+      impl.replayProcessor->begin_frame_context();
+    } else {
+      impl.replayProcessor->idle();
+    }
+
+    std::memcpy(impl.replayRam.data, capture.rdram.data(), impl.replayRam.size);
+    impl.replayIdentifier = capture.identifier;
+    impl.replayPacket = 0;
+    impl.replayCommand = -1;
+    impl.replayHidden = nullptr;
+    impl.replayTmem = nullptr;
+
+    impl.replayCrashError = nullptr;
+    auto hidden = (u8*)impl.replayProcessor->begin_read_hidden_rdram();
+    if(hidden && capture.hiddenRdram.size() == impl.replayRam.size / 2) {
+      std::memcpy(hidden, capture.hiddenRdram.data(), capture.hiddenRdram.size());
+    }
+    impl.replayProcessor->end_write_hidden_rdram();
+    if(capture.tmem.size() == 4_KiB) {
+      impl.replayProcessor->set_tmem(capture.tmem.data(), capture.tmem.size());
+    }
+    for(auto& words : capture.initialCommands) {
+      if(!words.empty()) {
+        impl.replayProcessor->enqueue_command(words.size(), words.data());
+      }
+    }
+    impl.replayProcessor->idle();
+  }
+
+  if((i32)targetCommand == impl.replayCommand) return true;
+  for(; impl.replayPacket < capture.packets.size(); impl.replayPacket++) {
+    auto& packet = capture.packets[impl.replayPacket];
+    if(packet.type == RDPFrameCapture::Packet::Type::DramDiff) {
+      bool beginsDiffGroup = impl.replayPacket == 0
+        || capture.packets[impl.replayPacket - 1].type
+          != RDPFrameCapture::Packet::Type::DramDiff;
+      if(beginsDiffGroup) impl.replayProcessor->idle();
+      if(packet.address + packet.bytes.size() <= impl.replayRam.size) {
+        std::memcpy(
+          impl.replayRam.data + packet.address,
+          packet.bytes.data(), packet.bytes.size()
+        );
+      }
+      continue;
+    }
+    if(packet.type == RDPFrameCapture::Packet::Type::ViRegister) {
+      impl.replayProcessor->set_vi_register(::RDP::VIRegister(packet.address), packet.value);
+      continue;
+    }
+    if(packet.type != RDPFrameCapture::Packet::Type::Commands) continue;
+
+    impl.replayProcessor->enqueue_command(packet.words.size(), packet.words.data());
+    impl.replayCommand++;
+    if(impl.replayCommand == (i32)targetCommand) {
+      impl.replayPacket++;
+      break;
+    }
+  }
+  impl.replayProcessor->idle();
+  impl.replayHidden = (const u8*)impl.replayProcessor->begin_read_hidden_rdram();
+  impl.replayTmem = (const u8*)impl.replayProcessor->get_tmem();
+  return impl.replayCommand == (i32)targetCommand;
+}
+
+auto Vulkan::replayRdram() const -> Memory::Writable* {
+  if(!implementation || !implementation->replayProcessor) return nullptr;
+  return &implementation->replayRam;
+}
+
+auto Vulkan::replayHiddenRdram() const -> const u8* {
+  if(!implementation) return nullptr;
+  return implementation->replayHidden;
+}
+
+auto Vulkan::replayTMEM() const -> const u8* {
+  if(!implementation) return nullptr;
+  return implementation->replayTmem;
+}
+
+auto Vulkan::replayCrashed() const -> const char* {
+  if(!implementation) return nullptr;
+  return implementation->replayCrashError;
+}
+
 Vulkan::Implementation::Implementation(u8* data, u32 size) {
   if(!::Vulkan::Context::init_loader(nullptr)) return;
   if(!context.init_instance_and_device(nullptr, 0, nullptr, 0, 0)) return;
   device.set_context(context);
   device.init_frame_contexts(3);
 
-  ::RDP::CommandProcessorFlags flags = ::RDP::COMMAND_PROCESSOR_FLAG_HOST_VISIBLE_HIDDEN_RDRAM_BIT;
+  //TODO: Keep TMEM device-local unless a debugger view needs it. The debugger node
+  //API cannot currently report whether its panel is open, so this 4 KiB allocation
+  //is host-visible unconditionally. Replace this with an on-demand
+  //staging readback (and a cached snapshot for the Memory node).
+  ::RDP::CommandProcessorFlags flags =
+    ::RDP::COMMAND_PROCESSOR_FLAG_HOST_VISIBLE_HIDDEN_RDRAM_BIT |
+    ::RDP::COMMAND_PROCESSOR_FLAG_HOST_VISIBLE_TMEM_BIT;
   switch(vulkan.internalUpscale) {
   case 2: flags |= ::RDP::COMMAND_PROCESSOR_FLAG_UPSCALING_2X_BIT; break;
   case 4: flags |= ::RDP::COMMAND_PROCESSOR_FLAG_UPSCALING_4X_BIT; break;
@@ -253,9 +417,12 @@ Vulkan::Implementation::Implementation(u8* data, u32 size) {
   }
 
   processor->set_validation_interface(&validator);
+  tmem = (u8*)processor->get_tmem();
 }
 
 Vulkan::Implementation::~Implementation() {
+  if(replayProcessor) delete replayProcessor;
+  replayRam.reset();
   if(processor) delete processor;
 }
 

--- a/ares/n64/vulkan/vulkan.hpp
+++ b/ares/n64/vulkan/vulkan.hpp
@@ -2,6 +2,11 @@
 
 namespace ares::Nintendo64 {
 
+struct RDPFrameCapture;
+//This header precedes memory.hpp; the replay RDRAM is only dereferenced by
+//translation units that include the full n64.hpp.
+namespace Memory { struct Writable; }
+
 struct Vulkan {
   auto load(Node::Object) -> bool;
   auto unload() -> void;
@@ -14,6 +19,14 @@ struct Vulkan {
   auto unmapScanoutRead() -> void;
   auto endScanout() -> void;
   auto crashed() -> const char*;
+  auto synchronize() -> void;
+  auto readTMEM(u32 address) -> u8;
+  auto copyTMEM(u8* target, u32 size) -> bool;
+  auto replay(const RDPFrameCapture& capture, u32 command) -> bool;
+  auto replayRdram() const -> Memory::Writable*;
+  auto replayHiddenRdram() const -> const u8*;
+  auto replayTMEM() const -> const u8*;
+  auto replayCrashed() const -> const char*;
 
   struct Implementation;
   Implementation* implementation = nullptr;

--- a/desktop-ui/tools/graphics.cpp
+++ b/desktop-ui/tools/graphics.cpp
@@ -2,6 +2,20 @@ auto GraphicsViewer::construct() -> void {
   setCollapsible();
   setVisible(false);
 
+  frameStatus.setCollapsible();
+  commandLayout.setCollapsible();
+  tickLayout.setCollapsible();
+  viewLayout.setCollapsible();
+  stateTable.setCollapsible();
+  graphicsView.setCollapsible();
+  exportButton.setCollapsible();
+  exportStatus.setCollapsible();
+  liveOption.setCollapsible();
+  refreshButton.setCollapsible();
+  captureButton.setCollapsible();
+  exportFrameButton.setCollapsible();
+  exportVideoButton.setCollapsible();
+
   graphicsLabel.setText("Graphics Viewer").setFont(Font().setBold());
   graphicsList.onChange([&] { eventChange(); });
   graphicsView.setAlignment({0.0, 0.0});
@@ -13,10 +27,77 @@ auto GraphicsViewer::construct() -> void {
   refreshButton.setText("Refresh").onActivate([&] {
     refresh();
   });
+  captureButton.setText("Capture Frame").onActivate([&] {
+    eventCapture();
+  });
+  exportFrameButton.setText("Export Text").onActivate([&] {
+    eventExportFrame();
+  });
+  exportVideoButton.setText("Export MP4").onActivate([&] {
+    eventExportVideo();
+  });
+  commandList.onChange([&] { eventCommand(); });
+  //Monospaced so the decoded operands line up column-wise between rows.
+  commandList.setFont(Font().setFamily(Font::Mono));
+  commandDetail.setEditable(false).setFont(Font().setFamily(Font::Mono));
+
+  tickLabel.setText("Ticks");
+  tickSlider.setLength(1).onChange([&] { eventTick(); });
+
+  resetStateTable();
+  stateTable.setFont(Font().setFamily(Font::Mono));
+  for(u32 index : range(FrameViewCount)) {
+    viewPanes[index]->setCollapsible();
+    viewLabels[index]->setFont(Font().setBold());
+    viewCanvases[index]->setAlignment({0.0, 0.0});
+  }
+
+  frameStatus.setVisible(false);
+  commandLayout.setVisible(false);
+  tickLayout.setVisible(false);
+  viewLayout.setVisible(false);
+  stateTable.setVisible(false);
+  captureButton.setVisible(false);
+  exportFrameButton.setVisible(false);
+  exportVideoButton.setVisible(false);
+}
+
+auto GraphicsViewer::selectedFrame() -> ares::Node::Debugger::GraphicsFrame {
+  if(auto item = graphicsList.selected()) {
+    return item.attribute<ares::Node::Debugger::GraphicsFrame>("frame");
+  }
+  return {};
+}
+
+auto GraphicsViewer::resetStateTable() -> void {
+  stateTable.reset();
+  stateTable.setHeadered();
+  stateTable.append(TableViewColumn().setText("Field"));
+  stateTable.append(TableViewColumn().setText("Value").setExpandable());
+}
+
+auto GraphicsViewer::clearFrame() -> void {
+  commandList.reset();
+  commandDetail.setText("");
+  resetStateTable();
+  for(u32 index : range(FrameViewCount)) {
+    viewCanvases[index]->setIcon();
+    viewPanes[index]->setVisible(false);
+  }
+  waitingForFrame = false;
+  shownFrame = false;
+  tickCommands.clear();
+  tickLayout.setVisible(false);
+  exportStatus.setText("");
 }
 
 auto GraphicsViewer::reload() -> void {
   graphicsList.reset();
+  for(auto frame : ares::Node::enumerate<ares::Node::Debugger::GraphicsFrame>(emulator->root)) {
+    ComboButtonItem item{&graphicsList};
+    item.setAttribute<ares::Node::Debugger::GraphicsFrame>("frame", frame);
+    item.setText(frame->name());
+  }
   for(auto graphics : ares::Node::enumerate<ares::Node::Debugger::Graphics>(emulator->root)) {
     ComboButtonItem item{&graphicsList};
     item.setAttribute<ares::Node::Debugger::Graphics>("node", graphics);
@@ -27,11 +108,16 @@ auto GraphicsViewer::reload() -> void {
 
 auto GraphicsViewer::unload() -> void {
   graphicsList.reset();
+  clearFrame();
   eventChange();
 }
 
 auto GraphicsViewer::refresh() -> void {
   if(auto item = graphicsList.selected()) {
+    if(auto frame = selectedFrame()) {
+      if(frame->captureValid()) refreshFrame(frame);
+      return;
+    }
     if(auto graphics = item.attribute<ares::Node::Debugger::Graphics>("node")) {
       auto width  = graphics->width();
       auto height = graphics->height();
@@ -54,11 +140,372 @@ auto GraphicsViewer::refresh() -> void {
 }
 
 auto GraphicsViewer::liveRefresh() -> void {
+  if(visible() && waitingForFrame) {
+    if(auto frame = selectedFrame()) {
+      if(frame->captureValid()) refreshFrame(frame);
+    }
+    return;
+  }
   if(visible() && liveOption.checked()) refresh();
 }
 
 auto GraphicsViewer::eventChange() -> void {
+  bool frameMode = (bool)selectedFrame();
+  frameStatus.setVisible(frameMode);
+  commandLayout.setVisible(frameMode);
+  tickLayout.setVisible(frameMode && !tickCommands.empty());
+  viewLayout.setVisible(frameMode);
+  stateTable.setVisible(frameMode);
+  captureButton.setVisible(frameMode);
+  exportFrameButton.setVisible(frameMode && shownFrame);
+  exportVideoButton.setVisible(frameMode && shownFrame && !tickCommands.empty());
+  graphicsView.setVisible(!frameMode);
+  exportButton.setVisible(!frameMode);
+  exportStatus.setVisible(frameMode);
+  liveOption.setVisible(!frameMode);
+  refreshButton.setVisible(!frameMode);
+  if(frameMode && !shownFrame) frameStatus.setText("Ready to capture an RDP frame.");
+  resize();
   refresh();
+}
+
+auto GraphicsViewer::eventCapture() -> void {
+  auto frame = selectedFrame();
+  if(!frame) return;
+  {
+    Program::Guard guard;
+    frame->requestCapture();
+  }
+  clearFrame();
+  waitingForFrame = true;
+  exportFrameButton.setVisible(false);
+  exportVideoButton.setVisible(false);
+  frameStatus.setText("Capture armed; waiting for the game to present its next frame.");
+  resize();
+}
+
+auto GraphicsViewer::eventCommand() -> void {
+  commandDetail.setText("");
+  auto command = commandList.selected();
+  if(!command) return;
+  auto frame = selectedFrame();
+  if(!frame) return;
+  u32 index = command.attribute<u32>("index");
+  commandDetail.setText(frame->commandDetail(index));
+  syncTickToCommand(index);
+  refreshFrameViews();
+  refreshFrameState();
+}
+
+//The core decides which syncs are worth an entry; the slider is just an index
+//into that list, so one notch is one visibly different image.
+auto GraphicsViewer::refreshTicks(ares::Node::Debugger::GraphicsFrame frame) -> void {
+  tickCommands = frame->ticks();
+  tickSlider.setLength(max(1u, (u32)tickCommands.size()));
+  tickSlider.setPosition(0);
+  tickLayout.setVisible(!tickCommands.empty());
+  tickLabel.setText(tickCommands.empty()
+    ? string{"Ticks: none"}
+    : string{"Ticks: ", tickCommands.size()});
+}
+
+auto GraphicsViewer::eventTick() -> void {
+  if(tickLocked || tickCommands.empty()) return;
+  u32 position = min(tickSlider.position(), (u32)tickCommands.size() - 1);
+  auto item = commandList.item(tickCommands[position]);
+  if(!item) return;
+  tickLocked = true;
+  item.setSelected().setFocused();
+  tickLocked = false;
+  eventCommand();
+}
+
+//Keeps the slider on the last tick at or before the selected command, so
+//selecting a command in the list leaves the strip pointing at the image that
+//command belongs to.
+auto GraphicsViewer::syncTickToCommand(u32 index) -> void {
+  if(tickLocked || tickCommands.empty()) return;
+  u32 position = 0;
+  for(u32 tick : range((u32)tickCommands.size())) {
+    if(tickCommands[tick] > index) break;
+    position = tick;
+  }
+  tickLocked = true;
+  tickSlider.setPosition(position);
+  tickLocked = false;
+  tickLabel.setText({"Tick ", position + 1, "/", tickCommands.size()});
+}
+
+//Renders every view the capture offers into its own pane, so the buffers can be
+//compared at a glance while scrubbing rather than switched between.
+auto GraphicsViewer::refreshFrameViews() -> void {
+  auto command = commandList.selected();
+  if(!command) {
+    for(u32 index : range(FrameViewCount)) viewPanes[index]->setVisible(false);
+    return;
+  }
+  auto frame = selectedFrame();
+  if(!frame) return;
+
+  Program::Guard guard;
+  u32 commandIndex = command.attribute<u32>("index");
+  auto views = frame->views();
+  for(u32 index : range(FrameViewCount)) {
+    if(index >= views.size()) {
+      viewPanes[index]->setVisible(false);
+      continue;
+    }
+    viewPanes[index]->setVisible(true);
+    viewLabels[index]->setText(views[index]);
+
+    auto result = frame->render(commandIndex, index);
+    if(!result.width || !result.height
+    || result.pixels.size() != result.width * result.height) {
+      viewCanvases[index]->setIcon();
+      continue;
+    }
+    image canvas;
+    canvas.allocate(result.width, result.height);
+    for(u32 y : range(result.height)) {
+      auto output = canvas.data() + y * canvas.pitch();
+      for(u32 x : range(result.width)) {
+        canvas.write(output, result.pixels[y * result.width + x]);
+        output += canvas.stride();
+      }
+    }
+    viewCanvases[index]->setIcon(canvas);
+  }
+}
+
+//The core emits one tab-separated field/value pair per line.
+auto GraphicsViewer::refreshFrameState() -> void {
+  resetStateTable();
+
+  auto command = commandList.selected();
+  if(!command) return;
+  auto frame = selectedFrame();
+  if(!frame) return;
+
+  Program::Guard guard;
+  auto state = frame->state(command.attribute<u32>("index"));
+  for(auto& line : nall::split(state, "\n")) {
+    if(!line) continue;
+    auto fields = nall::split(line, "\t", 1L);
+    TableViewItem item{&stateTable};
+    item.append(TableViewCell().setText(fields.size() > 0 ? fields[0] : string{}));
+    item.append(TableViewCell().setText(fields.size() > 1 ? fields[1] : string{}));
+  }
+  stateTable.resizeColumns();
+}
+
+auto GraphicsViewer::eventExportFrame() -> void {
+  auto frame = selectedFrame();
+  if(!frame || !frame->captureValid()) return;
+
+  Program::Guard guard;
+  u32 commandCount = frame->commandCount();
+  string output{"RDP Frame Capture\n", frame->summary(), "\n\n"};
+  for(u32 index : range(commandCount)) {
+    output.append(
+      "[", pad(string{index}, 4, '0'), " | 0x", hex(frame->commandOpcode(index), 2L),
+      "] ", frame->commandText(index), "\n"
+    );
+
+    //The detail pane starts with its own command heading. The export has the
+    //combined index/opcode heading above, so retain only the specially formatted
+    //decoded fields and raw-word section.
+    auto commandDetail = frame->commandDetail(index);
+    auto detail = nall::split(commandDetail, "\n\n", 1L);
+    if(detail.size() > 1) output.append(detail[1]);
+    output.append("\n");
+  }
+  if(commandCount) {
+    output.append("\nFinal RDP State\n", frame->state(commandCount - 1), "\n");
+  }
+  auto datetime = chrono::local::datetime().replace("-", "").replace(":", "").replace(" ", "-");
+  auto location = emulator->locate({
+    Location::notsuffix(emulator->game->location), "-rdp-frame-", datetime, ".txt"
+  }, ".txt", settings.paths.debugging);
+  file::write(location, output);
+  print("Wrote ", location, "\n");
+  exportStatus.setText({"Exported ", location});
+}
+
+//One video per channel, a frame per tick, so the capture plays back as the frame
+//being drawn. The tile view is skipped: it is a composite of eight unrelated tile
+//descriptors on a fixed grid, and animating that shows nothing.
+//
+//Frames are concatenated into one PPM stream per channel rather than encoded
+//individually: PNM images may be concatenated, so each frame carries its own
+//dimensions and can be resynchronised on, and both ffmpeg (-f image2pipe) and
+//ImageMagick read the result directly. Views are cropped to the scissor, so a
+//capture's ticks come out in several sizes; only the size most of them agree on is
+//written, which also drops the offscreen and HUD passes that would not line up.
+auto GraphicsViewer::eventExportVideo() -> void {
+  auto frame = selectedFrame();
+  if(!frame || !frame->captureValid() || tickCommands.empty()) return;
+
+  Program::Guard guard;
+  auto views = frame->views();
+  std::vector<u32> channels;
+  for(u32 view : range((u32)views.size())) {
+    if(views[view] != "Tiles") channels.push_back(view);
+  }
+  if(channels.empty()) return;
+
+  //Rendered up front, in tick order: the replay only rewinds when asked for a
+  //command earlier than the last one, and all views of a tick share one replay,
+  //so this walks the capture forwards exactly once. The size to keep is not known
+  //until every tick has been rendered, hence holding them all.
+  std::vector<std::vector<ares::Core::Debugger::GraphicsFrame::Image>> renders;
+  renders.resize(channels.size());
+  for(u32 command : tickCommands) {
+    for(u32 channel : range((u32)channels.size())) {
+      renders[channel].push_back(frame->render(command, channels[channel]));
+    }
+  }
+
+  //The export gets a directory of its own, named like the text export so the two
+  //are recognisable as coming from the same capture.
+  auto datetime = chrono::local::datetime().replace("-", "").replace(":", "").replace(" ", "-");
+  auto stem = emulator->locate({
+    Location::notsuffix(emulator->game->location), "-rdp-frame-", datetime, ".mp4"
+  }, ".mp4", settings.paths.debugging);
+  auto folder = string{Location::notsuffix(stem), "/"};
+  directory::create(folder);
+
+  string failure;
+  u32 encoded = 0;
+  for(u32 channel : range((u32)channels.size())) {
+    u32 keepWidth = 0, keepHeight = 0, keepCount = 0;
+    std::vector<u64> dimensions;
+    for(auto& candidate : renders[channel]) {
+      if(!candidate.width || !candidate.height) continue;
+      dimensions.push_back((u64)candidate.width << 32 | candidate.height);
+    }
+    std::sort(dimensions.begin(), dimensions.end());
+    for(u32 begin = 0; begin < dimensions.size();) {
+      u32 end = begin + 1;
+      while(end < dimensions.size() && dimensions[end] == dimensions[begin]) end++;
+      if(end - begin > keepCount) {
+        keepCount = end - begin;
+        keepWidth = dimensions[begin] >> 32;
+        keepHeight = dimensions[begin];
+      }
+      begin = end;
+    }
+    if(!keepCount) continue;
+
+    auto identifier = views[channels[channel]].downcase().replace(" ", "-");
+    auto framesLocation = string{folder, identifier, ".ppm"};
+    auto videoLocation = string{folder, identifier, ".mp4"};
+
+    u32 frames = 0;
+    if(auto fp = file::open(framesLocation, file::mode::write)) {
+      string header{"P6\n", keepWidth, " ", keepHeight, "\n255\n"};
+      std::vector<u8> row(keepWidth * 3);
+      for(auto& render : renders[channel]) {
+        if(render.width != keepWidth || render.height != keepHeight) continue;
+        if(render.pixels.size() != (u64)keepWidth * keepHeight) continue;
+        fp.writes(header);
+        for(u32 y : range(keepHeight)) {
+          auto pixels = render.pixels.data() + (u64)y * keepWidth;
+          for(u32 x : range(keepWidth)) {
+            row[x * 3 + 0] = pixels[x] >> 16;
+            row[x * 3 + 1] = pixels[x] >>  8;
+            row[x * 3 + 2] = pixels[x] >>  0;
+          }
+          fp.write(row);
+        }
+        frames++;
+      }
+      fp.close();
+    }
+    if(!frames) { file::remove(framesLocation); continue; }
+
+    //Looped by the filter rather than by -stream_loop: the demuxer cannot seek back
+    //to the start of a PPM stream, so -stream_loop fails outright. The frame count
+    //is known here, which is what the filter needs. The commas inside mod() are
+    //escaped for ffmpeg's filtergraph parser, which would otherwise read them as
+    //filter separators; the one before pad is a real separator. No shell involved.
+    auto result = nall::execute("ffmpeg",
+      "-y",
+      "-f", "image2pipe",
+      "-c:v", "ppm",
+      "-framerate", "15",
+      "-i", framesLocation,
+      "-vf", string{"loop=loop=2:size=", frames,
+                    ",pad=iw+mod(iw\\,2):ih+mod(ih\\,2)"},
+      "-pix_fmt", "yuv420p",
+      "-preset", "slow",
+      videoLocation
+    );
+    if(!result) {
+      //The frames are left behind on failure: ffmpeg or ImageMagick can be run
+      //over the PPM stream by hand without recapturing.
+      print("ffmpeg failed for ", videoLocation, "\n", result.error, "\n");
+      if(!failure) failure = string{"ffmpeg failed; PPM frames kept in ", folder};
+      continue;
+    }
+    file::remove(framesLocation);
+    encoded++;
+    print("Wrote ", videoLocation, " (", frames, " frames ", keepWidth, "x", keepHeight, ")\n");
+  }
+
+  if(failure) { exportStatus.setText(failure); return; }
+  exportStatus.setText({
+    "Exported ", encoded, " video", encoded == 1 ? "" : "s",
+    " from ", tickCommands.size(), " ticks to ", folder
+  });
+}
+
+//Commands are colored by what they do, so a capture can be skimmed for the ones
+//that put pixels on screen. Syncs are dimmed rather than highlighted: they are
+//numerous, carry no operands, and are only worth finding when looking for the end
+//of a command list.
+static auto commandColor(u32 type) -> Color {
+  switch(type) {
+  case 1: return {96, 160, 255};   //draws
+  case 2: return {224, 160, 64};   //texture loads
+  case 3: return {128, 128, 128};  //syncs
+  }
+  return {};  //state changes keep the theme's foreground color
+}
+
+auto GraphicsViewer::refreshFrame(ares::Node::Debugger::GraphicsFrame frame) -> void {
+  Program::Guard guard;
+  commandList.reset();
+  commandList.setHeadered();
+  commandList.append(TableViewColumn().setText("#").setAlignment(1.0));
+  commandList.append(TableViewColumn().setText("Command"));
+  commandList.append(TableViewColumn().setText("Arguments").setExpandable());
+  for(u32 index : range(frame->commandCount())) {
+    TableViewItem item{&commandList};
+    item.setAttribute<u32>("index", index);
+    auto color = commandColor(frame->commandType(index));
+    item.append(TableViewCell().setText(index));
+    item.append(TableViewCell().setText(frame->commandText(index)).setForegroundColor(color));
+    item.append(TableViewCell().setText(frame->commandArguments(index)).setForegroundColor(color));
+  }
+  commandList.resizeColumns();
+  commandList.column(0).setWidth(60_sx);
+  frameStatus.setText(frame->summary());
+  waitingForFrame = false;
+  shownFrame = true;
+  exportFrameButton.setVisible(true);
+  refreshTicks(frame);
+  exportVideoButton.setVisible(!tickCommands.empty());
+  //Every widget whose visibility depends on the capture has been set by here;
+  //one relayout picks them all up. Showing a widget without it leaves a hole in
+  //the layout until something else resizes the window.
+  resize();
+  //Open on the first tick when there is one: it is the first point in the frame
+  //with something drawn, where command 0 is always an empty buffer.
+  u32 first = tickCommands.empty() ? 0 : tickCommands[0];
+  if(auto item = commandList.item(first)) {
+    item.setSelected().setFocused();
+    eventCommand();
+  }
 }
 
 auto GraphicsViewer::eventExport() -> void {

--- a/desktop-ui/tools/tools.hpp
+++ b/desktop-ui/tools/tools.hpp
@@ -76,16 +76,70 @@ struct GraphicsViewer : VerticalLayout {
   auto liveRefresh() -> void;
   auto eventChange() -> void;
   auto eventExport() -> void;
+  auto eventCapture() -> void;
+  auto eventExportFrame() -> void;
+  auto eventExportVideo() -> void;
+  auto eventCommand() -> void;
+  auto refreshFrameViews() -> void;
+  auto refreshFrameState() -> void;
+  auto refreshTicks(ares::Node::Debugger::GraphicsFrame node) -> void;
+  auto eventTick() -> void;
+  auto syncTickToCommand(u32 index) -> void;
+  auto refreshFrame(ares::Node::Debugger::GraphicsFrame node) -> void;
+  auto selectedFrame() -> ares::Node::Debugger::GraphicsFrame;
+  auto clearFrame() -> void;
+  auto resetStateTable() -> void;
   auto setVisible(bool visible = true) -> GraphicsViewer&;
 
+  //Views are shown side by side rather than behind a selector, so the panes are
+  //fixed slots that the capture's view list is fitted into.
+  static constexpr u32 FrameViewCount = 4;
+
+  bool waitingForFrame = false;
+  bool shownFrame = false;
+  //Command indices behind the tick slider, ascending; empty hides the strip.
+  std::vector<u32> tickCommands;
+  bool tickLocked = false;  //guards slider <-> command list feedback
   Label graphicsLabel{this, Size{~0, 0}, 5};
   ComboButton graphicsList{this, Size{~0, 0}};
+  Label frameStatus{this, Size{~0, 0}, 5};
+  HorizontalLayout commandLayout{this, Size{~0, ~0}};
+    TableView commandList{&commandLayout, Size{~0, ~0}};
+    TextEdit commandDetail{&commandLayout, Size{~0, ~0}};
+  //Scrubs through the capture's distinct rendered images: one slider position per
+  //sync command whose color, depth or coverage buffer differs from the previous.
+  HorizontalLayout tickLayout{this, Size{~0, 0}};
+    Label tickLabel{&tickLayout, Size{0, 0}, 5};
+    HorizontalSlider tickSlider{&tickLayout, Size{~0, 0}};
+  HorizontalLayout viewLayout{this, Size{~0, ~0}};
+    VerticalLayout viewPaneA{&viewLayout, Size{~0, ~0}};
+      Label viewLabelA{&viewPaneA, Size{~0, 0}, 2};
+      Canvas viewCanvasA{&viewPaneA, Size{~0, ~0}};
+    VerticalLayout viewPaneB{&viewLayout, Size{~0, ~0}};
+      Label viewLabelB{&viewPaneB, Size{~0, 0}, 2};
+      Canvas viewCanvasB{&viewPaneB, Size{~0, ~0}};
+    VerticalLayout viewPaneC{&viewLayout, Size{~0, ~0}};
+      Label viewLabelC{&viewPaneC, Size{~0, 0}, 2};
+      Canvas viewCanvasC{&viewPaneC, Size{~0, ~0}};
+    VerticalLayout viewPaneD{&viewLayout, Size{~0, ~0}};
+      Label viewLabelD{&viewPaneD, Size{~0, 0}, 2};
+      Canvas viewCanvasD{&viewPaneD, Size{~0, ~0}};
+  TableView stateTable{this, Size{~0, ~0}};
   Canvas graphicsView{this, Size{~0, ~0}};
+
+  VerticalLayout* viewPanes[FrameViewCount]{&viewPaneA, &viewPaneB, &viewPaneC, &viewPaneD};
+  Label* viewLabels[FrameViewCount]{&viewLabelA, &viewLabelB, &viewLabelC, &viewLabelD};
+  Canvas* viewCanvases[FrameViewCount]{&viewCanvasA, &viewCanvasB, &viewCanvasC, &viewCanvasD};
   HorizontalLayout controlLayout{this, Size{~0, 0}};
     Button exportButton{&controlLayout, Size{80, 0}};
-    Widget spacer{&controlLayout, Size{~0, 0}};
+    Label exportStatus{&controlLayout, Size{~0, 0}, 2};
     CheckLabel liveOption{&controlLayout, Size{0, 0}, 2};
     Button refreshButton{&controlLayout, Size{80, 0}};
+    //Frame controls sit at the right, capture last: the exports only appear once
+    //there is a capture to export, so capture keeps a fixed position.
+    Button exportFrameButton{&controlLayout, Size{100, 0}};
+    Button exportVideoButton{&controlLayout, Size{110, 0}};
+    Button captureButton{&controlLayout, Size{110, 0}};
 };
 
 struct StreamManager : VerticalLayout {


### PR DESCRIPTION
You can capture a frame's RDP commands and then scrub through it to replay it, examine individual commands, and export a text or MP4 dump. You can also view some of the RDP buffers live.

The UI looks like:
<img width="1417" height="925" alt="image" src="https://github.com/user-attachments/assets/43b7c6ea-809d-4e80-ab32-6d2a626ad610" />

It constructs a "Ticks" bar by finding all sync commands that have different rendering state from a previous tick command. This is not quite as good as RSP-level displaylist debugging and capture, but it is decent. Export MP4 renders each tick to a PPM file and then invokes ffmpeg to create an mp4 file.

<details>
<summary>Dumped text format</summary>

RDP Frame Capture
Commands: 3378   Packets: 3521   DRAM diffs: 99 (396 KiB)   VI writes: 42   Scanouts: 2

[0000 | 0x27] Sync Pipe
Effect            stalls until the pipeline has drained

0000  e7000000 04d6045d

[0001 | 0x2d] Set Scissor
Scissor           0.00,0.00 -> 320.00,240.00

0000  ed000000 005003c0

[0002 | 0x3c] Set Combine Mode
RGB 0             (0 - 0) * 0 + SHADE
Alpha 0           (0 - 0) * 0 + SHADE
RGB 1             (0 - 0) * 0 + SHADE
Alpha 1           (0 - 0) * 0 + SHADE

0000  fcffffff fffe793c

[0003 | 0x2f] Set Other Modes
Cycle Type        1-Cycle
Z Mode            Opaque
Coverage          Clamp
RGB Dither        None
Alpha Dither      None
Blender 0         IN * IN_A + IN * 1-A
Blender 1         IN * IN_A + IN * 1-A
Flags             persp bilerp0 bilerp1
</details>