### PR TITLE
n64: remove hardcoded 8 MiB memory limit in recompiler

### DIFF
--- a/ares/n64/cpu/cpu.hpp
+++ b/ares/n64/cpu/cpu.hpp
@@ -1115,7 +1115,7 @@ struct CPU : Thread {
     }
 
     auto isRdramAddress(u32 address) const -> bool {
-      return address < RdramSize;
+      return address < rdram.ram.size;
     }
 
     auto rdramAddress(u32 address) const -> u32 {

--- a/ares/n64/cpu/recompiler-ipu.cpp
+++ b/ares/n64/cpu/recompiler-ipu.cpp
@@ -122,10 +122,11 @@ auto CPU::Recompiler::jitMemoryOpcode(u32 instruction, u32 size, u32 mode,
   add64(reg(0), mem(Rs), imm(i16));
   sljit_jump* addressMismatch = nullptr;
   sljit_jump* addressOutOfRange = nullptr;
+  const u32 rdramLimit = rdram.ram.size - 1;
   if(!rangeKnown) {
     if(extendedAddressing) {
       sub64(reg(1), reg(0), imm((sljit_sw)0xffff'ffff'8000'0000ull));
-      cmp64(reg(1), imm(0x007f'ffff), set_ugt);
+      cmp64(reg(1), imm(rdramLimit), set_ugt);
     } else {
       mov64_s32(reg(1), reg(0));
       cmp64(reg(0), reg(1), set_z);
@@ -133,7 +134,7 @@ auto CPU::Recompiler::jitMemoryOpcode(u32 instruction, u32 size, u32 mode,
     addressMismatch = jump(extendedAddressing ? flag_ugt : flag_nz);
     if(!extendedAddressing) {
       sub32(reg(1), reg(0), imm((sljit_sw)0x8000'0000u));
-      cmp32(reg(1), imm(0x007f'ffff), set_ugt);
+      cmp32(reg(1), imm(rdramLimit), set_ugt);
     }
     addressOutOfRange = !extendedAddressing ? jump(flag_ugt) : nullptr;
   }

--- a/ares/n64/cpu/recompiler.cpp
+++ b/ares/n64/cpu/recompiler.cpp
@@ -247,7 +247,7 @@ auto CPU::Recompiler::computeStateKey() const -> u64 {
   stateKey.setFpuDivisionByZeroEnabled(self.fpu.csr.enable.divisionByZero());
   stateKey.setFpuInvalidOperationEnabled(self.fpu.csr.enable.invalidOperation());
   const u64 cachedBase = 0xffff'ffff'8000'0000ull;
-  const u64 cachedEnd  = 0xffff'ffff'807f'ffffull;
+  const u64 cachedEnd  = cachedBase + rdram.ram.size - 1;
   auto gp = self.ipu.r[28].u64;
   auto sp = self.ipu.r[29].u64;
   bool gpCached = gp >= cachedBase && gp <= cachedEnd;
@@ -281,7 +281,6 @@ auto CPU::Recompiler::updateStackPointerStateKey(s16 offset) -> void {
 }
 
 auto CPU::Recompiler::section(u32 address) -> Section* {
-  assert(isRdramAddress(address));
   if(!isRdramAddress(address)) return nullptr;
   auto index = sectionIndex(address);
   auto& section = sections[index];
@@ -812,10 +811,10 @@ auto CPU::Recompiler::emit(u64 vaddr, u32 address, u64 stateKey) -> Block* {
       const u32 lineIndex = u32(slow.vaddr >> 5) & 0x1ffu;
       const u32 burst = (slow.icachePaddr & ~0xfffu) | ((lineIndex << 5) & 0xfe0u);
       const u32 tagKey = (slow.icachePaddr & ~0xfffu) | 1u;
-      if(!emitStateKey.rdramMapIdentity()) {
+      const bool sdram = Model::Aleck64() && burst > 0xbfff'ffffu;
+      if(!emitStateKey.rdramMapIdentity() || (!sdram && burst + 0x1f >= rdram.ram.size)) {
         callf(&CPU::icacheFillLine, imm64(slow.vaddr), imm(slow.icachePaddr));
       } else {
-        const bool sdram = Model::Aleck64() && burst > 0xbfff'ffffu;
         const sljit_sw ramDataField = sdram ? (sljit_sw)(uintptr_t)&aleck64.sdram.data
                                              : (sljit_sw)(uintptr_t)&rdram.ram.data;
         const u32 ramByteOff = sdram ? (burst & 0xffffffu) : burst;


### PR DESCRIPTION
Fallback to interpreter or slow-path when accessing out-of-bound memory