### PR TITLE
N64: add simple overclock setting

### DIFF
--- a/ares/n64/system/serialization.cpp
+++ b/ares/n64/system/serialization.cpp
@@ -33,6 +33,7 @@ auto System::unserialize(serializer& s) -> bool {
 
   if(synchronize) power(/* reset = */ false);
   serialize(s, synchronize);
+  setOverclock(overclock);
   return true;
 }
 

--- a/ares/n64/system/system.cpp
+++ b/ares/n64/system/system.cpp
@@ -36,6 +36,7 @@ auto option(string name, string value) -> bool {
   #endif
   if(name == "Homebrew Mode") system.homebrewMode = value.boolean();
   if(name == "Deterministic Entropy") system.deterministicEntropy = value.boolean();
+  if(name == "Overclock") system.setOverclock(value.real());
   if(name == "Recompiler") {
     if constexpr(Accuracy::CPU::Recompiler) {
       cpu.recompiler.enabled = value.boolean();
@@ -426,6 +427,13 @@ auto System::save() -> void {
   if(_DD()) dd.save();
 
   if(model() == Model::Aleck64) aleck64.save();
+}
+
+auto System::setOverclock(f64 multiplier) -> void {
+  overclock = max(0.3, min(4.0, multiplier));
+  if(ai.node && ai.dac.frequency) {
+    ai.dac.period = frequency() / ai.dac.frequency;
+  }
 }
 
 auto System::power(bool reset) -> void {

--- a/ares/n64/system/system.hpp
+++ b/ares/n64/system/system.hpp
@@ -6,6 +6,7 @@ struct System {
   bool expansionPak = true;
   u8 configuredControllerPakBankCount = 1;
   u8 controllerPakBankCount = 1;
+  f64 overclock = 1.0;
 
   enum class Model : u32 { Nintendo64, Aleck64 };
   enum class Region : u32 { NTSC, PAL };
@@ -14,7 +15,7 @@ struct System {
   auto model() const -> Model { return information.model; }
   auto region() const -> Region { return information.region; }
   auto _DD() const -> bool { return information.dd; }
-  auto frequency() const -> u32 { return information.frequency; }
+  auto frequency() const -> u32 { return information.frequency * overclock; }
   auto videoFrequency() const -> u32 { return information.videoFrequency; }
 
   //system.cpp
@@ -24,6 +25,7 @@ struct System {
   auto unload() -> void;
   auto save() -> void;
   auto power(bool reset) -> void;
+  auto setOverclock(f64 multiplier) -> void;
 
   //serialization.cpp
   auto serialize(bool synchronize = true) -> serializer;

--- a/desktop-ui/emulator/arcade.cpp
+++ b/desktop-ui/emulator/arcade.cpp
@@ -165,6 +165,7 @@ auto Arcade::load() -> LoadResult {
     ares::Nintendo64::option("Homebrew Mode", settings.developer.homebrewMode);
     ares::Nintendo64::option("Deterministic Entropy", settings.developer.deterministicEntropy);
     ares::Nintendo64::option("Recompiler", !settings.developer.forceInterpreter);
+    ares::Nintendo64::option("Overclock", settings.nintendo64.overclock);
 
     return successful;
   }

--- a/desktop-ui/emulator/emulator.hpp
+++ b/desktop-ui/emulator/emulator.hpp
@@ -31,6 +31,7 @@ struct Emulator {
   virtual auto save() -> bool { return true; }
   virtual auto pak(ares::Node::Object) -> std::shared_ptr<vfs::directory> = 0;
   virtual auto notify(const string& message) -> void {}
+  virtual auto configure() -> void {}
   virtual auto arcade() -> bool { return false; }
   virtual auto group() -> string { return manufacturer; }
   virtual auto portMenu(Menu& portMenu, ares::Node::Port port) -> void {}

--- a/desktop-ui/emulator/nintendo-64.cpp
+++ b/desktop-ui/emulator/nintendo-64.cpp
@@ -6,6 +6,7 @@ struct Nintendo64 : Emulator {
   auto unload() -> void override;
   auto save() -> bool override;
   auto pak(ares::Node::Object) -> std::shared_ptr<vfs::directory> override;
+  auto configure() -> void override;
 
   std::shared_ptr<mia::Pak> disk;
   u32 regionID = 0;
@@ -52,6 +53,11 @@ Nintendo64::Nintendo64() {
   
     ports.push_back(port);
   }
+}
+
+auto Nintendo64::configure() -> void {
+  Program::Guard guard;
+  ares::Nintendo64::option("Overclock", settings.nintendo64.overclock);
 }
 
 auto Nintendo64::load() -> LoadResult {
@@ -116,6 +122,7 @@ auto Nintendo64::load() -> LoadResult {
   ares::Nintendo64::option("Homebrew Mode", settings.developer.homebrewMode);
   ares::Nintendo64::option("Deterministic Entropy", settings.developer.deterministicEntropy);
   ares::Nintendo64::option("Recompiler", !settings.developer.forceInterpreter);
+  ares::Nintendo64::option("Overclock", settings.nintendo64.overclock);
   ares::Nintendo64::option("Expansion Pak", settings.nintendo64.expansionPak);
   ares::Nintendo64::option("Controller Pak Banks", settings.nintendo64.controllerPakBankString);
 

--- a/desktop-ui/emulator/nintendo-64dd.cpp
+++ b/desktop-ui/emulator/nintendo-64dd.cpp
@@ -91,6 +91,7 @@ auto Nintendo64DD::load() -> LoadResult {
   ares::Nintendo64::option("Homebrew Mode", settings.developer.homebrewMode);
   ares::Nintendo64::option("Deterministic Entropy", settings.developer.deterministicEntropy);
   ares::Nintendo64::option("Recompiler", !settings.developer.forceInterpreter);
+  ares::Nintendo64::option("Overclock", settings.nintendo64.overclock);
   ares::Nintendo64::option("Expansion Pak", settings.nintendo64.expansionPak);
   ares::Nintendo64::option("Controller Pak Banks", settings.nintendo64.controllerPakBankString);
 

--- a/desktop-ui/settings/cores.cpp
+++ b/desktop-ui/settings/cores.cpp
@@ -50,6 +50,20 @@ auto CoreSettings::construct() -> void {
     nintendo64ControllerPakBankLabel.setText("Controller Pak Size:");
     nintendo64ControllerPakBankHint.setText("Sets the size of a newly created Controller Pak's available memory").setFont(Font().setSize(7.0)).setForegroundColor(SystemColor::Sublabel);
 
+  u32 overclockTenths = max(3u, min(40u, (u32)(settings.nintendo64.overclock * 10.0 + 0.5)));
+  settings.nintendo64.overclock = overclockTenths / 10.0;
+  nintendo64OverclockLabel.setText("Clock Multiplier:");
+  nintendo64OverclockSlider.setLength(38).setPosition(overclockTenths - 3).onChange([&] {
+    u32 tenths = nintendo64OverclockSlider.position() + 3;
+    settings.nintendo64.overclock = tenths / 10.0;
+    nintendo64OverclockValue.setText({tenths / 10, ".", tenths % 10, "x"});
+    if(emulator && (emulator->name == "Nintendo 64" || emulator->name == "Nintendo 64DD")) {
+      emulator->configure();
+    }
+  }).doChange();
+  nintendo64OverclockLayout.setAlignment(0.5).setPadding(12_sx, 0);
+    nintendo64OverclockHint.setText("Runs the CPU, RSP, and RDP at the selected clock multiplier").setFont(Font().setSize(7.0)).setForegroundColor(SystemColor::Sublabel);
+
     renderQualityLayout.setPadding(12_sx, 0);
 
   disableVideoInterfaceProcessingOption.setText("Disable Video Interface Processing").setChecked(settings.nintendo64.disableVideoInterfaceProcessing).onToggle([&] {

--- a/desktop-ui/settings/settings.cpp
+++ b/desktop-ui/settings/settings.cpp
@@ -125,6 +125,7 @@ auto Settings::process(bool load) -> void {
 
   bind(boolean, "Nintendo64/ExpansionPak", nintendo64.expansionPak);
   bind(string,  "Nintendo64/ControllerPakBankString", nintendo64.controllerPakBankString);
+  bind(real,    "Nintendo64/Overclock", nintendo64.overclock);
   bind(string,  "Nintendo64/Quality", nintendo64.quality);
   bind(boolean, "Nintendo64/Supersampling", nintendo64.supersampling);
   bind(boolean, "Nintendo64/DisableVideoInterfaceProcessing", nintendo64.disableVideoInterfaceProcessing);

--- a/desktop-ui/settings/settings.hpp
+++ b/desktop-ui/settings/settings.hpp
@@ -113,6 +113,7 @@ struct Settings : Markup::Node {
     bool expansionPak = true;
     u8 controllerPakBankCount = 1;
     string controllerPakBankString = "32KiB (Default)";
+    f64 overclock = 1.0;
     string quality = "SD";
     bool supersampling = false;
     bool disableVideoInterfaceProcessing = false;
@@ -381,6 +382,11 @@ struct CoreSettings : VerticalLayout {
       Label nintendo64ControllerPakBankLabel{&nintendo64ControllerPakBankLayout, Size{0, layoutVertSize}};
       ComboButton nintendo64ControllerPakBankOption{&nintendo64ControllerPakBankLayout, Size{0, 0}};
       Label nintendo64ControllerPakBankHint{&nintendo64ControllerPakBankLayout, Size{0, layoutVertSize}};
+    HorizontalLayout nintendo64OverclockLayout{this, Size{~0, 0}, 5};
+      Label nintendo64OverclockLabel{&nintendo64OverclockLayout, Size{0, layoutVertSize}};
+      HorizontalSlider nintendo64OverclockSlider{&nintendo64OverclockLayout, Size{~0, 0}};
+      Label nintendo64OverclockValue{&nintendo64OverclockLayout, Size{45, layoutVertSize}};
+      Label nintendo64OverclockHint{&nintendo64OverclockLayout, Size{0, layoutVertSize}};
     HorizontalLayout disableVideoInterfaceProcessingLayout{this, Size{~0, 0}, 5};
       CheckLabel disableVideoInterfaceProcessingOption{&disableVideoInterfaceProcessingLayout, Size{0, 0}, 5};
       Label disableVideoInterfaceProcessingHint{&disableVideoInterfaceProcessingLayout, Size{0, layoutVertSize}};


### PR DESCRIPTION
This allows playing games with mild overclocks for better FPS, similar to what can be achieved with hardware mods and as is commonly implemented on other emulators.