### PR TITLE
fix: EEPROM null pointer access

### DIFF
--- a/ares/n64/cartridge/joybus.cpp
+++ b/ares/n64/cartridge/joybus.cpp
@@ -1,47 +1,54 @@
 
 auto Cartridge::joybusComm(n8 send, n8 recv, n8 input[], n8 output[]) -> n2 {
   n1 valid = 0, over = 0;
+  bool eepromPresent = cartridge.eeprom.size == 512 || cartridge.eeprom.size == 2048;
   
-  //status
-  if(input[0] == 0x00 || input[0] == 0xff) {
-    //cartridge EEPROM (4kbit)
-    if(cartridge.eeprom.size == 512) {
-      output[0] = 0x00;
-      output[1] = 0x80;
-      output[2] = eepromBusy ? 0x80 : 0x00;
-      valid = 1;
-    }
+  // with no EEPROM present, all commands are invalid.
+  // this also prevents any access to the uninitialized cartridge.eeprom data
+  if(eepromPresent) {
 
-    //cartridge EEPROM (16kbit)
-    if(cartridge.eeprom.size == 2048) {
-      output[0] = 0x00;
-      output[1] = 0xc0;
-      output[2] = eepromBusy ? 0x80 : 0x00;
-      valid = 1;
-    }
-  }
-
-  //read EEPROM
-  if(input[0] == 0x04 && send >= 2) {
-    u32 address = input[1] * 8;
-    for(u32 index : range(recv)) {
-      output[index] = !eepromBusy ? cartridge.eeprom.read<Byte>(address++) : 0xff;
-    }
-    valid = 1;
-  }
-
-  //write EEPROM
-  if(input[0] == 0x05 && send >= 2 && recv >= 1) {
-    output[0] = eepromBusy ? 0x80 : 0x00;
-    valid = 1;
-    if(!eepromBusy) {
-      u32 address = input[1] * 8;
-      for(u32 index : range(send - 2)) {
-        cartridge.eeprom.write<Byte>(address++, input[2 + index]);
+    //status
+    if(input[0] == 0x00 || input[0] == 0xff) {
+      //cartridge EEPROM (4kbit)
+      if(cartridge.eeprom.size == 512) {
+        output[0] = 0x00;
+        output[1] = 0x80;
+        output[2] = eepromBusy ? 0x80 : 0x00;
+        valid = 1;
       }
-      eepromBusy = 1;
-      cpu.queueInsert(Queue::EEPROM_Write, 187'500 * 6); //6ms
+
+      //cartridge EEPROM (16kbit)
+      if(cartridge.eeprom.size == 2048) {
+        output[0] = 0x00;
+        output[1] = 0xc0;
+        output[2] = eepromBusy ? 0x80 : 0x00;
+        valid = 1;
+      }
     }
+
+    //read EEPROM
+    if(input[0] == 0x04 && send >= 2) {
+      u32 address = input[1] * 8;
+      for(u32 index : range(recv)) {
+        output[index] = !eepromBusy ? cartridge.eeprom.read<Byte>(address++) : 0xff;
+      }
+      valid = 1;
+    }
+
+    //write EEPROM
+    if(input[0] == 0x05 && send >= 2 && recv >= 1) {
+      output[0] = eepromBusy ? 0x80 : 0x00;
+      valid = 1;
+      if(!eepromBusy) {
+        u32 address = input[1] * 8;
+        for(u32 index : range(send - 2)) {
+          cartridge.eeprom.write<Byte>(address++, input[2 + index]);
+        }
+        eepromBusy = 1;
+        cpu.queueInsert(Queue::EEPROM_Write, 187'500 * 6); //6ms
+      }
+    }
+
   }
 
   //RTC status


### PR DESCRIPTION
a game trying to read/write to EEPROM without it being present causes a segfault, since it tries to read from an (almost) null-pointer