### PR TITLE
desktop-ui: add configurable digital-to-analog mapping

### DIFF
--- a/desktop-ui/emulator/emulator.cpp
+++ b/desktop-ui/emulator/emulator.cpp
@@ -307,7 +307,7 @@ auto Emulator::input(ares::Node::Input::Input input) -> void {
       for(auto& inputPair : inputDevice.pairs) {
         if(inputPair.name != input->name()) continue;
         if(auto axis = input->cast<ares::Node::Input::Axis>()) {
-          auto value = inputPair.effectiveMappingHi().value() - inputPair.effectiveMappingLo().value();
+          auto value = inputPair.value();
           return axis->setValue(value);
         }
       }

--- a/desktop-ui/input/input.cpp
+++ b/desktop-ui/input/input.cpp
@@ -10,8 +10,8 @@ static auto inputAssignment(std::shared_ptr<HID::Device> device, u32 groupID, u3
 }
 
 auto digitalAxisMode(const string& name) -> DigitalAxisMode {
-  if(name == "Spring") return DigitalAxisMode::Spring;
-  if(name == "Hold") return DigitalAxisMode::Hold;
+  if(name == "GradualReturn") return DigitalAxisMode::GradualReturn;
+  if(name == "GradualHold") return DigitalAxisMode::GradualHold;
   return DigitalAxisMode::Immediate;
 }
 
@@ -333,11 +333,10 @@ auto InputPair::moveDigital(s32 target, u64 currentTime) -> s16 {
   auto elapsed = min(currentTime - digital.timestamp, MaximumUpdateInterval);
   digital.timestamp = currentTime;
 
-  //One half-second moves the digital approximation from center to either endpoint.
-  constexpr u64 CenterToEndpointTime = 500;
+  auto centerToEdgeTime = max(100u, min(1000u, settings.input.digitalToAnalogTime));
   auto distance = 32767 * elapsed + digital.remainder;
-  auto step = distance / CenterToEndpointTime;
-  digital.remainder = distance % CenterToEndpointTime;
+  auto step = distance / centerToEdgeTime;
+  digital.remainder = distance % centerToEdgeTime;
 
   if(digital.position < target) digital.position = min(target, digital.position + (s32)step);
   if(digital.position > target) digital.position = max(target, digital.position - (s32)step);
@@ -363,11 +362,11 @@ auto InputPair::clockDigital(DigitalAxisMode mode, bool assigned, s32 direction,
   case DigitalAxisMode::Immediate:
     resetDigital(mode, currentTime);
     return direction * 32767;
-  case DigitalAxisMode::Spring:
+  case DigitalAxisMode::GradualReturn:
     if(direction > 0) return moveDigital(+32767, currentTime);
     if(direction < 0) return moveDigital(-32767, currentTime);
     return moveDigital(0, currentTime);
-  case DigitalAxisMode::Hold:
+  case DigitalAxisMode::GradualHold:
     if(direction > 0) return moveDigital(+32767, currentTime);
     if(direction < 0) return moveDigital(-32767, currentTime);
     return moveDigital(digital.position, currentTime);

--- a/desktop-ui/input/input.cpp
+++ b/desktop-ui/input/input.cpp
@@ -9,6 +9,12 @@ static auto inputAssignment(std::shared_ptr<HID::Device> device, u32 groupID, u3
   return {"0x", hex(device->id()), "/", groupID, "/", inputID};
 }
 
+auto digitalAxisMode(const string& name) -> DigitalAxisMode {
+  if(name == "Spring") return DigitalAxisMode::Spring;
+  if(name == "Hold") return DigitalAxisMode::Hold;
+  return DigitalAxisMode::Immediate;
+}
+
 auto InputMapping::bind() -> void {
   lock_guard<recursive_mutex> inputLock(program.inputMutex);
   for(auto& binding : bindings) binding = {};
@@ -280,9 +286,11 @@ auto InputAnalog::bind(u32 binding, std::shared_ptr<HID::Device> device, u32 gro
   return false;
 }
 
-auto InputAnalog::value() -> s16 {
+auto InputAnalog::sample() -> Sample {
   lock_guard<recursive_mutex> inputLock(program.inputMutex);
   s32 result = 0;
+  bool digitalAssigned = false;
+  bool digitalPressed = false;
 
   for(auto& binding : bindings) {
     if(!binding.device) continue;  //unbound
@@ -295,11 +303,13 @@ auto InputAnalog::value() -> s16 {
     s16 value = device->group(groupID).input(inputID).value();
 
     if(device->isKeyboard() && groupID == HID::Keyboard::GroupID::Button) {
-      result += value != 0 ? 32767 : 0;
+      digitalAssigned = true;
+      digitalPressed |= value != 0;
     }
 
     if(device->isJoypad() && groupID == HID::Joypad::GroupID::Button) {
-      result += value != 0 ? 32767 : 0;
+      digitalAssigned = true;
+      digitalPressed |= value != 0;
     }
 
     if(device->isJoypad() && groupID != HID::Joypad::GroupID::Button) {
@@ -308,7 +318,72 @@ auto InputAnalog::value() -> s16 {
     }
   }
 
-  return sclamp<16>(result);
+
+  return {(s16)sclamp<16>(result), digitalAssigned, digitalPressed};
+}
+
+auto InputAnalog::value() -> s16 {
+  auto input = sample();
+  return sclamp<16>((s32)input.value + (input.pressed ? 32767 : 0));
+}
+
+auto InputPair::moveDigital(s32 target, u64 currentTime) -> s16 {
+  if(!digital.timestamp) digital.timestamp = currentTime;
+  constexpr u64 MaximumUpdateInterval = 50;
+  auto elapsed = min(currentTime - digital.timestamp, MaximumUpdateInterval);
+  digital.timestamp = currentTime;
+
+  //One half-second moves the digital approximation from center to either endpoint.
+  constexpr u64 CenterToEndpointTime = 500;
+  auto distance = 32767 * elapsed + digital.remainder;
+  auto step = distance / CenterToEndpointTime;
+  digital.remainder = distance % CenterToEndpointTime;
+
+  if(digital.position < target) digital.position = min(target, digital.position + (s32)step);
+  if(digital.position > target) digital.position = max(target, digital.position - (s32)step);
+  if(digital.position == target) digital.remainder = 0;
+  return digital.position;
+}
+
+auto InputPair::resetDigital(DigitalAxisMode mode, u64 currentTime) -> void {
+  digital.mode = mode;
+  digital.position = 0;
+  digital.remainder = 0;
+  digital.timestamp = currentTime;
+}
+
+auto InputPair::clockDigital(DigitalAxisMode mode, bool assigned, s32 direction, u64 currentTime) -> s16 {
+  if(mode != digital.mode) resetDigital(mode, currentTime);
+  if(!assigned) {
+    resetDigital(mode, currentTime);
+    return 0;
+  }
+
+  switch(mode) {
+  case DigitalAxisMode::Immediate:
+    resetDigital(mode, currentTime);
+    return direction * 32767;
+  case DigitalAxisMode::Spring:
+    if(direction > 0) return moveDigital(+32767, currentTime);
+    if(direction < 0) return moveDigital(-32767, currentTime);
+    return moveDigital(0, currentTime);
+  case DigitalAxisMode::Hold:
+    if(direction > 0) return moveDigital(+32767, currentTime);
+    if(direction < 0) return moveDigital(-32767, currentTime);
+    return moveDigital(digital.position, currentTime);
+  }
+
+  return 0;
+}
+
+auto InputPair::value() -> s16 {
+  auto lo = effectiveMappingLo().sample();
+  auto hi = effectiveMappingHi().sample();
+  s32 analog = hi.value - lo.value;
+  bool digitalAssigned = lo.digital || hi.digital;
+  s32 direction = (hi.pressed ? 1 : 0) - (lo.pressed ? 1 : 0);
+  auto digital = clockDigital(digitalAxisMode(settings.input.digitalToAnalog), digitalAssigned, direction, chrono::millisecond());
+  return sclamp<16>(analog + digital);
 }
 
 auto InputAnalog::pressed() -> bool {

--- a/desktop-ui/input/input.hpp
+++ b/desktop-ui/input/input.hpp
@@ -1,6 +1,9 @@
 enum : u32 { BindingLimit = 3 };
 
 enum class MappingMode : u32 { Direct, VirtualPad };
+enum class DigitalAxisMode : u32 { Immediate, Spring, Hold };
+
+auto digitalAxisMode(const string& name) -> DigitalAxisMode;
 
 struct InputMapping {
   enum class Qualifier : u32 { None, Lo, Hi, Rumble };
@@ -45,6 +48,16 @@ struct InputAnalog : InputMapping {
   auto bind(u32 binding, std::shared_ptr<HID::Device>, u32 groupID, u32 inputID, s16 oldValue, s16 newValue) -> bool override;
   auto value() -> s16 override;
   auto pressed() -> bool override;
+
+private:
+  struct Sample {
+    s16 value = 0;
+    bool digital = false;
+    bool pressed = false;
+  };
+
+  auto sample() -> Sample;
+  friend struct InputPair;
 };
 
 //-32768 ... +32767
@@ -124,44 +137,57 @@ struct InputNode {
 };
 
 struct InputPair {
-  enum class Type : u32 { Analog };
-  Type type;
-  string name;
-  InputMapping* mappingLo;
-  InputMapping* mappingHi;
-  std::shared_ptr<InputMapping> directMappingLo;
-  std::shared_ptr<InputMapping> directMappingHi;
+  InputPair(string name, InputAnalog& mappingLo, InputAnalog& mappingHi)
+  : name(name), mappingLo(&mappingLo), mappingHi(&mappingHi) {}
 
-  auto configuredMappingLo() -> InputMapping& {
+  string name;
+  InputAnalog* mappingLo;
+  InputAnalog* mappingHi;
+  std::shared_ptr<InputAnalog> directMappingLo;
+  std::shared_ptr<InputAnalog> directMappingHi;
+
+  auto configuredMappingLo() -> InputAnalog& {
     if(directMappingLo) return *directMappingLo;
     return *mappingLo;
   }
 
-  auto configuredMappingHi() -> InputMapping& {
+  auto configuredMappingHi() -> InputAnalog& {
     if(directMappingHi) return *directMappingHi;
     return *mappingHi;
   }
 
-  auto effectiveMappingLo() -> InputMapping& {
+  auto effectiveMappingLo() -> InputAnalog& {
     if(directMappingLo && directMappingLo->assigned()) return *directMappingLo;
     return *mappingLo;
   }
 
-  auto effectiveMappingHi() -> InputMapping& {
+  auto effectiveMappingHi() -> InputAnalog& {
     if(directMappingHi && directMappingHi->assigned()) return *directMappingHi;
     return *mappingHi;
   }
 
+  auto value() -> s16;
+
   auto setMappingMode(MappingMode mode) -> void {
     mappingMode = mode;
     if(mode != MappingMode::VirtualPad) return;
-    if(type == Type::Analog) {
-      if(!directMappingLo) directMappingLo = std::make_shared<InputAnalog>();
-      if(!directMappingHi) directMappingHi = std::make_shared<InputAnalog>();
-    }
+    if(!directMappingLo) directMappingLo = std::make_shared<InputAnalog>();
+    if(!directMappingHi) directMappingHi = std::make_shared<InputAnalog>();
   }
 
   MappingMode mappingMode = MappingMode::VirtualPad;
+
+private:
+  auto clockDigital(DigitalAxisMode mode, bool assigned, s32 direction, u64 currentTime) -> s16;
+  auto moveDigital(s32 target, u64 currentTime) -> s16;
+  auto resetDigital(DigitalAxisMode mode, u64 currentTime) -> void;
+
+  struct Digital {
+    DigitalAxisMode mode = DigitalAxisMode::Immediate;
+    s32 position = 0;
+    u32 remainder = 0;
+    u64 timestamp = 0;
+  } digital;
 };
 
 struct InputDevice {
@@ -195,12 +221,16 @@ struct InputDevice {
     if(mappingModeConfigured) inputs.back().setMappingMode(mappingMode);
   }
 
-  auto analog(string name, InputMapping& mappingLo, InputMapping& mappingHi) -> void {
-    pairs.push_back({InputPair::Type::Analog, name, &mappingLo, &mappingHi});
+  auto analog(string name, InputAnalog& mappingLo, InputAnalog& mappingHi) -> void {
+    pairs.emplace_back(name, mappingLo, mappingHi);
     if(mappingModeConfigured) pairs.back().setMappingMode(mappingMode);
     for(auto& input : inputs) {
-      if(input.mapping == &mappingLo && input.directMapping) pairs.back().directMappingLo = input.directMapping;
-      if(input.mapping == &mappingHi && input.directMapping) pairs.back().directMappingHi = input.directMapping;
+      if(input.mapping == &mappingLo && input.directMapping) {
+        pairs.back().directMappingLo = std::static_pointer_cast<InputAnalog>(input.directMapping);
+      }
+      if(input.mapping == &mappingHi && input.directMapping) {
+        pairs.back().directMappingHi = std::static_pointer_cast<InputAnalog>(input.directMapping);
+      }
     }
   }
 

--- a/desktop-ui/input/input.hpp
+++ b/desktop-ui/input/input.hpp
@@ -1,7 +1,7 @@
 enum : u32 { BindingLimit = 3 };
 
 enum class MappingMode : u32 { Direct, VirtualPad };
-enum class DigitalAxisMode : u32 { Immediate, Spring, Hold };
+enum class DigitalAxisMode : u32 { Immediate, GradualReturn, GradualHold };
 
 auto digitalAxisMode(const string& name) -> DigitalAxisMode;
 

--- a/desktop-ui/settings/input.cpp
+++ b/desktop-ui/settings/input.cpp
@@ -16,6 +16,20 @@ auto InputSettings::construct() -> void {
   if(settings.input.defocus == "Block") inputDefocusBlock.setChecked();
   if(settings.input.defocus == "Allow") inputDefocusAllow.setChecked();
 
+  digitalToAnalogLabel.setText("Digital to analog:").setFont(Font().setBold());
+  digitalToAnalogImmediate.setText("Immediate").onActivate([&] {
+    settings.input.digitalToAnalog = "Immediate";
+  });
+  digitalToAnalogSpring.setText("Spring (return to center)").onActivate([&] {
+    settings.input.digitalToAnalog = "Spring";
+  });
+  digitalToAnalogHold.setText("Hold position").onActivate([&] {
+    settings.input.digitalToAnalog = "Hold";
+  });
+  if(settings.input.digitalToAnalog == "Spring") digitalToAnalogSpring.setChecked();
+  else if(settings.input.digitalToAnalog == "Hold") digitalToAnalogHold.setChecked();
+  else digitalToAnalogImmediate.setChecked();
+
   systemList.append(ComboButtonItem().setText("Virtual Gamepads"));
   for(auto& emulator : emulators) {
     systemList.append(ComboButtonItem().setText(emulator->name));

--- a/desktop-ui/settings/input.cpp
+++ b/desktop-ui/settings/input.cpp
@@ -19,16 +19,30 @@ auto InputSettings::construct() -> void {
   digitalToAnalogLabel.setText("Digital to analog:").setFont(Font().setBold());
   digitalToAnalogImmediate.setText("Immediate").onActivate([&] {
     settings.input.digitalToAnalog = "Immediate";
+    refreshDigitalToAnalog();
   });
-  digitalToAnalogSpring.setText("Spring (return to center)").onActivate([&] {
-    settings.input.digitalToAnalog = "Spring";
+  digitalToAnalogGradualReturn.setText("Gradual (return to center)").onActivate([&] {
+    settings.input.digitalToAnalog = "GradualReturn";
+    refreshDigitalToAnalog();
   });
-  digitalToAnalogHold.setText("Hold position").onActivate([&] {
-    settings.input.digitalToAnalog = "Hold";
+  digitalToAnalogGradualHold.setText("Gradual (hold position)").onActivate([&] {
+    settings.input.digitalToAnalog = "GradualHold";
+    refreshDigitalToAnalog();
   });
-  if(settings.input.digitalToAnalog == "Spring") digitalToAnalogSpring.setChecked();
-  else if(settings.input.digitalToAnalog == "Hold") digitalToAnalogHold.setChecked();
-  else digitalToAnalogImmediate.setChecked();
+  if(settings.input.digitalToAnalog == "GradualReturn") {
+    digitalToAnalogGradualReturn.setChecked();
+  } else if(settings.input.digitalToAnalog == "GradualHold") {
+    digitalToAnalogGradualHold.setChecked();
+  } else {
+    digitalToAnalogImmediate.setChecked();
+  }
+
+  digitalToAnalogTimeLabel.setText("Center-to-edge time:").setFont(Font().setBold());
+  digitalToAnalogTimeSlider.setLength(19).setPosition((settings.input.digitalToAnalogTime - 100) / 50).onChange([&] {
+    settings.input.digitalToAnalogTime = 100 + digitalToAnalogTimeSlider.position() * 50;
+    refreshDigitalToAnalog();
+  });
+  refreshDigitalToAnalog();
 
   systemList.append(ComboButtonItem().setText("Virtual Gamepads"));
   for(auto& emulator : emulators) {
@@ -50,6 +64,13 @@ auto InputSettings::construct() -> void {
   spacer.setFocusable();
   assignButton.setText("Assign").onActivate([&] { eventAssign(inputList.selected().cell(0)); });
   clearButton.setText("Clear").onActivate([&] { eventClear(); });
+}
+
+auto InputSettings::refreshDigitalToAnalog() -> void {
+  auto gradual = settings.input.digitalToAnalog != "Immediate";
+  digitalToAnalogTimeLabel.setEnabled(gradual);
+  digitalToAnalogTimeSlider.setEnabled(gradual);
+  digitalToAnalogTimeValue.setEnabled(gradual).setText({settings.input.digitalToAnalogTime, " ms"});
 }
 
 auto InputSettings::systemChange() -> void {

--- a/desktop-ui/settings/settings.cpp
+++ b/desktop-ui/settings/settings.cpp
@@ -90,6 +90,7 @@ auto Settings::process(bool load) -> void {
   bind(real,    "Audio/Balance", audio.balance);
 
   bind(string,  "Input/Defocus", input.defocus);
+  bind(string,  "Input/DigitalToAnalog", input.digitalToAnalog);
 
   bind(boolean, "Boot/Fast", boot.fast);
   bind(boolean, "Boot/Debugger", boot.debugger);

--- a/desktop-ui/settings/settings.cpp
+++ b/desktop-ui/settings/settings.cpp
@@ -91,6 +91,8 @@ auto Settings::process(bool load) -> void {
 
   bind(string,  "Input/Defocus", input.defocus);
   bind(string,  "Input/DigitalToAnalog", input.digitalToAnalog);
+  bind(natural, "Input/DigitalToAnalogTime", input.digitalToAnalogTime);
+  input.digitalToAnalogTime = max(100u, min(1000u, input.digitalToAnalogTime));
 
   bind(boolean, "Boot/Fast", boot.fast);
   bind(boolean, "Boot/Debugger", boot.debugger);

--- a/desktop-ui/settings/settings.hpp
+++ b/desktop-ui/settings/settings.hpp
@@ -59,6 +59,7 @@ struct Settings : Markup::Node {
   struct Input {
     string driver;
     string defocus = "Pause";
+    string digitalToAnalog = "Immediate";
   } input;
 
   struct Boot {
@@ -234,6 +235,12 @@ struct InputSettings : VerticalLayout {
     RadioLabel inputDefocusBlock{&inputDefocusLayout, Size{0, 0}};
     RadioLabel inputDefocusAllow{&inputDefocusLayout, Size{0, 0}};
     Group inputDefocusGroup{&inputDefocusPause, &inputDefocusBlock, &inputDefocusAllow};
+  HorizontalLayout digitalToAnalogLayout{this, Size{~0, 0}};
+    Label digitalToAnalogLabel{&digitalToAnalogLayout, Size{0, 0}};
+    RadioLabel digitalToAnalogImmediate{&digitalToAnalogLayout, Size{0, 0}};
+    RadioLabel digitalToAnalogSpring{&digitalToAnalogLayout, Size{0, 0}};
+    RadioLabel digitalToAnalogHold{&digitalToAnalogLayout, Size{0, 0}};
+    Group digitalToAnalogGroup{&digitalToAnalogImmediate, &digitalToAnalogSpring, &digitalToAnalogHold};
   HorizontalLayout indexLayout{this, Size{~0, 0}};
     ComboButton systemList{&indexLayout, Size{~0, 0}};
     ComboButton portList{&indexLayout, Size{~0, 0}};

--- a/desktop-ui/settings/settings.hpp
+++ b/desktop-ui/settings/settings.hpp
@@ -60,6 +60,7 @@ struct Settings : Markup::Node {
     string driver;
     string defocus = "Pause";
     string digitalToAnalog = "Immediate";
+    u32 digitalToAnalogTime = 500;
   } input;
 
   struct Boot {
@@ -216,6 +217,7 @@ struct AudioSettings : VerticalLayout {
 
 struct InputSettings : VerticalLayout {
   auto construct() -> void;
+  auto refreshDigitalToAnalog() -> void;
   auto systemChange() -> void;
   auto portChange() -> void;
   auto deviceChange() -> void;
@@ -238,9 +240,13 @@ struct InputSettings : VerticalLayout {
   HorizontalLayout digitalToAnalogLayout{this, Size{~0, 0}};
     Label digitalToAnalogLabel{&digitalToAnalogLayout, Size{0, 0}};
     RadioLabel digitalToAnalogImmediate{&digitalToAnalogLayout, Size{0, 0}};
-    RadioLabel digitalToAnalogSpring{&digitalToAnalogLayout, Size{0, 0}};
-    RadioLabel digitalToAnalogHold{&digitalToAnalogLayout, Size{0, 0}};
-    Group digitalToAnalogGroup{&digitalToAnalogImmediate, &digitalToAnalogSpring, &digitalToAnalogHold};
+    RadioLabel digitalToAnalogGradualReturn{&digitalToAnalogLayout, Size{0, 0}};
+    RadioLabel digitalToAnalogGradualHold{&digitalToAnalogLayout, Size{0, 0}};
+    Group digitalToAnalogGroup{&digitalToAnalogImmediate, &digitalToAnalogGradualReturn, &digitalToAnalogGradualHold};
+  HorizontalLayout digitalToAnalogTimeLayout{this, Size{~0, 0}};
+    Label digitalToAnalogTimeLabel{&digitalToAnalogTimeLayout, Size{0, 0}};
+    HorizontalSlider digitalToAnalogTimeSlider{&digitalToAnalogTimeLayout, Size{~0, 0}};
+    Label digitalToAnalogTimeValue{&digitalToAnalogTimeLayout, Size{60, 0}};
   HorizontalLayout indexLayout{this, Size{~0, 0}};
     ComboButton systemList{&indexLayout, Size{~0, 0}};
     ComboButton portList{&indexLayout, Size{~0, 0}};


### PR DESCRIPTION
## Summary

This adds configurable digital-to-analog button mapping to the desktop input layer.

Digital buttons mapped to an analog axis previously produced full deflection immediately and returned to center when released. That behavior remains the default, but users can now select gradual movement for systems and games that rely on intermediate analog values.

## Motivation

The Atari 5200 controller exposes continuous potentiometer positions, and some games use intermediate axis values rather than treating the joystick as a digital control.

When using a keyboard or digital gamepad, the existing immediate full-deflection mapping makes those intermediate positions inaccessible. This feature addresses that limitation in the shared desktop input layer instead of adding Atari 5200-specific behavior to the core.

## Mapping modes

A global input setting provides three modes:

- **Immediate** — reaches full deflection immediately and returns to center when released. This is the default and preserves existing behavior.
- **Spring** — moves gradually while held and returns gradually to center when released.
- **Hold position** — moves gradually while held and retains its current position when released. This is useful for non-centering controls such as the original Atari 5200 joystick.

Gradual movement takes approximately 500 ms from the center to either endpoint.
