### PR TITLE
nall/gdb: support QPassSignals

### DIFF
--- a/nall/nall/gdb/server.cpp
+++ b/nall/nall/gdb/server.cpp
@@ -34,6 +34,7 @@ namespace nall::GDB {
 
   auto Server::reportSignal(Signal sig, u64 originPC) -> bool {
     if(!hasActiveClient || !handshakeDone)return true; // no client -> no error
+    if(passSignals[static_cast<u8>(sig)])return true; // QPassSignals: deliver without stopping or reporting
     if(forceHalt)return false; // Signals can only happen while the game is running, ignore others
 
     pcOverride = originPC;
@@ -241,8 +242,9 @@ namespace nall::GDB {
         // This tells the client what we can and can't do
         if(cmdName == "qSupported"){ return {
           "PacketSize=", hex(MAX_PACKET_SIZE),
-          ";fork-events-;swbreak+;hwbreak-", 
+          ";fork-events-;swbreak+;hwbreak-",
           ";vContSupported-", // prevent vCont commands (reduces potential GDB variations: some prefer using it, others don't)
+          ";QPassSignals+", // let the client ask us to swallow chosen signals
           NON_STOP_MODE ? ";QNonStop+" : "",
           "QStartNoAckMode+",
           hooks.targetXML ? ";xmlRegisters+;qXfer:features:read+" : "" // (see: https://marc.info/?l=gdb&m=149901965961257&w=2)
@@ -279,6 +281,16 @@ namespace nall::GDB {
         break;
 
       case 'Q':
+        if(cmdName == "QPassSignals") { // e.g. "QPassSignals:0b;0e" (hex signal numbers); empty list = clear
+          passSignals.fill(false);
+          if(cmdParts.size() > 1) {
+            for(auto sig : nall::split(cmdParts[1], ";")) {
+              if(sig.size()) passSignals[sig.hex() & 0xFF] = true;
+            }
+          }
+          return "OK";
+        }
+
         if(cmdName == "QNonStop") { // 0=stop, 1=non-stop-mode (this allows for async GDB-communication)
           if(cmdParts.size() <= 1)return "E00";
           nonStopMode = cmdParts[1] == "1";
@@ -551,6 +563,8 @@ namespace nall::GDB {
 
     watchpointWrite.clear();
     watchpointWrite.reserve(DEF_BREAKPOINT_SIZE);
+
+    passSignals.fill(false);
 
     pcOverride.reset();
     insideCommand = false;

--- a/nall/nall/gdb/server.hpp
+++ b/nall/nall/gdb/server.hpp
@@ -2,6 +2,7 @@
 
 #include <nall/tcptext/tcptext-server.hpp>
 #include <nall/gdb/watchpoint.hpp>
+#include <array>
 #include <functional>
 
 namespace nall::GDB {
@@ -136,6 +137,7 @@ class Server : public nall::TCPText::Server {
     std::vector<u64> breakpoints{};
     std::vector<Watchpoint> watchpointRead{};
     std::vector<Watchpoint> watchpointWrite{};
+    std::array<bool, 256> passSignals{};
 
     auto processCommand(const string& cmd, bool &shouldReply) -> string;
     auto resetClientData() -> void;


### PR DESCRIPTION
The client can now ask the stub to deliver chosen signals without stopping or reporting (gdb sends QPassSignals automatically for signals configured 'handle <sig> nostop noprint pass'). Advertised in qSupported; the pass set is client state, cleared on connect/disconnect like breakpoints.