### PR TITLE
atari 5200 emulation support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,7 +18,7 @@ add_subdirectory(hiro)
 # gersemi: off
 set(
   ARES_CORES
-  a26 fc sfc sg ms md ps1 pce ng msx cv myvision gb gba ws ngp spec n64
+  a26 a52 fc sfc sg ms md ps1 pce ng msx cv myvision gb gba ws ngp spec n64
   CACHE STRING "List of systems to be built by the project"
 )
 # gersemi: on

--- a/ares/CMakeLists.txt
+++ b/ares/CMakeLists.txt
@@ -152,6 +152,13 @@ else()
   disable_core("Atari 2600")
 endif()
 
+if(a52 IN_LIST ARES_CORES)
+  enable_core("Atari 5200")
+  add_subdirectory(a52)
+else()
+  disable_core("Atari 5200")
+endif()
+
 if(fc IN_LIST ARES_CORES)
   enable_core("NES / Famicom")
   add_subdirectory(fc)

--- a/ares/a52/CMakeLists.txt
+++ b/ares/a52/CMakeLists.txt
@@ -33,6 +33,12 @@ ares_add_sources(
     cpu/memory.cpp
     cpu/timing.cpp
     antic/antic.hpp
+    antic/display-list.cpp
+    antic/dma.cpp
+    antic/interrupt.cpp
+    antic/io.cpp
+    antic/playfield.cpp
+    antic/timing.cpp
     gtia/gtia.hpp
     pokey/pokey.hpp
 )

--- a/ares/a52/CMakeLists.txt
+++ b/ares/a52/CMakeLists.txt
@@ -40,5 +40,14 @@ ares_add_sources(
     antic/playfield.cpp
     antic/timing.cpp
     gtia/gtia.hpp
+    gtia/collision.cpp
+    gtia/color.cpp
+    gtia/console.cpp
+    gtia/io.cpp
+    gtia/player-missile.cpp
+    gtia/playfield.cpp
+    gtia/priority.cpp
+    gtia/timing.cpp
+    gtia/video.cpp
     pokey/pokey.hpp
 )

--- a/ares/a52/CMakeLists.txt
+++ b/ares/a52/CMakeLists.txt
@@ -1,0 +1,37 @@
+ares_components(mos6502)
+
+ares_add_sources(
+  CORE #
+    a52
+  UNITY #
+    a52.cpp
+  PRIMARY #
+    system/system.cpp
+    cartridge/cartridge.cpp
+    cpu/cpu.cpp
+    antic/antic.cpp
+    gtia/gtia.cpp
+    pokey/pokey.cpp
+)
+
+ares_add_sources(
+  CORE #
+    a52
+  INCLUDED #
+    a52.hpp
+    CMakeLists.txt
+    system/system.hpp
+    cartridge/cartridge.hpp
+    cartridge/slot.cpp
+    cartridge/slot.hpp
+    cartridge/board/board.cpp
+    cartridge/board/board.hpp
+    cartridge/board/linear.cpp
+    cpu/cpu.hpp
+    cpu/debugger.cpp
+    cpu/memory.cpp
+    cpu/timing.cpp
+    antic/antic.hpp
+    gtia/gtia.hpp
+    pokey/pokey.hpp
+)

--- a/ares/a52/CMakeLists.txt
+++ b/ares/a52/CMakeLists.txt
@@ -22,6 +22,7 @@ ares_add_sources(
     a52.hpp
     CMakeLists.txt
     system/system.hpp
+    system/serialization.cpp
     controller/controller.hpp
     controller/port.cpp
     controller/port.hpp
@@ -30,6 +31,7 @@ ares_add_sources(
     controller/trak-ball/trak-ball.cpp
     controller/trak-ball/trak-ball.hpp
     cartridge/cartridge.hpp
+    cartridge/serialization.cpp
     cartridge/slot.cpp
     cartridge/slot.hpp
     cartridge/board/board.cpp
@@ -39,6 +41,7 @@ ares_add_sources(
     cpu/cpu.hpp
     cpu/debugger.cpp
     cpu/memory.cpp
+    cpu/serialization.cpp
     cpu/timing.cpp
     antic/antic.hpp
     antic/display-list.cpp
@@ -46,6 +49,7 @@ ares_add_sources(
     antic/interrupt.cpp
     antic/io.cpp
     antic/playfield.cpp
+    antic/serialization.cpp
     antic/timing.cpp
     gtia/gtia.hpp
     gtia/collision.cpp
@@ -55,6 +59,7 @@ ares_add_sources(
     gtia/player-missile.cpp
     gtia/playfield.cpp
     gtia/priority.cpp
+    gtia/serialization.cpp
     gtia/timing.cpp
     gtia/video.cpp
     pokey/audio.cpp
@@ -67,5 +72,6 @@ ares_add_sources(
     pokey/pokey.hpp
     pokey/pots.cpp
     pokey/serial.cpp
+    pokey/serialization.cpp
     pokey/status.cpp
 )

--- a/ares/a52/CMakeLists.txt
+++ b/ares/a52/CMakeLists.txt
@@ -27,6 +27,8 @@ ares_add_sources(
     controller/port.hpp
     controller/standard/standard.cpp
     controller/standard/standard.hpp
+    controller/trak-ball/trak-ball.cpp
+    controller/trak-ball/trak-ball.hpp
     cartridge/cartridge.hpp
     cartridge/slot.cpp
     cartridge/slot.hpp

--- a/ares/a52/CMakeLists.txt
+++ b/ares/a52/CMakeLists.txt
@@ -26,6 +26,7 @@ ares_add_sources(
     cartridge/slot.hpp
     cartridge/board/board.cpp
     cartridge/board/board.hpp
+    cartridge/board/dual-window.cpp
     cartridge/board/linear.cpp
     cpu/cpu.hpp
     cpu/debugger.cpp

--- a/ares/a52/CMakeLists.txt
+++ b/ares/a52/CMakeLists.txt
@@ -7,6 +7,7 @@ ares_add_sources(
     a52.cpp
   PRIMARY #
     system/system.cpp
+    controller/controller.cpp
     cartridge/cartridge.cpp
     cpu/cpu.cpp
     antic/antic.cpp
@@ -21,6 +22,11 @@ ares_add_sources(
     a52.hpp
     CMakeLists.txt
     system/system.hpp
+    controller/controller.hpp
+    controller/port.cpp
+    controller/port.hpp
+    controller/standard/standard.cpp
+    controller/standard/standard.hpp
     cartridge/cartridge.hpp
     cartridge/slot.cpp
     cartridge/slot.hpp
@@ -49,5 +55,15 @@ ares_add_sources(
     gtia/priority.cpp
     gtia/timing.cpp
     gtia/video.cpp
+    pokey/audio.cpp
+    pokey/clock.cpp
+    pokey/dac.cpp
+    pokey/io.cpp
+    pokey/irq.cpp
+    pokey/keyboard.cpp
+    pokey/output.cpp
     pokey/pokey.hpp
+    pokey/pots.cpp
+    pokey/serial.cpp
+    pokey/status.cpp
 )

--- a/ares/a52/a52.cpp
+++ b/ares/a52/a52.cpp
@@ -1,0 +1,6 @@
+#include <a52/cartridge/cartridge.cpp>
+#include <a52/antic/antic.cpp>
+#include <a52/gtia/gtia.cpp>
+#include <a52/pokey/pokey.cpp>
+#include <a52/cpu/cpu.cpp>
+#include <a52/system/system.cpp>

--- a/ares/a52/a52.cpp
+++ b/ares/a52/a52.cpp
@@ -1,4 +1,5 @@
 #include <a52/cartridge/cartridge.cpp>
+#include <a52/controller/controller.cpp>
 #include <a52/antic/antic.cpp>
 #include <a52/gtia/gtia.cpp>
 #include <a52/pokey/pokey.cpp>

--- a/ares/a52/a52.hpp
+++ b/ares/a52/a52.hpp
@@ -1,0 +1,30 @@
+#pragma once
+
+#include <ares/ares.hpp>
+#include <vector>
+
+#include <component/processor/mos6502/mos6502.hpp>
+
+namespace ares::Atari5200 {
+  #include <ares/inline.hpp>
+
+  auto enumerate() -> std::vector<string>;
+  auto load(Node::System& node, string name) -> bool;
+
+  struct Timing {
+    static constexpr u32 MachineCyclesPerScanline = 114;
+    static constexpr u32 ColorClocksPerMachineCycle = 2;
+    static constexpr u32 ColorClocksPerScanline = MachineCyclesPerScanline * ColorClocksPerMachineCycle;
+    static constexpr u32 SamplesPerColorClock = 2;
+    static constexpr u32 SamplesPerMachineCycle = ColorClocksPerMachineCycle * SamplesPerColorClock;
+    static constexpr u32 SamplesPerScanline = ColorClocksPerScanline * SamplesPerColorClock;
+    static constexpr u32 ScanlinesPerFrame = 262;
+  };
+
+  #include <a52/system/system.hpp>
+  #include <a52/cartridge/cartridge.hpp>
+  #include <a52/antic/antic.hpp>
+  #include <a52/gtia/gtia.hpp>
+  #include <a52/pokey/pokey.hpp>
+  #include <a52/cpu/cpu.hpp>
+}

--- a/ares/a52/a52.hpp
+++ b/ares/a52/a52.hpp
@@ -28,6 +28,7 @@ namespace ares::Atari5200 {
 
   #include <a52/system/system.hpp>
   #include <a52/cartridge/cartridge.hpp>
+  #include <a52/controller/controller.hpp>
   #include <a52/antic/antic.hpp>
   #include <a52/gtia/gtia.hpp>
   #include <a52/pokey/pokey.hpp>

--- a/ares/a52/a52.hpp
+++ b/ares/a52/a52.hpp
@@ -19,6 +19,11 @@ namespace ares::Atari5200 {
     static constexpr u32 SamplesPerMachineCycle = ColorClocksPerMachineCycle * SamplesPerColorClock;
     static constexpr u32 SamplesPerScanline = ColorClocksPerScanline * SamplesPerColorClock;
     static constexpr u32 ScanlinesPerFrame = 262;
+    static constexpr u32 DisplayListFirstScanline = 8;
+    static constexpr u32 DisplayListLastScanline = 247;
+    static constexpr u32 VisibleFirstColorClock = 0x22;
+    static constexpr u32 VisibleLastColorClock = 0xdd;
+    static constexpr u32 WSYNCReleaseCycle = 105;
   };
 
   #include <a52/system/system.hpp>

--- a/ares/a52/antic/antic.cpp
+++ b/ares/a52/antic/antic.cpp
@@ -10,6 +10,7 @@ ANTIC antic;
 #include "dma.cpp"
 #include "playfield.cpp"
 #include "interrupt.cpp"
+#include "serialization.cpp"
 
 auto ANTIC::load(Node::Object parent) -> void {
   node = parent->append<Node::Object>("ANTIC");

--- a/ares/a52/antic/antic.cpp
+++ b/ares/a52/antic/antic.cpp
@@ -1,0 +1,41 @@
+#include <a52/a52.hpp>
+
+namespace ares::Atari5200 {
+
+ANTIC antic;
+
+auto ANTIC::load(Node::Object parent) -> void {
+  node = parent->append<Node::Object>("ANTIC");
+}
+
+auto ANTIC::unload() -> void {
+  Thread::destroy();
+  node = {};
+}
+
+auto ANTIC::main() -> void {
+  Thread::step(Timing::ColorClocksPerScanline);
+  Thread::synchronize(cpu);
+  if(++scanline == Timing::ScanlinesPerFrame) {
+    scanline = 0;
+    scheduler.exit(Event::Frame);
+  }
+}
+
+auto ANTIC::power() -> void {
+  Thread::create(system.frequency(), std::bind_front(&ANTIC::main, this));
+  scanline = 0;
+}
+
+auto ANTIC::read(n8 address) -> n8 {
+  return peek(address);
+}
+
+auto ANTIC::peek(n8 address) const -> n8 {
+  return 0xff;
+}
+
+auto ANTIC::write(n8 address, n8 data) -> void {
+}
+
+}

--- a/ares/a52/antic/antic.cpp
+++ b/ares/a52/antic/antic.cpp
@@ -4,6 +4,13 @@ namespace ares::Atari5200 {
 
 ANTIC antic;
 
+#include "io.cpp"
+#include "timing.cpp"
+#include "display-list.cpp"
+#include "dma.cpp"
+#include "playfield.cpp"
+#include "interrupt.cpp"
+
 auto ANTIC::load(Node::Object parent) -> void {
   node = parent->append<Node::Object>("ANTIC");
 }
@@ -14,28 +21,20 @@ auto ANTIC::unload() -> void {
 }
 
 auto ANTIC::main() -> void {
-  Thread::step(Timing::ColorClocksPerScanline);
-  Thread::synchronize(cpu);
-  if(++scanline == Timing::ScanlinesPerFrame) {
-    scanline = 0;
-    scheduler.exit(Event::Frame);
-  }
+  scanline();
 }
 
 auto ANTIC::power() -> void {
   Thread::create(system.frequency(), std::bind_front(&ANTIC::main, this));
-  scanline = 0;
-}
-
-auto ANTIC::read(n8 address) -> n8 {
-  return peek(address);
-}
-
-auto ANTIC::peek(n8 address) const -> n8 {
-  return 0xff;
-}
-
-auto ANTIC::write(n8 address, n8 data) -> void {
+  io = {};
+  counter = {};
+  displayList.power();
+  dma.power();
+  playfield.power();
+  wsync.power();
+  interrupt.power();
+  cpu.rdyLine(1);
+  cpu.nmiLine(0);
 }
 
 }

--- a/ares/a52/antic/antic.hpp
+++ b/ares/a52/antic/antic.hpp
@@ -12,6 +12,9 @@ struct ANTIC : Thread {
   auto peek(n8 address) const -> n8;
   auto write(n8 address, n8 data) -> void;
 
+  //serialization.cpp
+  auto serialize(serializer&) -> void;
+
 //private:
 
   struct ModeProperties {
@@ -116,6 +119,9 @@ struct ANTIC : Thread {
     auto arbitrate(Requests& requests) -> void;
     auto consume(const Request& request, n8 data) -> void;
 
+    //serialization.cpp
+    auto serialize(serializer&) -> void;
+
     n1 refreshPending;
   } dma{*this};
 
@@ -134,6 +140,9 @@ struct ANTIC : Thread {
     auto queueDMA(DMA::Requests& requests) -> void;
     auto consumeInstruction(n8 data) -> void;
     auto consumeOperand(u8 index, n8 data) -> void;
+
+    //serialization.cpp
+    auto serialize(serializer&) -> void;
 
     n8 instruction;
     n16 memoryScan;
@@ -183,6 +192,9 @@ struct ANTIC : Thread {
     auto consumeBitmap(n6 writePhase, n6 readPhase, n8 data) -> void;
     auto consumeCharacter(n8 character, n8 data) -> void;
 
+    //serialization.cpp
+    auto serialize(serializer&) -> void;
+
     n8 dmaClock;
     n8 dmaName[8];
     n6 lineWrite;
@@ -211,6 +223,9 @@ struct ANTIC : Thread {
     auto clock() -> void;
     auto wait() -> void;
 
+    //serialization.cpp
+    auto serialize(serializer&) -> void;
+
     n1 active;
     n9 scanline;
   } wsync{*this};
@@ -223,6 +238,9 @@ struct ANTIC : Thread {
     auto power() -> void;
     auto schedule(n8 source) -> void;
     auto clock() -> void;
+
+    //serialization.cpp
+    auto serialize(serializer&) -> void;
 
     n8 pending;
     n8 enable;

--- a/ares/a52/antic/antic.hpp
+++ b/ares/a52/antic/antic.hpp
@@ -1,0 +1,17 @@
+struct ANTIC : Thread {
+  Node::Object node;
+
+  auto load(Node::Object parent) -> void;
+  auto unload() -> void;
+  auto main() -> void;
+  auto power() -> void;
+
+  auto read(n8 address) -> n8;
+  auto peek(n8 address) const -> n8;
+  auto write(n8 address, n8 data) -> void;
+
+private:
+  u32 scanline = 0;
+};
+
+extern ANTIC antic;

--- a/ares/a52/antic/antic.hpp
+++ b/ares/a52/antic/antic.hpp
@@ -1,17 +1,233 @@
 struct ANTIC : Thread {
   Node::Object node;
 
+  //antic.cpp
   auto load(Node::Object parent) -> void;
   auto unload() -> void;
   auto main() -> void;
   auto power() -> void;
 
+  //io.cpp
   auto read(n8 address) -> n8;
   auto peek(n8 address) const -> n8;
   auto write(n8 address, n8 data) -> void;
 
-private:
-  u32 scanline = 0;
+//private:
+
+  struct ModeProperties {
+    u8 height;
+    u8 bytes;
+    u8 bitsPerPixel;
+    u8 samplesPerPixel;
+    bool character;
+    bool highResolution;
+  };
+
+  static constexpr ModeProperties Modes[16] = {
+    { 1,  0, 0, 0, false, false},
+    { 1,  0, 0, 0, false, false},
+    { 8, 40, 1, 1, true,  true },
+    {10, 40, 1, 1, true,  true },
+    { 8, 40, 2, 2, true,  false},
+    {16, 40, 2, 2, true,  false},
+    { 8, 20, 1, 2, true,  false},
+    {16, 20, 1, 2, true,  false},
+    { 8, 10, 2, 8, false, false},
+    { 4, 10, 1, 4, false, false},
+    { 4, 20, 2, 4, false, false},
+    { 2, 20, 1, 2, false, false},
+    { 1, 20, 1, 2, false, false},
+    { 2, 40, 2, 2, false, false},
+    { 1, 40, 2, 2, false, false},
+    { 1, 40, 1, 1, false, true },
+  };
+
+  enum class DMAConsumer : u8 {
+    Missile,
+    Player,
+    DisplayListInstruction,
+    DisplayListOperand,
+    LineBufferName,
+    LineBufferBitmap,
+    Character,
+  };
+
+  //timing.cpp
+  auto scanline() -> void;
+  auto clock() -> void;
+  auto step(u32 colorClocks) -> void;
+  auto clockRegisterPipelines() -> void;
+  auto finishScanline() -> void;
+  auto frame() -> void;
+
+  struct IO {
+    n6 dmactl;
+    n3 chactl;
+    n16 dlist;
+    n4 hscroll;
+    n4 vscroll;
+    n8 pmbase;
+    n8 chbase;
+    n8 penh;
+    n8 penv;
+    n8 nmien;
+    n8 nmist;
+    n8 chbasePipeline[2];
+    n2 playerMissileDMA[2];
+  } io;
+
+  struct Counter {
+    n8 machineCycle;
+    n9 scanline;
+  } counter;
+
+  struct DMA {
+    ANTIC& self;
+    DMA(ANTIC& self) : self(self) {}
+
+    struct Request {
+      n16 address;
+      DMAConsumer consumer;
+      n8 index;
+      n8 phase;
+      n1 addressValid;
+      n1 physical;
+      n1 next;
+    };
+
+    struct Requests {
+      Request item[4];
+      n3 size;
+      n1 lineBufferReplay;
+      n6 lineBufferPhase;
+
+      //dma.cpp
+      auto append(n16 address, DMAConsumer consumer, u8 index,
+        bool addressValid, bool physical, bool next = false, u8 phase = 0) -> void;
+      auto replayLineBuffer(n6 phase) -> void;
+    };
+
+    //dma.cpp
+    auto power() -> void;
+    auto beginScanline() -> void;
+    auto clockRefresh() -> void;
+    auto playerMissileAddress(u8 index) const -> n16;
+    auto queuePlayerMissile(Requests& requests) -> void;
+    auto arbitrate(Requests& requests) -> void;
+    auto consume(const Request& request, n8 data) -> void;
+
+    n1 refreshPending;
+  } dma{*this};
+
+  struct DisplayList {
+    ANTIC& self;
+    DisplayList(ANTIC& self) : self(self) {}
+
+    //display-list.cpp
+    auto power() -> void;
+    auto incrementDisplayList(n16 address) const -> n16;
+    auto incrementMemoryScan(n16 address) const -> n16;
+    auto beginInstruction() -> void;
+    auto beginScanline() -> void;
+    auto finishScanline() -> void;
+    auto clock() -> void;
+    auto queueDMA(DMA::Requests& requests) -> void;
+    auto consumeInstruction(n8 data) -> void;
+    auto consumeOperand(u8 index, n8 data) -> void;
+
+    n8 instruction;
+    n16 memoryScan;
+    n8 row;
+    n8 lastRow;
+    n1 valid;
+    n1 needInstruction;
+    n1 waitingForVerticalBlank;
+    n1 loadMemoryScan;
+    n1 verticalScroll;
+    n1 verticalScrollEnding;
+    n1 firstScanline;
+    n1 dmaEnabled;
+    n2 operand;
+    n16 lineAddress;
+    n4 vscrollStart;
+    n4 vscrollDLI;
+    n4 vscrollEnd;
+  } displayList{*this};
+
+  struct Playfield {
+    ANTIC& self;
+    Playfield(ANTIC& self) : self(self) {}
+
+    //playfield.cpp
+    auto power() -> void;
+    auto start() const -> u16;
+    auto end() const -> u16;
+    auto fetchWidth() const -> u8;
+    auto sample() const -> n3;
+    auto clockAN(u16 colorClock) -> n3;
+    auto characterAddress(n8 name, u8 row) const -> n16;
+    auto lineBufferRead(n6 phase) const -> n8;
+    auto lineBufferWrite(n6 phase, n8 data) -> void;
+    auto bitmapLineBufferPhase(bool next) -> n6;
+    auto incrementLineBuffer(n6& phase) -> void;
+    auto dmaFeedbackLength() const -> u8;
+    auto dmaStart() const -> u8;
+    auto dmaStop() const -> u8;
+    auto clearDMARing() -> void;
+    auto clockDMARing() -> void;
+    auto scheduleGraphics(n8 data, n8 name, u8 delay) -> void;
+    auto scheduleLineGraphics(n6 phase, u8 delay) -> void;
+    auto clockShiftRing() -> void;
+    auto queueDMA(DMA::Requests& requests) -> void;
+    auto consumeName(n6 writePhase, n6 readPhase, n8 data) -> void;
+    auto consumeBitmap(n6 writePhase, n6 readPhase, n8 data) -> void;
+    auto consumeCharacter(n8 character, n8 data) -> void;
+
+    n8 dmaClock;
+    n8 dmaName[8];
+    n6 lineWrite;
+    n6 lineRead;
+    n8 lineBuffer[48];
+
+    n4 shiftClock;
+    n8 graphics;
+    n8 name;
+    n2 output;
+    n3 delayed;
+    n4 queuePosition;
+    n16 queueValid;
+    n16 queueLine;
+    n8 queueData[16];
+    n8 queueName[16];
+    n6 queuePhase[16];
+  } playfield{*this};
+
+  struct WSYNC {
+    ANTIC& self;
+    WSYNC(ANTIC& self) : self(self) {}
+
+    //interrupt.cpp
+    auto power() -> void;
+    auto clock() -> void;
+    auto wait() -> void;
+
+    n1 active;
+    n9 scanline;
+  } wsync{*this};
+
+  struct Interrupt {
+    ANTIC& self;
+    Interrupt(ANTIC& self) : self(self) {}
+
+    //interrupt.cpp
+    auto power() -> void;
+    auto schedule(n8 source) -> void;
+    auto clock() -> void;
+
+    n8 pending;
+    n8 enable;
+    n1 pulse;
+  } interrupt{*this};
 };
 
 extern ANTIC antic;

--- a/ares/a52/antic/display-list.cpp
+++ b/ares/a52/antic/display-list.cpp
@@ -1,0 +1,181 @@
+auto ANTIC::DisplayList::power() -> void {
+  instruction = 0;
+  memoryScan = 0;
+  row = 0;
+  lastRow = 0;
+  valid = 0;
+  needInstruction = 1;
+  waitingForVerticalBlank = 0;
+  loadMemoryScan = 0;
+  verticalScroll = 0;
+  verticalScrollEnding = 0;
+  firstScanline = 0;
+  dmaEnabled = 0;
+  operand = 0;
+  lineAddress = 0;
+  vscrollStart = 0;
+  vscrollDLI = 0;
+  vscrollEnd = 0;
+}
+
+auto ANTIC::DisplayList::incrementDisplayList(n16 address) const -> n16 {
+  return (address & 0xfc00) | ((address + 1) & 0x03ff);
+}
+
+auto ANTIC::DisplayList::incrementMemoryScan(n16 address) const -> n16 {
+  return (address & 0xf000) | ((address + 1) & 0x0fff);
+}
+
+auto ANTIC::DisplayList::beginInstruction() -> void {
+  auto previousVerticalScroll = (bool)verticalScroll;
+  operand = 0;
+  lineAddress = 0;
+  firstScanline = 1;
+
+  auto mode = (u8)instruction & 15;
+  verticalScroll = mode >= 2 && instruction.bit(5);
+  verticalScrollEnding = previousVerticalScroll && !verticalScroll;
+  row = verticalScroll && !previousVerticalScroll ? (u8)vscrollStart : 0;
+  if(mode == 0) {
+    lastRow = ((u8)instruction >> 4 & 7);
+  } else if(mode == 1) {
+    lastRow = 0;
+    operand = 2;
+  } else {
+    lastRow = Modes[mode].height - 1;
+    loadMemoryScan = instruction.bit(6);
+    operand = loadMemoryScan ? 2 : 0;
+    lineAddress = memoryScan;
+  }
+  if(mode < 2) self.playfield.clearDMARing();
+}
+
+auto ANTIC::DisplayList::beginScanline() -> void {
+  // AHRM 4.6: vertical blank preserves the retained IR except for LMS/JVB bit 6.
+  if(self.counter.scanline == 248) {
+    instruction &= ~0x40;
+    self.playfield.clearDMARing();
+  }
+  if(self.counter.scanline == Timing::DisplayListFirstScanline && waitingForVerticalBlank) {
+    waitingForVerticalBlank = 0;
+    needInstruction = 1;
+  }
+
+  self.playfield.lineWrite = 0;
+  self.playfield.lineRead = 0;
+}
+
+auto ANTIC::DisplayList::finishScanline() -> void {
+  bool displayRange =
+    self.counter.scanline >= Timing::DisplayListFirstScanline
+    && self.counter.scanline <= Timing::DisplayListLastScanline;
+  if(displayRange && valid) {
+    if(waitingForVerticalBlank) {
+      if(verticalScrollEnding && row != lastRow) {
+        row = ((u8)row + 1) & 15;
+        firstScanline = 0;
+      } else {
+        row = 0;
+        lastRow = 0;
+        verticalScrollEnding = 0;
+        firstScanline = 1;
+      }
+    } else if(row == lastRow) {
+      needInstruction = 1;
+      row = 0;
+    } else {
+      row = ((u8)row + 1) & 15;
+      firstScanline = 0;
+    }
+  }
+}
+
+auto ANTIC::DisplayList::clock() -> void {
+  // AHRM 4.7: VSCROL has separate cycle 0, 5, and 108 deadlines for
+  // entering a region, deciding its DLI, and ending the region.
+  if(self.counter.machineCycle == 0) {
+    vscrollStart = self.io.vscroll;
+    auto mode = (u8)instruction & 15;
+    if(!needInstruction && !waitingForVerticalBlank
+    && verticalScrollEnding && mode == 1 && !instruction.bit(6) && row) {
+      // AHRM 4.6: an extended ordinary JMP follows an indirect-address chain.
+      // JVB fetches its target only on its first line and then replays without
+      // any further display-list DMA.
+      operand = 2;
+      lineAddress = 0;
+    }
+  }
+
+  if(self.counter.machineCycle == 5) {
+    vscrollDLI = self.io.vscroll;
+    bool displayRange =
+      self.counter.scanline >= Timing::DisplayListFirstScanline
+      && self.counter.scanline <= Timing::DisplayListLastScanline;
+    if(displayRange && valid && !needInstruction && instruction.bit(7)) {
+      auto last = verticalScrollEnding ? (u8)vscrollDLI : (u8)lastRow;
+      if(row == last) self.interrupt.schedule(0x80);
+    }
+  }
+
+  if(self.counter.machineCycle == 108) {
+    vscrollEnd = self.io.vscroll;
+    if(verticalScrollEnding) lastRow = vscrollEnd;
+  }
+}
+
+auto ANTIC::DisplayList::queueDMA(DMA::Requests& requests) -> void {
+  bool displayRange =
+    self.counter.scanline >= Timing::DisplayListFirstScanline
+    && self.counter.scanline <= Timing::DisplayListLastScanline;
+  if(!displayRange || waitingForVerticalBlank) return;
+
+  if(self.counter.machineCycle == 1 && needInstruction) {
+    if(dmaEnabled) {
+      requests.append(
+        self.io.dlist, DMAConsumer::DisplayListInstruction, 0, true, true
+      );
+      return;
+    }
+    if(valid) {
+      // The retained instruction is decoded even though its cycle-1 fetch was
+      // suppressed. Address operands remain gated by the live DMACTL value.
+      needInstruction = 0;
+      beginInstruction();
+    }
+  }
+
+  if(self.io.dmactl.bit(5) && operand
+  && (self.counter.machineCycle == 6 || self.counter.machineCycle == 7)) {
+    requests.append(
+      self.io.dlist, DMAConsumer::DisplayListOperand, self.counter.machineCycle - 6, true, true
+    );
+  }
+}
+
+auto ANTIC::DisplayList::consumeInstruction(n8 data) -> void {
+  instruction = data;
+  if(!self.io.playerMissileDMA[1]) {
+    // With GTIA missile DMA acceptance enabled but no ANTIC P/M slot,
+    // the first HALT can expose the display-list byte on the shared bus.
+    gtia.loadMissileDMA(data, self.counter.scanline);
+  }
+  self.io.dlist = incrementDisplayList(self.io.dlist);
+  valid = 1;
+  needInstruction = 0;
+  beginInstruction();
+}
+
+auto ANTIC::DisplayList::consumeOperand(u8 index, n8 data) -> void {
+  self.io.dlist = incrementDisplayList(self.io.dlist);
+  lineAddress.byte(index) = data;
+  operand--;
+  if(operand) return;
+
+  auto mode = (u8)instruction & 15;
+  if(mode == 1) {
+    self.io.dlist = lineAddress;
+    if(instruction.bit(6)) waitingForVerticalBlank = 1;
+  } else {
+    memoryScan = lineAddress;
+  }
+}

--- a/ares/a52/antic/dma.cpp
+++ b/ares/a52/antic/dma.cpp
@@ -1,0 +1,122 @@
+auto ANTIC::DMA::Requests::append(n16 address, DMAConsumer consumer, u8 index,
+  bool addressValid, bool physical, bool next, u8 phase) -> void {
+  assert(size < 4);
+  item[size++] = {address, consumer, index, phase, addressValid, physical, next};
+}
+
+auto ANTIC::DMA::Requests::replayLineBuffer(n6 phase) -> void {
+  lineBufferReplay = 1;
+  lineBufferPhase = phase;
+}
+
+auto ANTIC::DMA::power() -> void {
+  refreshPending = 0;
+}
+
+auto ANTIC::DMA::beginScanline() -> void {
+  refreshPending = 0;
+}
+
+auto ANTIC::DMA::clockRefresh() -> void {
+  if(self.counter.machineCycle >= 25 && self.counter.machineCycle <= 57
+  && (self.counter.machineCycle - 25) % 4 == 0) {
+    refreshPending = 1;
+  }
+}
+
+auto ANTIC::DMA::playerMissileAddress(u8 index) const -> n16 {
+  bool singleLine = self.io.dmactl.bit(4);
+  auto row = singleLine ? (u16)self.counter.scanline : (u16)self.counter.scanline >> 1;
+  auto base = (u16)self.io.pmbase << 8;
+  if(singleLine) {
+    base &= 0xf800;
+    return base + (index ? 0x400 + (index - 1) * 0x100 : 0x300) + row;
+  }
+  base &= 0xfc00;
+  return base + (index ? 0x200 + (index - 1) * 0x80 : 0x180) + row;
+}
+
+auto ANTIC::DMA::queuePlayerMissile(Requests& requests) -> void {
+  bool displayRange =
+    self.counter.scanline >= Timing::DisplayListFirstScanline
+    && self.counter.scanline <= Timing::DisplayListLastScanline;
+  auto enabled = self.io.playerMissileDMA[1];
+
+  if(displayRange && self.counter.machineCycle == 0) {
+    bool physical = enabled.bit(0) || enabled.bit(1);
+    requests.append(
+      physical ? playerMissileAddress(0) : n16{0},
+      DMAConsumer::Missile, 0, physical, physical
+    );
+  }
+
+  if(displayRange && self.counter.machineCycle >= 2 && self.counter.machineCycle <= 5) {
+    auto player = (u8)self.counter.machineCycle - 2;
+    bool physical = enabled.bit(1);
+    requests.append(
+      physical ? playerMissileAddress(player + 1) : n16{0},
+      DMAConsumer::Player, player, physical, physical
+    );
+  }
+}
+
+auto ANTIC::DMA::arbitrate(Requests& requests) -> void {
+  bool physical = false;
+  n16 address = 0xffff;
+
+  for(u32 index : range((u32)requests.size)) {
+    auto& request = requests.item[index];
+    if(request.addressValid) address &= request.address;
+    physical |= request.physical;
+  }
+
+  n8 data;
+  if(physical) {
+    cpu.rdyLine(0);
+    data = cpu.readDMA(address);
+    self.step(Timing::ColorClocksPerMachineCycle);
+    cpu.rdyLine(!self.wsync.active);
+  } else if(refreshPending) {
+    cpu.rdyLine(0);
+    self.step(Timing::ColorClocksPerMachineCycle);
+    cpu.rdyLine(!self.wsync.active);
+    refreshPending = 0;
+    data = cpu.dataBus();
+  } else {
+    self.step(Timing::ColorClocksPerMachineCycle);
+    data = cpu.dataBus();
+  }
+
+  for(u32 index : range((u32)requests.size)) {
+    consume(requests.item[index], data);
+  }
+  if(requests.lineBufferReplay) {
+    self.playfield.scheduleLineGraphics(requests.lineBufferPhase, 9);
+  }
+}
+
+auto ANTIC::DMA::consume(const Request& request, n8 data) -> void {
+  switch(request.consumer) {
+  case DMAConsumer::Missile:
+    gtia.loadMissileDMA(data, self.counter.scanline);
+    return;
+  case DMAConsumer::Player:
+    gtia.loadPlayerDMA(request.index, data, self.counter.scanline);
+    return;
+  case DMAConsumer::DisplayListInstruction:
+    self.displayList.consumeInstruction(data);
+    return;
+  case DMAConsumer::DisplayListOperand:
+    self.displayList.consumeOperand(request.index, data);
+    return;
+  case DMAConsumer::LineBufferName:
+    self.playfield.consumeName(request.index, request.phase, data);
+    return;
+  case DMAConsumer::LineBufferBitmap:
+    self.playfield.consumeBitmap(request.index, request.phase, data);
+    return;
+  case DMAConsumer::Character:
+    self.playfield.consumeCharacter(request.index, data);
+    return;
+  }
+}

--- a/ares/a52/antic/interrupt.cpp
+++ b/ares/a52/antic/interrupt.cpp
@@ -1,0 +1,53 @@
+auto ANTIC::Interrupt::power() -> void {
+  pending = 0;
+  enable = 0;
+  pulse = 0;
+}
+
+auto ANTIC::Interrupt::schedule(n8 source) -> void {
+  pending = source;
+}
+
+auto ANTIC::Interrupt::clock() -> void {
+  if(self.counter.machineCycle == 7 && pending) {
+    // VBI and DLI status are mutually exclusive and latch independently of
+    // NMIEN. The status becomes visible one cycle before the NMI pulse.
+    if(pending == 0x40) self.io.nmist &= ~0x80;
+    if(pending == 0x80) self.io.nmist &= ~0x40;
+    self.io.nmist |= pending;
+    // AHRM 4.8: enabling closes at cycle 7, while a cycle-8 write can still
+    // disable an interrupt that was enabled at the earlier boundary.
+    enable = self.io.nmien;
+  }
+  if(self.counter.machineCycle == 8 && pending) {
+    if(pending & enable & self.io.nmien) {
+      cpu.nmiLine(1);
+      pulse = 1;
+    }
+  }
+  if(self.counter.machineCycle == 9) {
+    if(pulse) cpu.nmiLine(0);
+    pulse = 0;
+    pending = 0;
+    enable = 0;
+  }
+}
+
+auto ANTIC::WSYNC::power() -> void {
+  active = 0;
+  scanline = 0;
+}
+
+auto ANTIC::WSYNC::clock() -> void {
+  if(active && scanline == self.counter.scanline && self.counter.machineCycle == Timing::WSYNCReleaseCycle) {
+    active = 0;
+    cpu.rdyLine(1);
+  }
+}
+
+auto ANTIC::WSYNC::wait() -> void {
+  active = 1;
+  scanline = self.counter.scanline + (self.counter.machineCycle >= 104);
+  if(scanline == Timing::ScanlinesPerFrame) scanline = 0;
+  cpu.rdyLine(0);
+}

--- a/ares/a52/antic/io.cpp
+++ b/ares/a52/antic/io.cpp
@@ -1,0 +1,34 @@
+auto ANTIC::read(n8 address) -> n8 {
+  return peek(address);
+}
+
+auto ANTIC::peek(n8 address) const -> n8 {
+  switch(address & 0x0f) {
+  case 0x0b: {
+    // AHRM 4.10: $83 is visible only on cycle 111 of the final NTSC line.
+    if(counter.scanline == Timing::ScanlinesPerFrame - 1 && counter.machineCycle >= 112) return 0;
+    auto scanline = (u16)counter.scanline + ((u8)counter.machineCycle >= 111);
+    return scanline >> 1;
+  }
+  case 0x0c: return io.penh;
+  case 0x0d: return io.penv;
+  case 0x0f: return io.nmist | 0x1f;
+  }
+  return 0xff;
+}
+
+auto ANTIC::write(n8 address, n8 data) -> void {
+  switch(address & 0x0f) {
+  case 0x00: io.dmactl = data;        return;
+  case 0x01: io.chactl = data;        return;
+  case 0x02: io.dlist.byte(0) = data; return;
+  case 0x03: io.dlist.byte(1) = data; return;
+  case 0x04: io.hscroll = data;       return;
+  case 0x05: io.vscroll = data;       return;
+  case 0x07: io.pmbase = data;        return;
+  case 0x09: io.chbase = data;        return;
+  case 0x0a: wsync.wait();            return;
+  case 0x0e: io.nmien = data;         return;
+  case 0x0f: io.nmist = 0;            return;
+  }
+}

--- a/ares/a52/antic/playfield.cpp
+++ b/ares/a52/antic/playfield.cpp
@@ -1,0 +1,342 @@
+auto ANTIC::Playfield::power() -> void {
+  dmaClock = 0;
+  for(auto& name : dmaName) name = 0;
+  lineWrite = 0;
+  lineRead = 0;
+  for(auto& data : lineBuffer) data = 0;
+  shiftClock = 0;
+  graphics = 0;
+  name = 0;
+  output = 0;
+  delayed = 0;
+  queuePosition = 0;
+  queueValid = 0;
+  queueLine = 0;
+  for(auto& data : queueData) data = 0;
+  for(auto& name : queueName) name = 0;
+  for(auto& phase : queuePhase) phase = 0;
+}
+
+auto ANTIC::Playfield::start() const -> u16 {
+  switch((u8)self.io.dmactl & 3) {
+  case 1: return 0x40 * Timing::SamplesPerColorClock;
+  case 2: return 0x30 * Timing::SamplesPerColorClock;
+  case 3: return 0x2c * Timing::SamplesPerColorClock;
+  }
+  return 0;
+}
+
+auto ANTIC::Playfield::end() const -> u16 {
+  switch((u8)self.io.dmactl & 3) {
+  case 1: return 0xc0 * Timing::SamplesPerColorClock;
+  case 2: return 0xd0 * Timing::SamplesPerColorClock;
+  case 3: return 0xe0 * Timing::SamplesPerColorClock;
+  }
+  return 0;
+}
+
+auto ANTIC::Playfield::fetchWidth() const -> u8 {
+  auto width = (u8)self.io.dmactl & 3;
+  if(self.displayList.instruction.bit(4) && width && width < 3) width++;
+  return width;
+}
+
+auto ANTIC::Playfield::sample() const -> n3 {
+  auto mode = (u8)self.displayList.instruction & 15;
+  auto value = (u8)output;
+  if((mode == 2 || mode == 3) && name.bit(7)) {
+    if(self.io.chactl.bit(0)) value = 0;
+    if(self.io.chactl.bit(1)) value ^= 3;
+  }
+  if((mode == 4 || mode == 5) && value == 3 && name.bit(7)) return 4;
+  if(mode == 6 || mode == 7) return value ? (((u8)name >> 6) + 1) : 0;
+  return value;
+}
+
+auto ANTIC::Playfield::clockAN(u16 colorClock) -> n3 {
+  clockShiftRing();
+
+  // ANTIC machine cycle 0 precedes GTIA horizontal position 0 by three
+  // color clocks. Translate the machine-cycle phase into the coordinate that
+  // GTIA is sampling before selecting the playfield data for the AN bus.
+  colorClock = (colorClock + Timing::ColorClocksPerScanline - 3)
+    % Timing::ColorClocksPerScanline;
+
+  auto mode = (u8)self.displayList.instruction & 15;
+  if(self.counter.scanline < Timing::DisplayListFirstScanline
+  || self.counter.scanline > Timing::DisplayListLastScanline) {
+    auto blank = self.counter.scanline >= 251 && self.counter.scanline <= 253
+      ? 1 : Modes[mode].highResolution ? 3 : 2;
+    auto sample = colorClock * Timing::SamplesPerColorClock;
+    bool corruptHiresBlank = Modes[mode].highResolution
+      && (self.io.dmactl & 3)
+      && sample >= start()
+      && sample < end();
+    return corruptHiresBlank ? blank | 4 : blank;
+  }
+  if(colorClock < Timing::VisibleFirstColorClock || colorClock > Timing::VisibleLastColorClock) {
+    return Modes[mode].highResolution ? 3 : 2;
+  }
+
+  auto position = colorClock * Timing::SamplesPerColorClock;
+  if(!self.displayList.valid || mode < 2 || !(self.io.dmactl & 3)) {
+    delayed = 0;
+    return 0;
+  }
+
+  auto value = (u8)sample();
+  n3 encoded = Modes[mode].highResolution ? n3{4 | value} : n3{value ? value + 3 : 0};
+  auto an = self.displayList.instruction.bit(4) && self.io.hscroll.bit(0) ? delayed : encoded;
+  delayed = encoded;
+  if(position < start() || position >= end()) return 0;
+  return an;
+}
+
+auto ANTIC::Playfield::characterAddress(n8 name, u8 row) const -> n16 {
+  auto mode = (u8)self.displayList.instruction & 15;
+  auto character = mode < 6 ? (u8)name & 0x7f : (u8)name & 0x3f;
+  auto characterRow = mode == 5 || mode == 7 ? (row >> 1) & 7 : row & 7;
+
+  if(mode == 3) {
+    if(character < 0x60 && row >= 8) return 0xffff;
+    if(character >= 0x60) {
+      if(row < 2) return 0xffff;
+      characterRow = row & 7;
+    }
+  }
+  if(self.io.chactl.bit(2)) characterRow ^= 7;
+
+  auto mask = mode < 6 ? 0xfc00 : 0xfe00;
+  return ((u16)self.io.chbasePipeline[1] << 8 & mask) | ((u16)character << 3) | characterRow;
+}
+
+auto ANTIC::Playfield::lineBufferRead(n6 phase) const -> n8 {
+  if(phase < 48) return lineBuffer[phase];
+  return 0xff;
+}
+
+auto ANTIC::Playfield::lineBufferWrite(n6 phase, n8 data) -> void {
+  if(phase < 48) lineBuffer[phase] = data;
+}
+
+auto ANTIC::Playfield::bitmapLineBufferPhase(bool next) -> n6 {
+  // Consecutive bitmap reads clock the address before every read except the
+  // last one. A run [i..i+n-1] therefore returns
+  // [i+1..i+n-1, i+n-1] while still advancing by n positions overall.
+  if(next) incrementLineBuffer(lineRead);
+  auto phase = lineRead;
+  if(!next) incrementLineBuffer(lineRead);
+  return phase;
+}
+
+auto ANTIC::Playfield::incrementLineBuffer(n6& phase) -> void {
+  phase = phase == 62 ? 0 : phase + 1;
+}
+
+auto ANTIC::Playfield::dmaFeedbackLength() const -> u8 {
+  auto mode = (u8)self.displayList.instruction & 15;
+  if(mode >= 8 && mode <= 9) return 8;
+  if(mode >= 6 && mode <= 7) return 4;
+  if(mode >= 10 && mode <= 12) return 4;
+  return 2;
+}
+
+auto ANTIC::Playfield::dmaStart() const -> u8 {
+  auto mode = (u8)self.displayList.instruction & 15;
+  auto width = fetchWidth();
+  if(mode < 2 || !width) return 0xff;
+
+  auto cycle = width == 1 ? 26 : width == 2 ? 18 : 10;
+  if(self.displayList.instruction.bit(4)) cycle += (u8)self.io.hscroll >> 1;
+  return cycle;
+}
+
+auto ANTIC::Playfield::dmaStop() const -> u8 {
+  auto mode = (u8)self.displayList.instruction & 15;
+  auto width = fetchWidth();
+  if(mode < 2 || !width) return 0xff;
+
+  auto cycle = width == 1 ? 90 : width == 2 ? 98 : 106;
+  if(self.displayList.instruction.bit(4)) cycle += (u8)self.io.hscroll >> 1;
+  return cycle;
+}
+
+auto ANTIC::Playfield::clearDMARing() -> void {
+  dmaClock = 0;
+  for(auto& name : dmaName) name = 0;
+}
+
+auto ANTIC::Playfield::clockDMARing() -> void {
+  auto start = dmaStart();
+  auto stop = dmaStop();
+
+  if(self.counter.machineCycle == start) {
+    dmaClock.bit(0) = 1;
+    lineWrite = 0;
+    lineRead = 0;
+  }
+  if(self.counter.machineCycle == stop) {
+    dmaClock.bit(0) = 0;
+    dmaName[0] = 0;
+  }
+}
+
+auto ANTIC::Playfield::scheduleGraphics(n8 data, n8 name, u8 delay) -> void {
+  auto slot = ((u8)queuePosition + delay) & 15;
+  queueData[slot] |= data;
+  queueName[slot] = name;
+  queueValid.bit(slot) = 1;
+}
+
+auto ANTIC::Playfield::scheduleLineGraphics(n6 phase, u8 delay) -> void {
+  auto slot = ((u8)queuePosition + delay) & 15;
+  queueLine.bit(slot) = 1;
+  queuePhase[slot] = phase;
+  queueName[slot] = 0;
+  queueValid.bit(slot) = 1;
+}
+
+auto ANTIC::Playfield::clockShiftRing() -> void {
+  auto slot = (u8)queuePosition;
+  if(self.counter.machineCycle < 8) {
+    shiftClock = 0;
+    graphics = 0;
+    output = 0;
+    delayed = 0;
+    queueValid = 0;
+    queueLine = 0;
+    for(auto& data : queueData) data = 0;
+  } else if(queueValid.bit(slot)) {
+    if(queueLine.bit(slot)) {
+      queueData[slot] |= lineBufferRead(queuePhase[slot]);
+    }
+    graphics |= queueData[slot];
+    name = queueName[slot];
+    shiftClock.bit(0) = 1;
+    queueValid.bit(slot) = 0;
+    queueLine.bit(slot) = 0;
+    queueData[slot] = 0;
+  }
+
+  auto mode = (u8)self.displayList.instruction & 15;
+  u8 shiftMask = 0x0f;
+  u8 shiftBits = 1;
+  switch(mode) {
+  case 2: case 3: case 4: case 5:
+    shiftBits = 2;
+    break;
+  case 8:
+    shiftMask = 0x01;
+    shiftBits = 2;
+    break;
+  case 9:
+    shiftMask = 0x05;
+    break;
+  case 10:
+    shiftMask = 0x05;
+    shiftBits = 2;
+    break;
+  case 13: case 14: case 15:
+    shiftBits = 2;
+    break;
+  }
+
+  if((u8)shiftClock & shiftMask) {
+    if(shiftBits == 2) {
+      output = (u8)graphics >> 6;
+      graphics <<= 2;
+    } else {
+      output = (u8)graphics >> 7;
+      graphics <<= 1;
+    }
+  }
+
+  shiftClock = ((u8)shiftClock << 1 | (u8)shiftClock >> 3) & 15;
+  queuePosition = (slot + 1) & 15;
+}
+
+auto ANTIC::Playfield::queueDMA(DMA::Requests& requests) -> void {
+  bool displayRange =
+    self.counter.scanline >= Timing::DisplayListFirstScanline
+    && self.counter.scanline <= Timing::DisplayListLastScanline;
+  auto mode = (u8)self.displayList.instruction & 15;
+  if(!displayRange || !self.displayList.valid || mode < 2) return;
+
+  clockDMARing();
+  bool enabled = (self.io.dmactl & 3) != 0;
+  auto physical = enabled && self.counter.machineCycle >= 10 && self.counter.machineCycle <= 105;
+  auto& properties = Modes[mode];
+
+  if(properties.character && dmaClock.bit(0)) {
+    auto readPhase = lineRead;
+    auto name = lineBufferRead(readPhase);
+    if(self.displayList.firstScanline) {
+      auto writePhase = lineWrite;
+      requests.append(
+        self.displayList.memoryScan,
+        DMAConsumer::LineBufferName, writePhase, true, physical, false, readPhase
+      );
+      self.displayList.memoryScan = self.displayList.incrementMemoryScan(self.displayList.memoryScan);
+      incrementLineBuffer(lineWrite);
+    } else {
+      dmaName[0] = name;
+    }
+    incrementLineBuffer(lineRead);
+  }
+
+  if(!properties.character && dmaClock.bit(2)) {
+    bool next = dmaClock.bit(1);
+    auto readPhase = bitmapLineBufferPhase(next);
+    if(self.displayList.firstScanline) {
+      auto writePhase = lineWrite;
+      requests.append(
+        self.displayList.memoryScan,
+        DMAConsumer::LineBufferBitmap, writePhase, true, physical, next, readPhase
+      );
+      self.displayList.memoryScan = self.displayList.incrementMemoryScan(self.displayList.memoryScan);
+      incrementLineBuffer(lineWrite);
+    } else {
+      requests.replayLineBuffer(readPhase);
+    }
+  }
+
+  if(properties.character && dmaClock.bit(3)) {
+    auto name = dmaName[3];
+    auto address = characterAddress(name, self.displayList.row);
+    if(address == 0xffff) {
+      scheduleGraphics(0, name, 7);
+    } else {
+      requests.append(
+        address,
+        DMAConsumer::Character, name, true, physical
+      );
+    }
+  }
+
+  auto length = dmaFeedbackLength();
+  bool feedback = dmaClock.bit(length - 1);
+  auto feedbackName = dmaName[length - 1];
+  dmaClock <<= 1;
+  for(s32 index = 7; index >= 1; index--) {
+    dmaName[index] = dmaName[index - 1];
+  }
+  dmaClock.bit(0) = feedback;
+  dmaName[0] = feedback ? feedbackName : n8{0};
+}
+
+auto ANTIC::Playfield::consumeName(n6 writePhase, n6 readPhase, n8 data) -> void {
+  lineBufferWrite(writePhase, data);
+  // The DMA ring has already advanced while the bus cycle was in flight.
+  // Place the returned name in stage 1 so the stage-3 character request
+  // observes it three machine cycles after the stage-0 name request.
+  dmaName[1] = lineBufferRead(readPhase);
+}
+
+auto ANTIC::Playfield::consumeBitmap(n6 writePhase, n6 readPhase, n8 data) -> void {
+  lineBufferWrite(writePhase, data);
+  scheduleLineGraphics(readPhase, 9);
+}
+
+auto ANTIC::Playfield::consumeCharacter(n8 character, n8 data) -> void {
+  scheduleGraphics(data, character, 7);
+}

--- a/ares/a52/antic/serialization.cpp
+++ b/ares/a52/antic/serialization.cpp
@@ -1,0 +1,80 @@
+auto ANTIC::serialize(serializer& s) -> void {
+  Thread::serialize(s);
+
+  s(io.dmactl);
+  s(io.chactl);
+  s(io.dlist);
+  s(io.hscroll);
+  s(io.vscroll);
+  s(io.pmbase);
+  s(io.chbase);
+  s(io.penh);
+  s(io.penv);
+  s(io.nmien);
+  s(io.nmist);
+  for(auto& chbase : io.chbasePipeline) s(chbase);
+  for(auto& dma : io.playerMissileDMA) s(dma);
+
+  s(counter.machineCycle);
+  s(counter.scanline);
+
+  displayList.serialize(s);
+  dma.serialize(s);
+  playfield.serialize(s);
+  wsync.serialize(s);
+  interrupt.serialize(s);
+}
+
+auto ANTIC::DisplayList::serialize(serializer& s) -> void {
+  s(instruction);
+  s(memoryScan);
+  s(row);
+  s(lastRow);
+  s(valid);
+  s(needInstruction);
+  s(waitingForVerticalBlank);
+  s(loadMemoryScan);
+  s(verticalScroll);
+  s(verticalScrollEnding);
+  s(firstScanline);
+  s(dmaEnabled);
+  s(operand);
+  s(lineAddress);
+  s(vscrollStart);
+  s(vscrollDLI);
+  s(vscrollEnd);
+}
+
+auto ANTIC::DMA::serialize(serializer& s) -> void {
+  s(refreshPending);
+}
+
+auto ANTIC::Playfield::serialize(serializer& s) -> void {
+  s(dmaClock);
+  for(auto& name : dmaName) s(name);
+  s(lineWrite);
+  s(lineRead);
+  for(auto& data : lineBuffer) s(data);
+  s(shiftClock);
+  s(graphics);
+  s(name);
+  s(output);
+  s(delayed);
+  s(queuePosition);
+  s(queueValid);
+  s(queueLine);
+  for(auto& data : queueData) s(data);
+  for(auto& name : queueName) s(name);
+  for(auto& phase : queuePhase) s(phase);
+}
+
+auto ANTIC::WSYNC::serialize(serializer& s) -> void {
+  s(active);
+  s(scanline);
+}
+
+auto ANTIC::Interrupt::serialize(serializer& s) -> void {
+  s(pending);
+  s(enable);
+  s(pulse);
+}

--- a/ares/a52/antic/timing.cpp
+++ b/ares/a52/antic/timing.cpp
@@ -1,0 +1,63 @@
+auto ANTIC::scanline() -> void {
+  dma.beginScanline();
+  if(counter.scanline == 248) interrupt.schedule(0x40);
+  displayList.beginScanline();
+
+  for(counter.machineCycle = 0; counter.machineCycle < Timing::MachineCyclesPerScanline; counter.machineCycle++) {
+    clock();
+  }
+
+  finishScanline();
+}
+
+auto ANTIC::clock() -> void {
+  displayList.clock();
+  interrupt.clock();
+  wsync.clock();
+
+  DMA::Requests requests = {};
+  dma.queuePlayerMissile(requests);
+  displayList.queueDMA(requests);
+  playfield.queueDMA(requests);
+
+  dma.clockRefresh();
+  dma.arbitrate(requests);
+  clockRegisterPipelines();
+}
+
+auto ANTIC::step(u32 colorClocks) -> void {
+  auto firstColorClock = (u16)counter.machineCycle * Timing::ColorClocksPerMachineCycle;
+  for(u32 phase = 0; phase < colorClocks; phase++) {
+    gtia.clock(playfield.clockAN(firstColorClock + phase));
+  }
+  Thread::step(colorClocks);
+  Thread::synchronize(cpu);
+}
+
+auto ANTIC::clockRegisterPipelines() -> void {
+  // AHRM 4.2 and 4.13: CHBASE and P/M DMA enable reach their consumers two
+  // machine cycles after the CPU write.
+  io.chbasePipeline[1] = io.chbasePipeline[0];
+  io.chbasePipeline[0] = io.chbase;
+  io.playerMissileDMA[1] = io.playerMissileDMA[0];
+  io.playerMissileDMA[0] = (u8)io.dmactl >> 2 & 3;
+
+  // AHRM 4.6: cycle 1 uses the display-list DMA state sampled on cycle 113.
+  if(counter.machineCycle == 113) {
+    displayList.dmaEnabled = io.dmactl.bit(5);
+  }
+}
+
+auto ANTIC::finishScanline() -> void {
+  displayList.finishScanline();
+  if(++counter.scanline == Timing::ScanlinesPerFrame) {
+    counter.scanline = 0;
+    frame();
+  }
+  counter.machineCycle = 0;
+}
+
+auto ANTIC::frame() -> void {
+  gtia.frame();
+  scheduler.exit(Event::Frame);
+}

--- a/ares/a52/cartridge/board/board.cpp
+++ b/ares/a52/cartridge/board/board.cpp
@@ -1,0 +1,5 @@
+namespace Board {
+
+#include "linear.cpp"
+
+}

--- a/ares/a52/cartridge/board/board.cpp
+++ b/ares/a52/cartridge/board/board.cpp
@@ -1,5 +1,32 @@
 namespace Board {
 
+struct ProgramROM {
+  auto load(VFS::Pak pak, u32 size) -> bool {
+    memory.reset();
+    auto fp = pak->read("program.rom");
+    if(!fp || fp->size() != size) return false;
+    memory.allocate(size);
+    memory.load(fp);
+    return true;
+  }
+
+  auto reset() -> void {
+    memory.reset();
+  }
+
+  auto read(u32 address) const -> n8 {
+    return memory.read(address);
+  }
+
+  explicit operator bool() const {
+    return (bool)memory;
+  }
+
+private:
+  Memory::Readable<n8> memory;
+};
+
 #include "linear.cpp"
+#include "dual-window.cpp"
 
 }

--- a/ares/a52/cartridge/board/board.hpp
+++ b/ares/a52/cartridge/board/board.hpp
@@ -12,6 +12,8 @@ struct Interface {
   virtual auto read(n16 address, n8 data) -> n8 { return data; }
   virtual auto peek(n16 address, n8 data) const -> n8 { return data; }
   virtual auto write(n16 address, n8 data) -> bool { return false; }
+  virtual auto serialize(serializer&) -> void {}
+
   Cartridge& cartridge;
 };
 

--- a/ares/a52/cartridge/board/board.hpp
+++ b/ares/a52/cartridge/board/board.hpp
@@ -1,0 +1,19 @@
+namespace Board {
+
+struct Interface {
+  VFS::Pak pak;
+
+  Interface(Cartridge& cartridge) : cartridge(cartridge) {}
+  virtual ~Interface() = default;
+
+  virtual auto load() -> bool { return false; }
+  virtual auto unload() -> void {}
+  virtual auto power() -> void {}
+  virtual auto read(n16 address, n8 data) -> n8 { return data; }
+  virtual auto peek(n16 address, n8 data) const -> n8 { return data; }
+  virtual auto write(n16 address, n8 data) -> bool { return false; }
+
+  Cartridge& cartridge;
+};
+
+}

--- a/ares/a52/cartridge/board/board.hpp
+++ b/ares/a52/cartridge/board/board.hpp
@@ -12,7 +12,6 @@ struct Interface {
   virtual auto read(n16 address, n8 data) -> n8 { return data; }
   virtual auto peek(n16 address, n8 data) const -> n8 { return data; }
   virtual auto write(n16 address, n8 data) -> bool { return false; }
-
   Cartridge& cartridge;
 };
 

--- a/ares/a52/cartridge/board/dual-window.cpp
+++ b/ares/a52/cartridge/board/dual-window.cpp
@@ -31,6 +31,11 @@ struct DualWindow40K : Interface {
     return select(address);
   }
 
+  auto serialize(serializer& s) -> void override {
+    s(bank0);
+    s(bank1);
+  }
+
 private:
   auto select(n16 address) -> bool {
     if(address >= 0x0ff6 && address <= 0x0ff9) {

--- a/ares/a52/cartridge/board/dual-window.cpp
+++ b/ares/a52/cartridge/board/dual-window.cpp
@@ -1,0 +1,50 @@
+struct DualWindow40K : Interface {
+  using Interface::Interface;
+
+  auto load() -> bool override {
+    return rom.load(pak, 40_KiB);
+  }
+
+  auto unload() -> void override {
+    rom.reset();
+  }
+
+  auto power() -> void override {
+    bank0 = 0;
+    bank1 = 0;
+  }
+
+  auto read(n16 address, n8 data) -> n8 override {
+    select(address);
+    return peek(address, data);
+  }
+
+  auto peek(n16 address, n8 data) const -> n8 override {
+    if(!rom) return data;
+    if(address <= 0x0fff) return rom.read(bank0 * 0x1000 | (address & 0x0fff));
+    if(address <= 0x1fff) return rom.read((4 + bank1) * 0x1000 | (address & 0x0fff));
+    if(address < 0x4000) return data;
+    return rom.read(0x8000 | (address & 0x1fff));
+  }
+
+  auto write(n16 address, n8 data) -> bool override {
+    return select(address);
+  }
+
+private:
+  auto select(n16 address) -> bool {
+    if(address >= 0x0ff6 && address <= 0x0ff9) {
+      bank0 = address - 0x0ff6;
+      return true;
+    }
+    if(address >= 0x1ff6 && address <= 0x1ff9) {
+      bank1 = address - 0x1ff6;
+      return true;
+    }
+    return false;
+  }
+
+  ProgramROM rom;
+  n2 bank0;
+  n2 bank1;
+};

--- a/ares/a52/cartridge/board/linear.cpp
+++ b/ares/a52/cartridge/board/linear.cpp
@@ -1,0 +1,27 @@
+struct Linear32K : Interface {
+  using Interface::Interface;
+
+  auto load() -> bool override {
+    auto fp = pak->read("program.rom");
+    if(!fp || fp->size() != 32_KiB) return false;
+    rom.allocate(32_KiB);
+    rom.load(fp);
+    return true;
+  }
+
+  auto unload() -> void override {
+    rom.reset();
+  }
+
+  auto read(n16 address, n8 data) -> n8 override {
+    return peek(address, data);
+  }
+
+  auto peek(n16 address, n8 data) const -> n8 override {
+    if(!rom) return data;
+    return rom.read(address & 0x7fff);
+  }
+
+private:
+  Memory::Readable<n8> rom;
+};

--- a/ares/a52/cartridge/board/linear.cpp
+++ b/ares/a52/cartridge/board/linear.cpp
@@ -1,12 +1,15 @@
-struct Linear32K : Interface {
-  using Interface::Interface;
+struct Linear : Interface {
+  enum class Wiring {
+    Upper,
+    Split,
+    Full,
+    Overlapping,
+  };
+
+  Linear(Cartridge& cartridge, u32 size, Wiring wiring) : Interface(cartridge), size(size), wiring(wiring) {}
 
   auto load() -> bool override {
-    auto fp = pak->read("program.rom");
-    if(!fp || fp->size() != 32_KiB) return false;
-    rom.allocate(32_KiB);
-    rom.load(fp);
-    return true;
+    return rom.load(pak, size);
   }
 
   auto unload() -> void override {
@@ -19,9 +22,28 @@ struct Linear32K : Interface {
 
   auto peek(n16 address, n8 data) const -> n8 override {
     if(!rom) return data;
-    return rom.read(address & 0x7fff);
+
+    switch(wiring) {
+    case Wiring::Upper:
+      if(address < 0x4000) return data;
+      return rom.read(address & (size - 1));
+    case Wiring::Split:
+      if(address < 0x4000) return rom.read(address & 0x1fff);
+      return rom.read(0x2000 | (address & 0x1fff));
+    case Wiring::Full:
+      return rom.read(address & (size - 1));
+    case Wiring::Overlapping:
+      //Map 12KiB at $7000-$9fff, then repeat the final 8KiB through $a000-$bfff.
+      if(address < 0x3000) return data;
+      if(address < 0x6000) return rom.read(address - 0x3000);
+      return rom.read(0x2000 | (address & 0x1fff));
+    }
+
+    return data;
   }
 
 private:
-  Memory::Readable<n8> rom;
+  ProgramROM rom;
+  u32 size;
+  Wiring wiring;
 };

--- a/ares/a52/cartridge/cartridge.cpp
+++ b/ares/a52/cartridge/cartridge.cpp
@@ -11,13 +11,21 @@ auto Cartridge::allocate(Node::Port parent) -> Node::Peripheral {
 }
 
 auto Cartridge::connect() -> void {
+  board.reset();
   if(!node->setPak(pak = platform->pak(node))) return;
 
   information = {};
   information.title = pak->attribute("title");
   information.board = pak->attribute("board");
 
-  if(information.board == "Linear32K") board = std::make_unique<Board::Linear32K>(*this);
+  using Wiring = Board::Linear::Wiring;
+  if(information.board == "Linear4K"      ) board = std::make_unique<Board::Linear>(*this,  4_KiB, Wiring::Upper);
+  if(information.board == "Linear8K"      ) board = std::make_unique<Board::Linear>(*this,  8_KiB, Wiring::Upper);
+  if(information.board == "OneChip16K"    ) board = std::make_unique<Board::Linear>(*this, 16_KiB, Wiring::Full);
+  if(information.board == "TwoChip16K"    ) board = std::make_unique<Board::Linear>(*this, 16_KiB, Wiring::Split);
+  if(information.board == "Overlapping16K") board = std::make_unique<Board::Linear>(*this, 16_KiB, Wiring::Overlapping);
+  if(information.board == "Linear32K"     ) board = std::make_unique<Board::Linear>(*this, 32_KiB, Wiring::Full);
+  if(information.board == "DualWindow40K" ) board = std::make_unique<Board::DualWindow40K>(*this);
   if(!board) return;
 
   board->pak = pak;

--- a/ares/a52/cartridge/cartridge.cpp
+++ b/ares/a52/cartridge/cartridge.cpp
@@ -5,6 +5,7 @@ namespace ares::Atari5200 {
 Cartridge& cartridge = cartridgeSlot.cartridge;
 #include "board/board.cpp"
 #include "slot.cpp"
+#include "serialization.cpp"
 
 auto Cartridge::allocate(Node::Port parent) -> Node::Peripheral {
   return node = parent->append<Node::Peripheral>("Atari 5200 Cartridge");

--- a/ares/a52/cartridge/cartridge.cpp
+++ b/ares/a52/cartridge/cartridge.cpp
@@ -1,0 +1,59 @@
+#include <a52/a52.hpp>
+
+namespace ares::Atari5200 {
+
+Cartridge& cartridge = cartridgeSlot.cartridge;
+#include "board/board.cpp"
+#include "slot.cpp"
+
+auto Cartridge::allocate(Node::Port parent) -> Node::Peripheral {
+  return node = parent->append<Node::Peripheral>("Atari 5200 Cartridge");
+}
+
+auto Cartridge::connect() -> void {
+  if(!node->setPak(pak = platform->pak(node))) return;
+
+  information = {};
+  information.title = pak->attribute("title");
+  information.board = pak->attribute("board");
+
+  if(information.board == "Linear32K") board = std::make_unique<Board::Linear32K>(*this);
+  if(!board) return;
+
+  board->pak = pak;
+  if(!board->load()) {
+    board.reset();
+    return;
+  }
+}
+
+auto Cartridge::disconnect() -> void {
+  if(board) board->unload();
+  board.reset();
+  pak.reset();
+  node.reset();
+}
+
+auto Cartridge::save() -> void {
+}
+
+auto Cartridge::power() -> void {
+  if(board) board->power();
+}
+
+auto Cartridge::read(n16 address, n8 data) -> n8 {
+  if(!board) return data;
+  return board->read(address, data);
+}
+
+auto Cartridge::peek(n16 address, n8 data) const -> n8 {
+  if(!board) return data;
+  return board->peek(address, data);
+}
+
+auto Cartridge::write(n16 address, n8 data) -> bool {
+  if(!board) return false;
+  return board->write(address, data);
+}
+
+}

--- a/ares/a52/cartridge/cartridge.hpp
+++ b/ares/a52/cartridge/cartridge.hpp
@@ -7,6 +7,7 @@ struct Cartridge {
 
   auto title() const -> string { return information.title; }
 
+  //cartridge.cpp
   auto allocate(Node::Port parent) -> Node::Peripheral;
   auto connect() -> void;
   auto disconnect() -> void;

--- a/ares/a52/cartridge/cartridge.hpp
+++ b/ares/a52/cartridge/cartridge.hpp
@@ -19,6 +19,9 @@ struct Cartridge {
   auto peek(n16 address, n8 data) const -> n8;
   auto write(n16 address, n8 data) -> bool;
 
+  //serialization.cpp
+  auto serialize(serializer&) -> void;
+
   std::unique_ptr<Board::Interface> board;
 
 private:

--- a/ares/a52/cartridge/cartridge.hpp
+++ b/ares/a52/cartridge/cartridge.hpp
@@ -1,0 +1,31 @@
+struct Cartridge;
+#include "board/board.hpp"
+
+struct Cartridge {
+  Node::Peripheral node;
+  VFS::Pak pak;
+
+  auto title() const -> string { return information.title; }
+
+  auto allocate(Node::Port parent) -> Node::Peripheral;
+  auto connect() -> void;
+  auto disconnect() -> void;
+
+  auto save() -> void;
+  auto power() -> void;
+
+  auto read(n16 address, n8 data) -> n8;
+  auto peek(n16 address, n8 data) const -> n8;
+  auto write(n16 address, n8 data) -> bool;
+
+  std::unique_ptr<Board::Interface> board;
+
+private:
+  struct Information {
+    string title;
+    string board;
+  } information;
+};
+
+#include "slot.hpp"
+extern Cartridge& cartridge;

--- a/ares/a52/cartridge/serialization.cpp
+++ b/ares/a52/cartridge/serialization.cpp
@@ -1,0 +1,3 @@
+auto Cartridge::serialize(serializer& s) -> void {
+  if(board) s(*board);
+}

--- a/ares/a52/cartridge/slot.cpp
+++ b/ares/a52/cartridge/slot.cpp
@@ -1,0 +1,15 @@
+CartridgeSlot cartridgeSlot;
+
+auto CartridgeSlot::load(Node::Object parent) -> void {
+  port = parent->append<Node::Port>("Cartridge Slot");
+  port->setFamily(system.name());
+  port->setType("Cartridge");
+  port->setAllocate([&](auto name) { return cartridge.allocate(port); });
+  port->setConnect([&] { return cartridge.connect(); });
+  port->setDisconnect([&] { return cartridge.disconnect(); });
+}
+
+auto CartridgeSlot::unload() -> void {
+  cartridge.disconnect();
+  port = {};
+}

--- a/ares/a52/cartridge/slot.hpp
+++ b/ares/a52/cartridge/slot.hpp
@@ -2,6 +2,7 @@ struct CartridgeSlot {
   Node::Port port;
   Cartridge cartridge;
 
+  //slot.cpp
   auto load(Node::Object parent) -> void;
   auto unload() -> void;
 };

--- a/ares/a52/cartridge/slot.hpp
+++ b/ares/a52/cartridge/slot.hpp
@@ -1,0 +1,9 @@
+struct CartridgeSlot {
+  Node::Port port;
+  Cartridge cartridge;
+
+  auto load(Node::Object parent) -> void;
+  auto unload() -> void;
+};
+
+extern CartridgeSlot cartridgeSlot;

--- a/ares/a52/controller/controller.cpp
+++ b/ares/a52/controller/controller.cpp
@@ -1,0 +1,70 @@
+#include <a52/a52.hpp>
+
+namespace ares::Atari5200 {
+
+Controller::Controller(Node::Port parent, string name) {
+  node = parent->append<Node::Peripheral>(name);
+}
+
+auto Controller::appendControls() -> void {
+  top    = node->append<Node::Input::Button>("Top Fire");
+  bottom = node->append<Node::Input::Button>("Bottom Fire");
+  one    = node->append<Node::Input::Button>("1");
+  two    = node->append<Node::Input::Button>("2");
+  three  = node->append<Node::Input::Button>("3");
+  four   = node->append<Node::Input::Button>("4");
+  five   = node->append<Node::Input::Button>("5");
+  six    = node->append<Node::Input::Button>("6");
+  seven  = node->append<Node::Input::Button>("7");
+  eight  = node->append<Node::Input::Button>("8");
+  nine   = node->append<Node::Input::Button>("9");
+  star   = node->append<Node::Input::Button>("*");
+  zero   = node->append<Node::Input::Button>("0");
+  pound  = node->append<Node::Input::Button>("#");
+  start  = node->append<Node::Input::Button>("Start");
+  pause  = node->append<Node::Input::Button>("Pause");
+  reset  = node->append<Node::Input::Button>("Reset");
+}
+
+auto Controller::poll() -> void {
+  bottomFireLevel = pressed(bottom);
+}
+
+auto Controller::pressed(Node::Input::Button input) -> bool {
+  if(platform) platform->input(input);
+  return input->value();
+}
+
+auto Controller::keypad(n4 code) -> bool {
+  switch(code) {
+  case 0x0f: return pressed(one);
+  case 0x0e: return pressed(two);
+  case 0x0d: return pressed(three);
+  case 0x0c: return pressed(start);
+  case 0x0b: return pressed(four);
+  case 0x0a: return pressed(five);
+  case 0x09: return pressed(six);
+  case 0x08: return pressed(pause);
+  case 0x07: return pressed(seven);
+  case 0x06: return pressed(eight);
+  case 0x05: return pressed(nine);
+  case 0x04: return pressed(reset);
+  case 0x03: return pressed(star);
+  case 0x02: return pressed(zero);
+  case 0x01: return pressed(pound);
+  }
+  return false;
+}
+
+auto Controller::topFire() -> bool {
+  return pressed(top);
+}
+
+auto Controller::bottomFire() -> bool {
+  return bottomFireLevel;
+}
+
+#include "port.cpp"
+#include "standard/standard.cpp"
+
+}

--- a/ares/a52/controller/controller.cpp
+++ b/ares/a52/controller/controller.cpp
@@ -66,5 +66,6 @@ auto Controller::bottomFire() -> bool {
 
 #include "port.cpp"
 #include "standard/standard.cpp"
+#include "trak-ball/trak-ball.cpp"
 
 }

--- a/ares/a52/controller/controller.hpp
+++ b/ares/a52/controller/controller.hpp
@@ -38,3 +38,4 @@ private:
 
 #include "port.hpp"
 #include "standard/standard.hpp"
+#include "trak-ball/trak-ball.hpp"

--- a/ares/a52/controller/controller.hpp
+++ b/ares/a52/controller/controller.hpp
@@ -1,0 +1,40 @@
+struct Controller {
+  Node::Peripheral node;
+  Node::Input::Button top;
+  Node::Input::Button bottom;
+  Node::Input::Button one;
+  Node::Input::Button two;
+  Node::Input::Button three;
+  Node::Input::Button four;
+  Node::Input::Button five;
+  Node::Input::Button six;
+  Node::Input::Button seven;
+  Node::Input::Button eight;
+  Node::Input::Button nine;
+  Node::Input::Button star;
+  Node::Input::Button zero;
+  Node::Input::Button pound;
+  Node::Input::Button start;
+  Node::Input::Button pause;
+  Node::Input::Button reset;
+
+  Controller(Node::Port parent, string name);
+  virtual ~Controller() = default;
+
+  virtual auto poll() -> void;
+  virtual auto axis(u32 index, bool powered) -> s16 { return 0; }
+  virtual auto keypad(n4 code) -> bool;
+  virtual auto topFire() -> bool;
+  virtual auto bottomFire() -> bool;
+
+protected:
+  auto appendControls() -> void;
+
+private:
+  auto pressed(Node::Input::Button input) -> bool;
+
+  bool bottomFireLevel = false;
+};
+
+#include "port.hpp"
+#include "standard/standard.hpp"

--- a/ares/a52/controller/port.cpp
+++ b/ares/a52/controller/port.cpp
@@ -15,7 +15,7 @@ auto ControllerPort::load(Node::Object parent) -> void {
   port->setHotSwappable(true);
   port->setAllocate([&](auto name) { return allocate(name); });
   port->setDisconnect([&] { device.reset(); });
-  port->setSupported({"Controller"});
+  port->setSupported({"Controller", "Trak-Ball"});
 }
 
 auto ControllerPort::unload() -> void {
@@ -25,6 +25,7 @@ auto ControllerPort::unload() -> void {
 
 auto ControllerPort::allocate(string name) -> Node::Peripheral {
   if(name == "Controller") device = std::make_unique<StandardController>(port);
+  if(name == "Trak-Ball") device = std::make_unique<TrakBall>(port);
   if(device) return device->node;
   return {};
 }

--- a/ares/a52/controller/port.cpp
+++ b/ares/a52/controller/port.cpp
@@ -1,0 +1,58 @@
+ControllerPort controllerPorts[4] = {
+  {"Controller Port 1"},
+  {"Controller Port 2"},
+  {"Controller Port 3"},
+  {"Controller Port 4"},
+};
+
+ControllerPort::ControllerPort(string name) : name(name) {
+}
+
+auto ControllerPort::load(Node::Object parent) -> void {
+  port = parent->append<Node::Port>(name);
+  port->setFamily(system.name());
+  port->setType("Controller");
+  port->setHotSwappable(true);
+  port->setAllocate([&](auto name) { return allocate(name); });
+  port->setDisconnect([&] { device.reset(); });
+  port->setSupported({"Controller"});
+}
+
+auto ControllerPort::unload() -> void {
+  device = {};
+  port = {};
+}
+
+auto ControllerPort::allocate(string name) -> Node::Peripheral {
+  if(name == "Controller") device = std::make_unique<StandardController>(port);
+  if(device) return device->node;
+  return {};
+}
+
+auto ControllerPort::connected() const -> bool {
+  return (bool)device;
+}
+
+auto ControllerPort::poll() -> void {
+  if(device) device->poll();
+}
+
+auto ControllerPort::axis(u32 index, bool powered) -> s16 {
+  if(device) return device->axis(index, powered);
+  return 0;
+}
+
+auto ControllerPort::keypad(n4 code) -> bool {
+  if(device) return device->keypad(code);
+  return false;
+}
+
+auto ControllerPort::topFire() -> bool {
+  if(device) return device->topFire();
+  return false;
+}
+
+auto ControllerPort::bottomFire() -> bool {
+  if(device) return device->bottomFire();
+  return false;
+}

--- a/ares/a52/controller/port.hpp
+++ b/ares/a52/controller/port.hpp
@@ -1,0 +1,22 @@
+struct ControllerPort {
+  Node::Port port;
+  std::unique_ptr<Controller> device;
+
+  //port.cpp
+  ControllerPort(string name);
+
+  auto load(Node::Object parent) -> void;
+  auto unload() -> void;
+  auto allocate(string name) -> Node::Peripheral;
+
+  auto connected() const -> bool;
+  auto poll() -> void;
+  auto axis(u32 index, bool powered) -> s16;
+  auto keypad(n4 code) -> bool;
+  auto topFire() -> bool;
+  auto bottomFire() -> bool;
+
+  const string name;
+};
+
+extern ControllerPort controllerPorts[4];

--- a/ares/a52/controller/standard/standard.cpp
+++ b/ares/a52/controller/standard/standard.cpp
@@ -1,0 +1,12 @@
+StandardController::StandardController(Node::Port parent) : Controller(parent, "Controller") {
+  x = node->append<Node::Input::Axis>("X-Axis");
+  y = node->append<Node::Input::Axis>("Y-Axis");
+  appendControls();
+}
+
+auto StandardController::axis(u32 index, bool powered) -> s16 {
+  if(!powered) return 32767;
+  auto input = index == 0 ? x : y;
+  if(platform) platform->input(input);
+  return input->value();
+}

--- a/ares/a52/controller/standard/standard.hpp
+++ b/ares/a52/controller/standard/standard.hpp
@@ -1,0 +1,9 @@
+struct StandardController : Controller {
+  Node::Input::Axis x;
+  Node::Input::Axis y;
+
+  //standard.cpp
+  StandardController(Node::Port parent);
+
+  auto axis(u32 index, bool powered) -> s16 override;
+};

--- a/ares/a52/controller/trak-ball/trak-ball.cpp
+++ b/ares/a52/controller/trak-ball/trak-ball.cpp
@@ -1,0 +1,29 @@
+TrakBall::TrakBall(Node::Port parent) : Controller(parent, "Trak-Ball") {
+  x = node->append<Node::Input::Axis>("X-Axis");
+  y = node->append<Node::Input::Axis>("Y-Axis");
+  appendControls();
+}
+
+auto TrakBall::poll() -> void {
+  if(platform) {
+    platform->input(x);
+    platform->input(y);
+  }
+  velocityX = velocity(x->value());
+  velocityY = velocity(y->value());
+  Controller::poll();
+}
+
+auto TrakBall::velocity(s16 motion) -> s16 {
+  // The service manual specifies a 900:600 maximum slope-change ratio for
+  // left/up versus right/down, but not a CPU-visible count per optical pulse.
+  // MotionScale is therefore an explicit host-to-controller approximation.
+  s32 result = (s32)motion * MotionScale;
+  if(result < 0) result = result * 3 / 2;
+  return sclamp<16>(result);
+}
+
+auto TrakBall::axis(u32 index, bool powered) -> s16 {
+  if(!powered) return 0;
+  return index == 0 ? velocityX : velocityY;
+}

--- a/ares/a52/controller/trak-ball/trak-ball.hpp
+++ b/ares/a52/controller/trak-ball/trak-ball.hpp
@@ -1,0 +1,18 @@
+struct TrakBall : Controller {
+  Node::Input::Axis x;
+  Node::Input::Axis y;
+
+  //trak-ball.cpp
+  TrakBall(Node::Port parent);
+
+  auto poll() -> void override;
+  auto axis(u32 index, bool powered) -> s16 override;
+
+private:
+  //trak-ball.cpp
+  auto velocity(s16 motion) -> s16;
+
+  static constexpr s32 MotionScale = 1024;
+  s16 velocityX = 0;
+  s16 velocityY = 0;
+};

--- a/ares/a52/cpu/cpu.cpp
+++ b/ares/a52/cpu/cpu.cpp
@@ -6,6 +6,7 @@ CPU cpu;
 #include "memory.cpp"
 #include "timing.cpp"
 #include "debugger.cpp"
+#include "serialization.cpp"
 
 auto CPU::load(Node::Object parent) -> void {
   node = parent->append<Node::Object>("CPU");

--- a/ares/a52/cpu/cpu.cpp
+++ b/ares/a52/cpu/cpu.cpp
@@ -1,0 +1,56 @@
+#include <a52/a52.hpp>
+
+namespace ares::Atari5200 {
+
+CPU cpu;
+#include "memory.cpp"
+#include "timing.cpp"
+#include "debugger.cpp"
+
+auto CPU::load(Node::Object parent) -> void {
+  node = parent->append<Node::Object>("CPU");
+  debugger.load(node);
+}
+
+auto CPU::unload() -> void {
+  Thread::destroy();
+  debugger = {};
+  node = {};
+}
+
+auto CPU::main() -> void {
+  if(io.interruptPending) {
+    if(io.resetPending) {
+      debugger.interrupt("Reset");
+      reset();
+      io.resetPending = 0;
+    } else if(io.nmiPending) {
+      debugger.interrupt("NMI");
+      interrupt();
+    } else {
+      debugger.interrupt("IRQ");
+      interrupt();
+    }
+  }
+
+  debugger.instruction();
+  instruction();
+}
+
+auto CPU::step(u32 clocks) -> void {
+  Thread::step(clocks);
+  Thread::synchronize();
+}
+
+auto CPU::power(bool reset) -> void {
+  MOS6502::BCD = 1;
+  if(!reset) MOS6502::power();
+  Thread::create(system.frequency() / Timing::ColorClocksPerMachineCycle, std::bind_front(&CPU::main, this));
+
+  io = {};
+  io.rdyLine = 1;
+  io.resetPending = 1;
+  io.interruptPending = 1;
+}
+
+}

--- a/ares/a52/cpu/cpu.hpp
+++ b/ares/a52/cpu/cpu.hpp
@@ -1,0 +1,61 @@
+struct CPU : MOS6502, Thread {
+  Node::Object node;
+
+  struct Debugger {
+    //debugger.cpp
+    auto load(Node::Object parent) -> void;
+    auto instruction() -> void;
+    auto interrupt(string_view type) -> void;
+
+    struct Memory {
+      Node::Debugger::Memory bus;
+      Node::Debugger::Memory ram;
+    } memory;
+
+    struct Tracer {
+      Node::Debugger::Tracer::Instruction instruction;
+      Node::Debugger::Tracer::Notification interrupt;
+    } tracer;
+  } debugger;
+
+  //cpu.cpp
+  auto load(Node::Object parent) -> void;
+  auto unload() -> void;
+  auto main() -> void;
+  auto step(u32 clocks) -> void;
+  auto power(bool reset) -> void;
+
+  //memory.cpp
+  auto readBus(n16 address) -> n8;
+  auto writeBus(n16 address, n8 data) -> void;
+  auto readDebugger(n16 address) -> n8 override;
+
+  //timing.cpp
+  auto read(n16 address) -> n8 override;
+  auto write(n16 address, n8 data) -> void override;
+  auto lastCycle() -> void override;
+  auto cancelNmi() -> void override;
+  auto delayIrq() -> void override;
+  auto irqPending() -> bool override;
+  auto nmi(n16& vector) -> void override;
+
+  auto nmiLine(bool line) -> void;
+  auto irqLine(bool line) -> void;
+  auto rdyLine(bool line) -> void;
+
+private:
+  //memory.cpp
+  auto peekBus(n16 address) const -> n8;
+
+  struct IO {
+    n1 interruptPending;
+    n1 resetPending;
+    n1 nmiPending;
+    n1 nmiLine;
+    n1 irqLine;
+    n1 rdyLine = 1;
+    n8 openBus;
+  } io;
+};
+
+extern CPU cpu;

--- a/ares/a52/cpu/cpu.hpp
+++ b/ares/a52/cpu/cpu.hpp
@@ -18,6 +18,8 @@ struct CPU : MOS6502, Thread {
     } tracer;
   } debugger;
 
+  auto dataBus() const -> n8 { return io.openBus; }
+
   //cpu.cpp
   auto load(Node::Object parent) -> void;
   auto unload() -> void;
@@ -32,6 +34,7 @@ struct CPU : MOS6502, Thread {
 
   //timing.cpp
   auto read(n16 address) -> n8 override;
+  auto readDMA(n16 address) -> n8;
   auto write(n16 address, n8 data) -> void override;
   auto lastCycle() -> void override;
   auto cancelNmi() -> void override;

--- a/ares/a52/cpu/cpu.hpp
+++ b/ares/a52/cpu/cpu.hpp
@@ -46,6 +46,9 @@ struct CPU : MOS6502, Thread {
   auto irqLine(bool line) -> void;
   auto rdyLine(bool line) -> void;
 
+  //serialization.cpp
+  auto serialize(serializer&) -> void;
+
 private:
   //memory.cpp
   auto peekBus(n16 address) const -> n8;

--- a/ares/a52/cpu/debugger.cpp
+++ b/ares/a52/cpu/debugger.cpp
@@ -1,0 +1,30 @@
+auto CPU::Debugger::load(Node::Object parent) -> void {
+  memory.bus = parent->append<Node::Debugger::Memory>("CPU Bus");
+  memory.bus->setSize(64_KiB);
+  memory.bus->setRead([&](u32 address) -> u8 {
+    return cpu.readDebugger(address);
+  });
+
+  memory.ram = parent->append<Node::Debugger::Memory>("CPU RAM");
+  memory.ram->setSize(system.ram.size());
+  memory.ram->setRead([&](u32 address) -> u8 {
+    return system.ram.read(address);
+  });
+  memory.ram->setWrite([&](u32 address, u8 data) -> void {
+    system.ram.write(address, data);
+  });
+
+  tracer.instruction = parent->append<Node::Debugger::Tracer::Instruction>("Instruction", "CPU");
+  tracer.instruction->setAddressBits(16);
+  tracer.interrupt = parent->append<Node::Debugger::Tracer::Notification>("Interrupt", "CPU");
+}
+
+auto CPU::Debugger::instruction() -> void {
+  if(tracer.instruction->enabled() && tracer.instruction->address(cpu.PC)) {
+    tracer.instruction->notify(cpu.disassembleInstruction(), cpu.disassembleContext());
+  }
+}
+
+auto CPU::Debugger::interrupt(string_view type) -> void {
+  if(tracer.interrupt->enabled()) tracer.interrupt->notify(type);
+}

--- a/ares/a52/cpu/memory.cpp
+++ b/ares/a52/cpu/memory.cpp
@@ -1,0 +1,33 @@
+auto CPU::readBus(n16 address) -> n8 {
+  if(auto result = platform->cheat(address)) return *result;
+
+  if(address <= 0x3fff) return system.ram.read(address);
+  if(address <= 0xbfff) return cartridge.read(address - 0x4000, io.openBus);
+  if(address <= 0xc0ff) return gtia.read(address);
+  if(address >= 0xd400 && address <= 0xd4ff) return antic.read(address);
+  if(address >= 0xe800 && address <= 0xefff) return pokey.read(address);
+  if(address >= 0xf800) return system.bios.read(address - 0xf800);
+  return io.openBus;
+}
+
+auto CPU::peekBus(n16 address) const -> n8 {
+  if(address <= 0x3fff) return system.ram.read(address);
+  if(address <= 0xbfff) return cartridge.peek(address - 0x4000, io.openBus);
+  if(address <= 0xc0ff) return gtia.peek(address);
+  if(address >= 0xd400 && address <= 0xd4ff) return antic.peek(address);
+  if(address >= 0xe800 && address <= 0xefff) return pokey.peek(address);
+  if(address >= 0xf800) return system.bios.read(address - 0xf800);
+  return io.openBus;
+}
+
+auto CPU::writeBus(n16 address, n8 data) -> void {
+  if(address <= 0x3fff) return system.ram.write(address, data);
+  if(address <= 0xbfff) return (void)cartridge.write(address - 0x4000, data);
+  if(address <= 0xc0ff) return gtia.write(address, data);
+  if(address >= 0xd400 && address <= 0xd4ff) return antic.write(address, data);
+  if(address >= 0xe800 && address <= 0xefff) return pokey.write(address, data);
+}
+
+auto CPU::readDebugger(n16 address) -> n8 {
+  return peekBus(address);
+}

--- a/ares/a52/cpu/serialization.cpp
+++ b/ares/a52/cpu/serialization.cpp
@@ -1,0 +1,12 @@
+auto CPU::serialize(serializer& s) -> void {
+  MOS6502::serialize(s);
+  Thread::serialize(s);
+
+  s(io.interruptPending);
+  s(io.resetPending);
+  s(io.nmiPending);
+  s(io.nmiLine);
+  s(io.irqLine);
+  s(io.rdyLine);
+  s(io.openBus);
+}

--- a/ares/a52/cpu/timing.cpp
+++ b/ares/a52/cpu/timing.cpp
@@ -6,6 +6,12 @@ auto CPU::read(n16 address) -> n8 {
   return data;
 }
 
+auto CPU::readDMA(n16 address) -> n8 {
+  // ANTIC DMA shares the physical data bus, but must not advance CPU time or
+  // trigger CPU-facing debugger, cheat, or acknowledge side effects.
+  return io.openBus = peekBus(address);
+}
+
 auto CPU::write(n16 address, n8 data) -> void {
   writeBus(address, data);
   io.openBus = data;

--- a/ares/a52/cpu/timing.cpp
+++ b/ares/a52/cpu/timing.cpp
@@ -1,0 +1,49 @@
+auto CPU::read(n16 address) -> n8 {
+  while(!io.rdyLine) step(1);
+  auto data = readBus(address);
+  io.openBus = data;
+  step(1);
+  return data;
+}
+
+auto CPU::write(n16 address, n8 data) -> void {
+  writeBus(address, data);
+  io.openBus = data;
+  step(1);
+}
+
+auto CPU::lastCycle() -> void {
+  io.interruptPending = io.nmiPending | irqPending();
+}
+
+auto CPU::cancelNmi() -> void {
+  io.interruptPending = irqPending();
+}
+
+auto CPU::delayIrq() -> void {
+  io.interruptPending = io.nmiPending;
+}
+
+auto CPU::irqPending() -> bool {
+  return io.irqLine && !P.i;
+}
+
+auto CPU::nmi(n16& vector) -> void {
+  if(io.nmiPending) {
+    io.nmiPending = 0;
+    vector = 0xfffa;
+  }
+}
+
+auto CPU::nmiLine(bool line) -> void {
+  if(!io.nmiLine && line) io.nmiPending = 1;
+  io.nmiLine = line;
+}
+
+auto CPU::irqLine(bool line) -> void {
+  io.irqLine = line;
+}
+
+auto CPU::rdyLine(bool line) -> void {
+  io.rdyLine = line;
+}

--- a/ares/a52/gtia/collision.cpp
+++ b/ares/a52/gtia/collision.cpp
@@ -1,0 +1,27 @@
+auto GTIA::Collision::clock(int playfield, u8 players, u8 missiles) -> void {
+  if(playfield >= 0) {
+    for(u32 index = 0; index < 4; index++) {
+      if(missiles >> index & 1) missilePlayfield[index] |= 1 << playfield;
+      if(players >> index & 1) playerPlayfield[index] |= 1 << playfield;
+    }
+  }
+  for(u32 missile = 0; missile < 4; missile++) {
+    if(!(missiles >> missile & 1)) continue;
+    missilePlayer[missile] |= players;
+  }
+  for(u32 player = 0; player < 4; player++) {
+    if(!(players >> player & 1)) continue;
+    playerPlayer[player] |= players & ~(1 << player);
+  }
+}
+
+auto GTIA::Collision::read(u8 address) const -> n8 {
+  if(address <= 0x03) return missilePlayfield[address];
+  if(address <= 0x07) return playerPlayfield[address - 0x04];
+  if(address <= 0x0b) return missilePlayer[address - 0x08];
+  return playerPlayer[address - 0x0c];
+}
+
+auto GTIA::Collision::clear() -> void {
+  *this = {};
+}

--- a/ares/a52/gtia/color.cpp
+++ b/ares/a52/gtia/color.cpp
@@ -1,0 +1,79 @@
+auto GTIA::ColorRegisters::power() -> void {
+  for(auto& color : playerColor) color = 0;
+  for(auto& color : playfieldColor) color = 0;
+  backgroundColor = 0;
+}
+
+auto GTIA::ColorRegisters::clock() -> void {
+  for(u32 index = 0; index < 9; index++) {
+    if(!colorDelay[index]) continue;
+    colorDelay[index] = 0;
+    if(index < 4) playerColor[index] = pendingColor[index];
+    else if(index < 8) playfieldColor[index - 4] = pendingColor[index];
+    else backgroundColor = pendingColor[index];
+  }
+}
+
+auto GTIA::ColorRegisters::write(u8 index, n8 data) -> void {
+  if(index >= 9) return;
+  pendingColor[index] = data;
+  colorDelay[index] = 1;
+}
+
+auto GTIA::ColorRegisters::player(u8 index) const -> n8 {
+  return playerColor[index];
+}
+
+auto GTIA::ColorRegisters::playfield(u8 index) const -> n8 {
+  return playfieldColor[index];
+}
+
+auto GTIA::ColorRegisters::background() const -> n8 {
+  return backgroundColor;
+}
+
+auto GTIA::color(n32 color) -> n64 {
+  static constexpr f64 LuminanceResistorsKOhm[4] = {39.0, 20.0, 10.0, 5.1};
+  static constexpr f64 MaximumLuminanceConductance =
+    1.0 / LuminanceResistorsKOhm[0] + 1.0 / LuminanceResistorsKOhm[1]
+    + 1.0 / LuminanceResistorsKOhm[2] + 1.0 / LuminanceResistorsKOhm[3];
+  static constexpr f64 BlackSetupIRE = 7.5;
+  static constexpr f64 WhiteIRE = 100.0;
+  static constexpr f64 ColorBurstPhaseDegrees = -57.0;
+  static constexpr f64 HuePhaseStepDegrees = 24.0;
+  static constexpr f64 ChromaAmplitude = 0.20;
+
+  auto code = (u8)color;
+  auto hue = code >> 4;
+  auto clampColorChannel = [](f64 value) -> u64 {
+    return (u64)(std::clamp(value, 0.0, 1.0) * 65535.0 + 0.5);
+  };
+
+  f64 conductance = 0.0;
+  for(u32 bit = 0; bit < 4; bit++) {
+    if(code >> bit & 1) conductance += 1.0 / LuminanceResistorsKOhm[bit];
+  }
+
+  // GTIA exposes separate hue and four-bit luminance signals. The CX5200
+  // motherboard combines the luminance bits through this resistor family,
+  // while luminance zero sits at blanking below the NTSC black setup.
+  auto luminance = conductance / MaximumLuminanceConductance;
+  auto y = (luminance * WhiteIRE - BlackSetupIRE) / (WhiteIRE - BlackSetupIRE);
+  f64 i = 0.0;
+  f64 q = 0.0;
+
+  if(hue) {
+    // Hue zero suppresses chroma. The remaining fifteen hues are successive
+    // nominal GTIA delay stages measured from calibrated NTSC color burst.
+    auto phase = (ColorBurstPhaseDegrees + HuePhaseStepDegrees * (hue - 1)) * Math::Pi / 180.0;
+    i = ChromaAmplitude * cos(phase);
+    q = ChromaAmplitude * sin(phase);
+  }
+
+  // Decode gamma-domain YIQ and clamp only after the matrix. This preserves
+  // the component clipping that shifts very dark GTIA colors.
+  auto red = clampColorChannel(y + 0.956 * i + 0.621 * q);
+  auto green = clampColorChannel(y - 0.272 * i - 0.647 * q);
+  auto blue = clampColorChannel(y - 1.106 * i + 1.703 * q);
+  return red << 32 | green << 16 | blue;
+}

--- a/ares/a52/gtia/console.cpp
+++ b/ares/a52/gtia/console.cpp
@@ -1,0 +1,50 @@
+auto GTIA::Console::power() -> void {
+  *this = {};
+  output = 0x07;
+  pinSense = 0x08;
+  for(auto& value : trigger) value = 1;
+}
+
+auto GTIA::Console::clock(n3 graphicsControl) -> void {
+  // GTIA latches T0-T3 whenever an input goes low, independently of CPU reads.
+  // Source: Atari GTIA Chip (NTSC) data sheet, section 7.0, Trigger Inputs.
+  for(u32 index = 0; index < 4; index++) {
+    // Controller ports are connected by the standard-controller commit.
+    auto state = true;
+    if(graphicsControl.bit(2)) trigger[index] &= state;
+    else trigger[index] = state;
+  }
+}
+
+auto GTIA::Console::readTrigger(u8 index, n3 graphicsControl) -> n1 {
+  clock(graphicsControl);
+  return trigger[index];
+}
+
+auto GTIA::Console::triggerValue(u8 index) const -> n1 {
+  return trigger[index];
+}
+
+auto GTIA::Console::pins() const -> n4 {
+  return pinSense;
+}
+
+auto GTIA::Console::releaseTriggers() -> void {
+  for(auto& value : trigger) value = 1;
+}
+
+auto GTIA::Console::write(n8 data) -> void {
+  output = data;
+  // A written one enables GTIA's sink transistor and reads back low. A zero
+  // releases the pin to the board pull-up. S3 is only modeled as released-high;
+  // its four-port-board destination is still unknown.
+  pinSense = ~(u8)output;
+}
+
+auto GTIA::controllerSelect() const -> u32 {
+  return (u8)console.output & 3;
+}
+
+auto GTIA::controllerPower() const -> bool {
+  return console.output.bit(2);
+}

--- a/ares/a52/gtia/console.cpp
+++ b/ares/a52/gtia/console.cpp
@@ -9,8 +9,7 @@ auto GTIA::Console::clock(n3 graphicsControl) -> void {
   // GTIA latches T0-T3 whenever an input goes low, independently of CPU reads.
   // Source: Atari GTIA Chip (NTSC) data sheet, section 7.0, Trigger Inputs.
   for(u32 index = 0; index < 4; index++) {
-    // Controller ports are connected by the standard-controller commit.
-    auto state = true;
+    auto state = !controllerPorts[index].bottomFire();
     if(graphicsControl.bit(2)) trigger[index] &= state;
     else trigger[index] = state;
   }

--- a/ares/a52/gtia/gtia.cpp
+++ b/ares/a52/gtia/gtia.cpp
@@ -1,0 +1,31 @@
+#include <a52/a52.hpp>
+
+namespace ares::Atari5200 {
+
+GTIA gtia;
+
+auto GTIA::load(Node::Object parent) -> void {
+  node = parent->append<Node::Object>("GTIA");
+}
+
+auto GTIA::unload() -> void {
+  node = {};
+}
+
+auto GTIA::power() -> void {
+}
+
+auto GTIA::read(n8 address) -> n8 {
+  return peek(address);
+}
+
+auto GTIA::peek(n8 address) const -> n8 {
+  address &= 0x1f;
+  if(address <= 0x13) return 0x00;
+  return 0x0f;
+}
+
+auto GTIA::write(n8 address, n8 data) -> void {
+}
+
+}

--- a/ares/a52/gtia/gtia.cpp
+++ b/ares/a52/gtia/gtia.cpp
@@ -13,6 +13,7 @@ GTIA gtia;
 #include "collision.cpp"
 #include "video.cpp"
 #include "color.cpp"
+#include "serialization.cpp"
 
 auto GTIA::load(Node::Object parent) -> void {
   node = parent->append<Node::Object>("GTIA");

--- a/ares/a52/gtia/gtia.cpp
+++ b/ares/a52/gtia/gtia.cpp
@@ -26,6 +26,20 @@ auto GTIA::peek(n8 address) const -> n8 {
 }
 
 auto GTIA::write(n8 address, n8 data) -> void {
+  // Register side effects arrive with the GTIA implementation.
+}
+
+auto GTIA::clock(n3 an) -> void {
+}
+
+auto GTIA::loadPlayerDMA(u8 player, n8 data, u32 scanline) -> void {
+}
+
+auto GTIA::loadMissileDMA(n8 data, u32 scanline) -> void {
+}
+
+auto GTIA::frame() -> void {
+  scheduler.exit(Event::Frame);
 }
 
 }

--- a/ares/a52/gtia/gtia.cpp
+++ b/ares/a52/gtia/gtia.cpp
@@ -4,42 +4,46 @@ namespace ares::Atari5200 {
 
 GTIA gtia;
 
+#include "io.cpp"
+#include "timing.cpp"
+#include "console.cpp"
+#include "player-missile.cpp"
+#include "playfield.cpp"
+#include "priority.cpp"
+#include "collision.cpp"
+#include "video.cpp"
+#include "color.cpp"
+
 auto GTIA::load(Node::Object parent) -> void {
   node = parent->append<Node::Object>("GTIA");
+
+  screen = node->append<Node::Video::Screen>(
+    "Screen", Timing::SamplesPerScanline, Timing::ScanlinesPerFrame
+  );
+  screen->colors(1 << 8, std::bind_front(&GTIA::color, this));
+  screen->setSize(Timing::SamplesPerScanline, Timing::ScanlinesPerFrame);
+  screen->setScale(1.0, 1.0);
+  screen->setAspect(20.0, 21.0);
+  screen->refreshRateHint(system.frequency(), Timing::ColorClocksPerScanline, Timing::ScanlinesPerFrame);
 }
 
 auto GTIA::unload() -> void {
+  if(screen) screen->quit();
+  if(node && screen) node->remove(screen);
+  screen.reset();
   node = {};
 }
 
 auto GTIA::power() -> void {
-}
-
-auto GTIA::read(n8 address) -> n8 {
-  return peek(address);
-}
-
-auto GTIA::peek(n8 address) const -> n8 {
-  address &= 0x1f;
-  if(address <= 0x13) return 0x00;
-  return 0x0f;
-}
-
-auto GTIA::write(n8 address, n8 data) -> void {
-  // Register side effects arrive with the GTIA implementation.
-}
-
-auto GTIA::clock(n3 an) -> void {
-}
-
-auto GTIA::loadPlayerDMA(u8 player, n8 data, u32 scanline) -> void {
-}
-
-auto GTIA::loadMissileDMA(n8 data, u32 scanline) -> void {
-}
-
-auto GTIA::frame() -> void {
-  scheduler.exit(Event::Frame);
+  if(screen) screen->power();
+  playerMissile = {};
+  priority = {};
+  console.power();
+  colors.power();
+  collision.clear();
+  playfield.power();
+  counter.power();
+  graphicsControl = 0;
 }
 
 }

--- a/ares/a52/gtia/gtia.hpp
+++ b/ares/a52/gtia/gtia.hpp
@@ -1,0 +1,14 @@
+struct GTIA {
+  Node::Object node;
+
+  auto load(Node::Object parent) -> void;
+  auto unload() -> void;
+  auto power() -> void;
+
+  auto read(n8 address) -> n8;
+  auto peek(n8 address) const -> n8;
+  auto write(n8 address, n8 data) -> void;
+
+};
+
+extern GTIA gtia;

--- a/ares/a52/gtia/gtia.hpp
+++ b/ares/a52/gtia/gtia.hpp
@@ -42,6 +42,9 @@ struct GTIA {
     OverscanViewportX + (OverscanViewportWidth - NominalViewportWidth) / 2;
   static constexpr u32 NominalViewportY = OverscanViewportY;
 
+  //serialization.cpp
+  auto serialize(serializer&) -> void;
+
 private:
   struct Sample {
     n3 an;
@@ -65,6 +68,9 @@ private:
     auto writePlayerSize(u8 index, n2 data) -> void;
     auto writeMissileSize(n8 data) -> void;
     auto writeVerticalDelay(n8 data) -> void;
+
+    //serialization.cpp
+    auto serialize(serializer&) -> void;
 
   private:
     //player-missile.cpp
@@ -133,6 +139,9 @@ private:
     auto fifthPlayer() const -> bool;
     auto multicolor() const -> bool;
 
+    //serialization.cpp
+    auto serialize(serializer&) -> void;
+
     n8 control;
     n6 pendingLow;
     n2 lowDelay;
@@ -159,6 +168,9 @@ private:
     auto signals(Sample sample, u8 special, u8 mode) const -> Signals;
     auto clearHighResolution() -> void;
 
+    //serialization.cpp
+    auto serialize(serializer&) -> void;
+
     struct Special {
       Sample sample[4];
       n4 players[4];
@@ -182,6 +194,9 @@ private:
     auto releaseTriggers() -> void;
     auto write(n8 data) -> void;
 
+    //serialization.cpp
+    auto serialize(serializer&) -> void;
+
     n4 output;
     n4 pinSense;
     n1 trigger[4];
@@ -196,6 +211,9 @@ private:
     auto playfield(u8 index) const -> n8;
     auto background() const -> n8;
 
+    //serialization.cpp
+    auto serialize(serializer&) -> void;
+
     n8 playerColor[4];
     n8 playfieldColor[4];
     n8 backgroundColor;
@@ -209,6 +227,9 @@ private:
     auto read(u8 address) const -> n8;
     auto clear() -> void;
 
+    //serialization.cpp
+    auto serialize(serializer&) -> void;
+
     n4 missilePlayfield[4];
     n4 playerPlayfield[4];
     n4 missilePlayer[4];
@@ -220,6 +241,9 @@ private:
     auto power() -> void;
     auto synchronizeHorizontalBlank() -> void;
     auto advance() -> void;
+
+    //serialization.cpp
+    auto serialize(serializer&) -> void;
 
     n8 horizontal;
     n9 vertical;

--- a/ares/a52/gtia/gtia.hpp
+++ b/ares/a52/gtia/gtia.hpp
@@ -9,6 +9,11 @@ struct GTIA {
   auto peek(n8 address) const -> n8;
   auto write(n8 address, n8 data) -> void;
 
+  auto clock(n3 an) -> void;
+  auto loadPlayerDMA(u8 player, n8 data, u32 scanline) -> void;
+  auto loadMissileDMA(n8 data, u32 scanline) -> void;
+  auto frame() -> void;
+
 };
 
 extern GTIA gtia;

--- a/ares/a52/gtia/gtia.hpp
+++ b/ares/a52/gtia/gtia.hpp
@@ -1,19 +1,238 @@
+// GTIA: graphics television interface adapter
 struct GTIA {
   Node::Object node;
+  Node::Video::Screen screen;
 
+  //gtia.cpp
   auto load(Node::Object parent) -> void;
   auto unload() -> void;
   auto power() -> void;
 
+  //timing.cpp
+  auto clock(n3 an) -> void;
+
+  //io.cpp
   auto read(n8 address) -> n8;
   auto peek(n8 address) const -> n8;
   auto write(n8 address, n8 data) -> void;
 
-  auto clock(n3 an) -> void;
+  //player-missile.cpp
   auto loadPlayerDMA(u8 player, n8 data, u32 scanline) -> void;
   auto loadMissileDMA(n8 data, u32 scanline) -> void;
+
+  //console.cpp
+  auto controllerSelect() const -> u32;
+  auto controllerPower() const -> bool;
+
+  //video.cpp
   auto frame() -> void;
 
+  //color.cpp
+  auto color(n32 color) -> n64;
+
+  static constexpr u32 OverscanViewportX = Timing::VisibleFirstColorClock * Timing::SamplesPerColorClock;
+  static constexpr u32 OverscanViewportY = Timing::DisplayListFirstScanline;
+  static constexpr u32 OverscanViewportWidth =
+    (Timing::VisibleLastColorClock - Timing::VisibleFirstColorClock + 1) * Timing::SamplesPerColorClock;
+  static constexpr u32 OverscanViewportHeight =
+    Timing::DisplayListLastScanline - Timing::DisplayListFirstScanline + 1;
+  static constexpr u32 NominalViewportWidth = 42 * 8;
+  static constexpr u32 NominalViewportHeight = OverscanViewportHeight;
+  static constexpr u32 NominalViewportX =
+    OverscanViewportX + (OverscanViewportWidth - NominalViewportWidth) / 2;
+  static constexpr u32 NominalViewportY = OverscanViewportY;
+
+private:
+  struct Sample {
+    n3 an;
+    n1 hblank;
+    n1 vsync;
+  };
+
+  struct PlayerMissile {
+    struct Signals {
+      u8 players;
+      u8 missiles;
+    };
+
+    //player-missile.cpp
+    auto loadPlayerDMA(u8 player, n8 data, bool enabled, bool oddLine) -> void;
+    auto loadMissileDMA(n8 data, bool enabled, bool oddLine) -> void;
+    auto clock(u8 horizontal) -> Signals;
+    auto clockRegisters() -> void;
+    auto writePosition(u8 index, n8 data) -> void;
+    auto writeGraphics(u8 index, n8 data) -> void;
+    auto writePlayerSize(u8 index, n2 data) -> void;
+    auto writeMissileSize(n8 data) -> void;
+    auto writeVerticalDelay(n8 data) -> void;
+
+  private:
+    //player-missile.cpp
+    auto clockPlayer(u8 index, u8 horizontal) -> bool;
+    auto clockMissile(u8 index, u8 horizontal) -> bool;
+
+  public:
+    n8 playerPosition[4];
+    n8 missilePosition[4];
+    n2 playerSize[4];
+    n8 missileSize;
+    n8 playerGraphics[4];
+    n8 missileGraphics;
+    n8 verticalDelay;
+
+    n8 playerShift[4];
+    n2 missileShift[4];
+    n4 playerRemaining[4];
+    n2 missileRemaining[4];
+    n2 playerStretch[4];
+    n2 missileStretch[4];
+
+    n8 pendingPosition[8];
+    n3 positionDelay[8];
+    n8 pendingGraphics[5];
+    n2 graphicsDelay[5];
+    n2 pendingPlayerSize[4];
+    n3 playerSizeDelay[4];
+    n8 pendingMissileSize;
+    n3 missileSizeDelay;
+  } playerMissile;
+
+  struct Priority {
+    struct Rule {
+      bool pri0;
+      bool pri2;
+      bool pri01;
+      bool pri12;
+      bool pri23;
+      bool pri03;
+    };
+
+    struct Signals {
+      u8 players;
+      u8 playfields;
+      bool background;
+    };
+
+    static constexpr Rule Rules[16] = {
+      {0, 0, 0, 0, 0, 0}, {1, 0, 1, 0, 0, 1},
+      {0, 0, 1, 1, 0, 0}, {1, 0, 1, 1, 0, 1},
+      {0, 1, 0, 1, 1, 0}, {1, 1, 1, 1, 1, 1},
+      {0, 1, 1, 1, 1, 0}, {1, 1, 1, 1, 1, 1},
+      {0, 0, 0, 0, 1, 1}, {1, 0, 1, 0, 1, 1},
+      {0, 0, 1, 1, 1, 1}, {1, 0, 1, 1, 1, 1},
+      {0, 1, 0, 1, 1, 1}, {1, 1, 1, 1, 1, 1},
+      {0, 1, 1, 1, 1, 1}, {1, 1, 1, 1, 1, 1},
+    };
+
+    //priority.cpp
+    auto clock() -> void;
+    auto write(n8 data) -> void;
+    auto signals(u8 players, u8 playfields) const -> Signals;
+    auto mode() const -> u8;
+    auto rule() const -> u8;
+    auto fifthPlayer() const -> bool;
+    auto multicolor() const -> bool;
+
+    n8 control;
+    n6 pendingLow;
+    n2 lowDelay;
+    n2 pendingMode;
+    n3 modeDelay;
+  } priority;
+
+  struct Playfield {
+    struct Signals {
+      int collision;
+      u8 playfields;
+      u8 specialPlayers;
+    };
+
+    struct Input {
+      Sample sample[2];
+      n1 bit[2];
+      n1 synchronize;
+    };
+
+    //playfield.cpp
+    auto power() -> void;
+    auto clock(n3 an) -> Input;
+    auto signals(Sample sample, u8 special, u8 mode) const -> Signals;
+    auto clearHighResolution() -> void;
+
+    struct Special {
+      Sample sample[4];
+      n4 players[4];
+      n4 missiles[4];
+      n1 bit[4];
+      u32 y;
+      u32 x;
+      n4 mode10Previous;
+    } special;
+    n1 highResolution;
+    n1 horizontalBlank;
+  } playfield;
+
+  struct Console {
+    //console.cpp
+    auto power() -> void;
+    auto clock(n3 graphicsControl) -> void;
+    auto readTrigger(u8 index, n3 graphicsControl) -> n1;
+    auto triggerValue(u8 index) const -> n1;
+    auto pins() const -> n4;
+    auto releaseTriggers() -> void;
+    auto write(n8 data) -> void;
+
+    n4 output;
+    n4 pinSense;
+    n1 trigger[4];
+  } console;
+
+  struct ColorRegisters {
+    //color.cpp
+    auto power() -> void;
+    auto clock() -> void;
+    auto write(u8 index, n8 data) -> void;
+    auto player(u8 index) const -> n8;
+    auto playfield(u8 index) const -> n8;
+    auto background() const -> n8;
+
+    n8 playerColor[4];
+    n8 playfieldColor[4];
+    n8 backgroundColor;
+    n8 pendingColor[9];
+    n1 colorDelay[9];
+  } colors;
+
+  struct Collision {
+    //collision.cpp
+    auto clock(int playfield, u8 players, u8 missiles) -> void;
+    auto read(u8 address) const -> n8;
+    auto clear() -> void;
+
+    n4 missilePlayfield[4];
+    n4 playerPlayfield[4];
+    n4 missilePlayer[4];
+    n4 playerPlayer[4];
+  } collision;
+
+  struct Counter {
+    //timing.cpp
+    auto power() -> void;
+    auto synchronizeHorizontalBlank() -> void;
+    auto advance() -> void;
+
+    n8 horizontal;
+    n9 vertical;
+  } counter;
+
+  //video.cpp
+  auto outputSample(u32 y, u32 x, Sample sample, u8 players, u8 missiles, n1 specialBit) -> void;
+  auto resolve(Sample sample, u8 special, u8 players, u8 missiles) -> n8;
+
+  //io.cpp
+  auto writeControl(n8 address, n8 data) -> void;
+
+  n3 graphicsControl;
 };
 
 extern GTIA gtia;

--- a/ares/a52/gtia/io.cpp
+++ b/ares/a52/gtia/io.cpp
@@ -1,0 +1,37 @@
+auto GTIA::read(n8 address) -> n8 {
+  address &= 0x1f;
+  if(address >= 0x10 && address <= 0x13) return console.readTrigger(address - 0x10, graphicsControl);
+  return peek(address);
+}
+
+auto GTIA::peek(n8 address) const -> n8 {
+  address &= 0x1f;
+  if(address <= 0x0f) return collision.read(address);
+  if(address <= 0x13) return console.triggerValue(address - 0x10);
+  if(address == 0x14) return 0x0f; // NTSC 0x0f, PAL 0x01
+  if(address == 0x1f) return console.pins();
+  return 0x0f;
+}
+
+auto GTIA::writeControl(n8 address, n8 data) -> void {
+  address &= 0x1f;
+  if(address >= 0x08 && address <= 0x0b) playerMissile.writePlayerSize(address - 0x08, data);
+  else if(address == 0x0c) playerMissile.writeMissileSize(data);
+  else if(address == 0x1c) playerMissile.writeVerticalDelay(data);
+  else if(address == 0x1d) {
+    graphicsControl = data;
+    if(!graphicsControl.bit(2)) console.releaseTriggers();
+  }
+  else if(address == 0x1e) collision.clear();
+  else if(address == 0x1f) console.write(data);
+}
+
+auto GTIA::write(n8 address, n8 data) -> void {
+  address &= 0x1f;
+  data &= address >= 0x12 && address <= 0x1a ? 0xfe : 0xff;
+  if(address <= 0x07) return playerMissile.writePosition(address, data);
+  if(address >= 0x0d && address <= 0x11) return playerMissile.writeGraphics(address - 0x0d, data);
+  if(address >= 0x12 && address <= 0x1a) return colors.write(address - 0x12, data);
+  if(address == 0x1b) return priority.write(data);
+  writeControl(address, data);
+}

--- a/ares/a52/gtia/player-missile.cpp
+++ b/ares/a52/gtia/player-missile.cpp
@@ -1,0 +1,120 @@
+auto GTIA::loadPlayerDMA(u8 player, n8 data, u32 scanline) -> void {
+  playerMissile.loadPlayerDMA(player, data, graphicsControl.bit(1), scanline & 1);
+}
+
+auto GTIA::loadMissileDMA(n8 data, u32 scanline) -> void {
+  playerMissile.loadMissileDMA(data, graphicsControl.bit(0), scanline & 1);
+}
+
+auto GTIA::PlayerMissile::loadPlayerDMA(u8 player, n8 data, bool enabled, bool oddLine) -> void {
+  if(player >= 4 || !enabled) return;
+  if(verticalDelay.bit(player + 4) && !oddLine) return;
+  playerGraphics[player] = data;
+}
+
+auto GTIA::PlayerMissile::loadMissileDMA(n8 data, bool enabled, bool oddLine) -> void {
+  if(!enabled) return;
+  u8 mask = 0xff;
+  for(u32 missile = 0; missile < 4; missile++) {
+    if(verticalDelay.bit(missile) && !oddLine) mask &= ~(3 << (missile * 2));
+  }
+  data = ((u8)missileGraphics & ~mask) | ((u8)data & mask);
+  missileGraphics = data;
+}
+
+auto GTIA::PlayerMissile::clock(u8 horizontal) -> Signals {
+  u8 players = 0;
+  u8 missiles = 0;
+
+  for(u32 index = 0; index < 4; index++) {
+    if(clockPlayer(index, horizontal)) players |= 1 << index;
+    if(clockMissile(index, horizontal)) missiles |= 1 << index;
+  }
+
+  return {players, missiles};
+}
+
+auto GTIA::PlayerMissile::clockPlayer(u8 index, u8 horizontal) -> bool {
+  if(horizontal == playerPosition[index]) {
+    playerShift[index] |= playerGraphics[index];
+    playerRemaining[index] = 8;
+    playerStretch[index] = 0;
+  }
+
+  bool output = playerRemaining[index] && playerShift[index].bit(7);
+  if(playerRemaining[index]) {
+    playerStretch[index] = ((u8)playerStretch[index] + 1) & (u8)playerSize[index];
+    if(!playerStretch[index]) {
+      playerShift[index] <<= 1;
+      playerRemaining[index]--;
+    }
+  }
+  return output;
+}
+
+auto GTIA::PlayerMissile::clockMissile(u8 index, u8 horizontal) -> bool {
+  if(horizontal == missilePosition[index]) {
+    missileShift[index] |= (u8)missileGraphics >> (index * 2) & 3;
+    missileRemaining[index] = 2;
+    missileStretch[index] = 0;
+  }
+
+  bool output = missileRemaining[index] && missileShift[index].bit(1);
+  auto sizeCode = (u8)missileSize >> (index * 2) & 3;
+  if(missileRemaining[index]) {
+    missileStretch[index] = ((u8)missileStretch[index] + 1) & sizeCode;
+    if(!missileStretch[index]) {
+      missileShift[index] <<= 1;
+      missileRemaining[index]--;
+    }
+  }
+  return output;
+}
+
+auto GTIA::PlayerMissile::clockRegisters() -> void {
+  for(u32 index = 0; index < 8; index++) {
+    if(positionDelay[index] && !--positionDelay[index]) {
+      if(index < 4) playerPosition[index] = pendingPosition[index];
+      else missilePosition[index - 4] = pendingPosition[index];
+    }
+  }
+  for(u32 index = 0; index < 5; index++) {
+    if(graphicsDelay[index] && !--graphicsDelay[index]) {
+      if(index < 4) playerGraphics[index] = pendingGraphics[index];
+      else missileGraphics = pendingGraphics[index];
+    }
+  }
+  for(u32 index = 0; index < 4; index++) {
+    if(playerSizeDelay[index] && !--playerSizeDelay[index]) {
+      playerSize[index] = pendingPlayerSize[index];
+    }
+  }
+  if(missileSizeDelay && !--missileSizeDelay) missileSize = pendingMissileSize;
+}
+
+auto GTIA::PlayerMissile::writePosition(u8 index, n8 data) -> void {
+  if(index >= 8) return;
+  pendingPosition[index] = data;
+  positionDelay[index] = 5;
+}
+
+auto GTIA::PlayerMissile::writeGraphics(u8 index, n8 data) -> void {
+  if(index >= 5) return;
+  pendingGraphics[index] = data;
+  graphicsDelay[index] = 3;
+}
+
+auto GTIA::PlayerMissile::writePlayerSize(u8 index, n2 data) -> void {
+  if(index >= 4) return;
+  pendingPlayerSize[index] = data;
+  playerSizeDelay[index] = 5;
+}
+
+auto GTIA::PlayerMissile::writeMissileSize(n8 data) -> void {
+  pendingMissileSize = data;
+  missileSizeDelay = 5;
+}
+
+auto GTIA::PlayerMissile::writeVerticalDelay(n8 data) -> void {
+  verticalDelay = data;
+}

--- a/ares/a52/gtia/playfield.cpp
+++ b/ares/a52/gtia/playfield.cpp
@@ -1,0 +1,73 @@
+auto GTIA::Playfield::clock(n3 anValue) -> Input {
+  Input input = {};
+  auto an = (u8)anValue;
+
+  if(an == 2 || an == 3) {
+    input.synchronize = !horizontalBlank;
+    horizontalBlank = 1;
+    highResolution = an == 3;
+  } else {
+    horizontalBlank = 0;
+  }
+
+  if(an == 1) {
+    input.sample[0].vsync = 1;
+    input.sample[1].vsync = 1;
+  } else if(an == 2 || an == 3) {
+    input.sample[0].hblank = 1;
+    input.sample[1].hblank = 1;
+  } else if(an >= 4) {
+    input.bit[0] = an >> 1 & 1;
+    input.bit[1] = an >> 0 & 1;
+    if(highResolution) {
+      input.sample[0].an = 5 + (an >> 1 & 1);
+      input.sample[1].an = 5 + (an >> 0 & 1);
+    } else {
+      input.sample[0].an = an - 3;
+      input.sample[1].an = an - 3;
+    }
+  }
+
+  return input;
+}
+
+auto GTIA::Playfield::signals(Sample sample, u8 special, u8 mode) const -> Signals {
+  int collisionPlayfield = -1;
+  u8 playfields = 0;
+  u8 specialPlayers = 0;
+  auto an = (u8)sample.an;
+  if(an >= 1 && an <= 4) {
+    collisionPlayfield = an - 1;
+    playfields = 1 << collisionPlayfield;
+  }
+
+  if(!mode && (an == 5 || an == 6)) {
+    // High-resolution data always enters priority as PF2. The two half-color
+    // clock pixels are ORed for collision purposes, so only a set bit latches
+    // the PF2 collision.
+    playfields = 1 << 2;
+    if(an == 6) collisionPlayfield = 2;
+  } else if(special != 0xff) {
+    collisionPlayfield = -1;
+    playfields = 0;
+    if(mode == 2) {
+      if(special <= 3) {
+        specialPlayers = 1 << special;
+      } else if((special >= 4 && special <= 7) || special >= 12) {
+        collisionPlayfield = special & 3;
+        playfields = 1 << collisionPlayfield;
+      }
+    }
+  }
+
+  return {collisionPlayfield, playfields, specialPlayers};
+}
+
+auto GTIA::Playfield::clearHighResolution() -> void {
+  highResolution = 0;
+}
+
+auto GTIA::Playfield::power() -> void {
+  *this = {};
+  horizontalBlank = 1;
+}

--- a/ares/a52/gtia/priority.cpp
+++ b/ares/a52/gtia/priority.cpp
@@ -1,0 +1,65 @@
+auto GTIA::Priority::signals(u8 players, u8 playfields) const -> Signals {
+  const auto& priorityRule = Rules[rule()];
+  bool p0 = players & 0x01;
+  bool p1 = players & 0x02;
+  bool p2 = players & 0x04;
+  bool p3 = players & 0x08;
+  bool pf0 = playfields & 0x01;
+  bool pf1 = playfields & 0x02;
+  bool pf2 = playfields & 0x04;
+  bool pf3 = playfields & 0x08;
+  bool p01 = p0 || p1;
+  bool p23 = p2 || p3;
+  bool pf01 = pf0 || pf1;
+  bool pf23 = pf2 || pf3;
+
+  // These are the output-gate equations from the GTIA hardware manual. More
+  // than one output can be active; the corresponding color registers are
+  // electrically ORed, which is observable for PRIOR=0 and combined PRI bits.
+  bool sp0 = p0 && !(pf01 && priorityRule.pri23) && !(priorityRule.pri2 && pf23);
+  bool sp1 = p1 && !(pf01 && priorityRule.pri23) && !(priorityRule.pri2 && pf23)
+    && (!p0 || multicolor());
+  bool sp2 = p2 && !p01 && !(pf23 && priorityRule.pri12) && !(pf01 && !priorityRule.pri0);
+  bool sp3 = p3 && !p01 && !(pf23 && priorityRule.pri12) && !(pf01 && !priorityRule.pri0)
+    && (!p2 || multicolor());
+
+  bool sf3 = pf3 && !(p23 && priorityRule.pri03) && !(p01 && !priorityRule.pri2);
+  bool sf0 = pf0 && !(p23 && priorityRule.pri0) && !(p01 && priorityRule.pri01) && !sf3;
+  bool sf1 = pf1 && !(p23 && priorityRule.pri0) && !(p01 && priorityRule.pri01) && !sf3;
+  bool sf2 = pf2 && !(p23 && priorityRule.pri03) && !(p01 && !priorityRule.pri2) && !sf3;
+  bool background = !p01 && !p23 && !pf01 && !pf23;
+
+  return {
+    (u8)(sp0 << 0 | sp1 << 1 | sp2 << 2 | sp3 << 3),
+    (u8)(sf0 << 0 | sf1 << 1 | sf2 << 2 | sf3 << 3),
+    background,
+  };
+}
+
+auto GTIA::Priority::clock() -> void {
+  if(lowDelay && !--lowDelay) control = ((u8)control & 0xc0) | pendingLow;
+  if(modeDelay && !--modeDelay) control = ((u8)control & 0x3f) | ((u8)pendingMode << 6);
+}
+
+auto GTIA::Priority::write(n8 data) -> void {
+  pendingLow = (u8)data & 0x3f;
+  pendingMode = (u8)data >> 6;
+  lowDelay = 2;
+  modeDelay = 4;
+}
+
+auto GTIA::Priority::mode() const -> u8 {
+  return (u8)control >> 6;
+}
+
+auto GTIA::Priority::rule() const -> u8 {
+  return (u8)control & 15;
+}
+
+auto GTIA::Priority::fifthPlayer() const -> bool {
+  return control.bit(4);
+}
+
+auto GTIA::Priority::multicolor() const -> bool {
+  return control.bit(5);
+}

--- a/ares/a52/gtia/serialization.cpp
+++ b/ares/a52/gtia/serialization.cpp
@@ -1,0 +1,86 @@
+auto GTIA::serialize(serializer& s) -> void {
+  playerMissile.serialize(s);
+  colors.serialize(s);
+  priority.serialize(s);
+  s(graphicsControl);
+  console.serialize(s);
+  collision.serialize(s);
+  playfield.serialize(s);
+  counter.serialize(s);
+}
+
+auto GTIA::PlayerMissile::serialize(serializer& s) -> void {
+  for(auto& value : playerPosition) s(value);
+  for(auto& value : missilePosition) s(value);
+  for(auto& value : playerSize) s(value);
+  s(missileSize);
+  for(auto& value : playerGraphics) s(value);
+  s(missileGraphics);
+  s(verticalDelay);
+
+  for(auto& value : playerShift) s(value);
+  for(auto& value : missileShift) s(value);
+  for(auto& value : playerRemaining) s(value);
+  for(auto& value : missileRemaining) s(value);
+  for(auto& value : playerStretch) s(value);
+  for(auto& value : missileStretch) s(value);
+
+  for(auto& value : pendingPosition) s(value);
+  for(auto& value : positionDelay) s(value);
+  for(auto& value : pendingGraphics) s(value);
+  for(auto& value : graphicsDelay) s(value);
+  for(auto& value : pendingPlayerSize) s(value);
+  for(auto& value : playerSizeDelay) s(value);
+  s(pendingMissileSize);
+  s(missileSizeDelay);
+}
+
+auto GTIA::ColorRegisters::serialize(serializer& s) -> void {
+  for(auto& value : playerColor) s(value);
+  for(auto& value : playfieldColor) s(value);
+  s(backgroundColor);
+  for(auto& value : pendingColor) s(value);
+  for(auto& value : colorDelay) s(value);
+}
+
+auto GTIA::Priority::serialize(serializer& s) -> void {
+  s(control);
+  s(pendingLow);
+  s(lowDelay);
+  s(pendingMode);
+  s(modeDelay);
+}
+
+auto GTIA::Console::serialize(serializer& s) -> void {
+  s(output);
+  s(pinSense);
+  for(auto& value : trigger) s(value);
+}
+
+auto GTIA::Collision::serialize(serializer& s) -> void {
+  for(auto& value : missilePlayfield) s(value);
+  for(auto& value : playerPlayfield) s(value);
+  for(auto& value : missilePlayer) s(value);
+  for(auto& value : playerPlayer) s(value);
+}
+
+auto GTIA::Playfield::serialize(serializer& s) -> void {
+  for(auto& sample : special.sample) {
+    s(sample.an);
+    s(sample.hblank);
+    s(sample.vsync);
+  }
+  for(auto& value : special.players) s(value);
+  for(auto& value : special.missiles) s(value);
+  for(auto& value : special.bit) s(value);
+  s(special.y);
+  s(special.x);
+  s(special.mode10Previous);
+  s(highResolution);
+  s(horizontalBlank);
+}
+
+auto GTIA::Counter::serialize(serializer& s) -> void {
+  s(horizontal);
+  s(vertical);
+}

--- a/ares/a52/gtia/timing.cpp
+++ b/ares/a52/gtia/timing.cpp
@@ -1,0 +1,41 @@
+auto GTIA::clock(n3 an) -> void {
+  console.clock(graphicsControl);
+  playerMissile.clockRegisters();
+  priority.clock();
+  colors.clock();
+
+  auto input = playfield.clock(an);
+  if(input.synchronize) counter.synchronizeHorizontalBlank();
+
+  auto objects = playerMissile.clock(counter.horizontal);
+
+  auto x = (u32)counter.horizontal * Timing::SamplesPerColorClock;
+  auto y = (u32)counter.vertical;
+  outputSample(y, x + 0, input.sample[0], objects.players, objects.missiles, input.bit[0]);
+  outputSample(y, x + 1, input.sample[1], objects.players, objects.missiles, input.bit[1]);
+
+  // Enabling a GTIA special mode clears the normal high-resolution latch.
+  // Returning to normal mode cannot restore it until ANTIC presents the next
+  // horizontal-blank mode code, which is the source of pseudo mode E.
+  if(priority.mode()) playfield.clearHighResolution();
+  counter.advance();
+}
+
+auto GTIA::Counter::synchronizeHorizontalBlank() -> void {
+  horizontal = Timing::VisibleLastColorClock + 1;
+}
+
+auto GTIA::Counter::advance() -> void {
+  if(++horizontal == Timing::ColorClocksPerScanline) {
+    horizontal = 0;
+    if(++vertical == Timing::ScanlinesPerFrame) vertical = 0;
+  }
+}
+
+auto GTIA::Counter::power() -> void {
+  *this = {};
+  // ANTIC machine cycle 0 begins three color clocks before GTIA horizontal
+  // position 0. The GTIA counter therefore finishes the preceding line first.
+  horizontal = Timing::ColorClocksPerScanline - 3;
+  vertical = Timing::ScanlinesPerFrame - 1;
+}

--- a/ares/a52/gtia/video.cpp
+++ b/ares/a52/gtia/video.cpp
@@ -1,0 +1,140 @@
+auto GTIA::frame() -> void {
+  if(!screen) return;
+  if(screen->overscan()) {
+    screen->setSize(OverscanViewportWidth, OverscanViewportHeight);
+    screen->setViewport(
+      OverscanViewportX, OverscanViewportY,
+      OverscanViewportWidth, OverscanViewportHeight
+    );
+  } else {
+    screen->setSize(NominalViewportWidth, NominalViewportHeight);
+    screen->setViewport(
+      NominalViewportX, NominalViewportY,
+      NominalViewportWidth, NominalViewportHeight
+    );
+  }
+  screen->frame();
+}
+
+auto GTIA::outputSample(
+  u32 y, u32 x, Sample sample, u8 players, u8 missiles, n1 specialBit
+) -> void {
+  if(y >= Timing::ScanlinesPerFrame || x >= Timing::SamplesPerScanline) return;
+
+  auto mode = priority.mode();
+  auto phase = x & 3;
+  if(phase == 0) {
+    if(playfield.special.y != y) playfield.special.mode10Previous = 0;
+    playfield.special.y = y;
+    playfield.special.x = x;
+  }
+  playfield.special.sample[phase] = sample;
+  playfield.special.players[phase] = players;
+  playfield.special.missiles[phase] = missiles;
+  playfield.special.bit[phase] = specialBit;
+
+  if(mode) {
+    if(phase != 3) return;
+
+    u8 value = 0;
+    for(u32 index = 0; index < 4; index++) {
+      value = value << 1 | playfield.special.bit[index];
+    }
+    bool lowResolutionBAKMute = mode == 2
+      && (u8)playfield.special.sample[0].an >= 1
+      && (u8)playfield.special.sample[0].an <= 4
+      && (u8)playfield.special.sample[2].an == 0
+      && (u8)playfield.special.sample[3].an == 0;
+    if(lowResolutionBAKMute) value = 8;
+    for(u32 index = 0; index < 4; index++) {
+      // Mode 10 delays playfield identity by one color clock: the first half
+      // uses the previous nibble and the second half uses the current nibble.
+      // In low-resolution modes, BAK on the second color clock mutes both halves.
+      auto delayed = mode == 2 && index < 2 && !lowResolutionBAKMute
+        ? (u8)playfield.special.mode10Previous : value;
+      auto color = resolve(playfield.special.sample[index], delayed,
+        playfield.special.players[index], playfield.special.missiles[index]);
+      if(screen) {
+        screen->pixels().data()[
+          playfield.special.y * Timing::SamplesPerScanline + playfield.special.x + index
+        ] = color;
+      }
+    }
+    if(mode == 2) playfield.special.mode10Previous = value;
+    return;
+  }
+
+  auto color = resolve(sample, 0xff, players, missiles);
+  if(screen) screen->pixels().data()[y * Timing::SamplesPerScanline + x] = color;
+}
+
+auto GTIA::resolve(Sample sample, u8 special, u8 players, u8 missiles) -> n8 {
+  n8 playerColors[4];
+  n8 playfieldColors[4];
+  for(u32 index = 0; index < 4; index++) {
+    playerColors[index] = colors.player(index);
+    playfieldColors[index] = colors.playfield(index);
+  }
+  auto backgroundColor = (u8)colors.background();
+
+  if(sample.vsync) return 0;
+  if(sample.hblank) {
+    return backgroundColor;
+  }
+
+  auto mode = priority.mode();
+  auto playfieldSignals = playfield.signals(sample, special, mode);
+  collision.clock(playfieldSignals.collision, players, missiles);
+
+  players |= playfieldSignals.specialPlayers;
+  bool fifthPlayer = priority.fifthPlayer();
+  if(fifthPlayer) playfieldSignals.playfields |= missiles ? 1 << 3 : 0;
+  else players |= missiles;
+
+  n8 sourceColors[4] = {
+    playfieldColors[0],
+    playfieldColors[1],
+    playfieldColors[2],
+    playfieldColors[3],
+  };
+  if(special != 0xff) {
+    if(mode == 1) {
+      backgroundColor |= special;
+      sourceColors[3] = (u8)playfieldColors[3] | special;
+    }
+    if(mode == 2) {
+      if((special >= 4 && special <= 7) || special >= 12) {
+        sourceColors[special & 3] = playfieldColors[special & 3];
+      }
+    }
+    if(mode == 3) {
+      backgroundColor = special ? (special << 4 | backgroundColor) : (backgroundColor & 0xf0);
+      sourceColors[3] = special
+        ? (special << 4 | (u8)playfieldColors[3])
+        : ((u8)playfieldColors[3] & 0xf0);
+    }
+  }
+
+  auto signals = priority.signals(players, playfieldSignals.playfields);
+  // P5 normally enters the PF3 path, but its raw signal also suppresses the
+  // other playfields. This creates the documented PRIOR=%1000 three-way case:
+  // PF0/1 suppress the players and P5 then suppresses PF0/1.
+  if(fifthPlayer && missiles && (playfieldSignals.playfields & 0x03) && players
+  && priority.rule() == 0x08) {
+    signals = {0, 0x08, false};
+  }
+  n8 color = 0;
+  if(signals.background) color = backgroundColor;
+  for(u32 index = 0; index < 4; index++) {
+    if(signals.players >> index & 1) color = (u8)color | (u8)playerColors[index];
+    if(signals.playfields >> index & 1) color = (u8)color | (u8)sourceColors[index];
+  }
+
+  // High-resolution data bypasses priority and impresses PF1 luminance onto
+  // the selected source, including players, missiles, and the fifth player.
+  if(!mode && (u8)sample.an == 6) {
+    color = ((u8)color & 0xf0) | ((u8)playfieldColors[1] & 0x0f);
+  }
+
+  return color;
+}

--- a/ares/a52/pokey/audio.cpp
+++ b/ares/a52/pokey/audio.cpp
@@ -1,0 +1,262 @@
+auto POKEY::Audio::power() -> void {
+  for(auto& item : channel) {
+    item = {};
+    item.filterLatch = 1;
+  }
+  control = 0;
+  timersRunning = 0;
+  startDelay = 0;
+  twoToneResyncPipeline = 0;
+  reloadTimers();
+  timersRunning = 0;
+}
+
+auto POKEY::Audio::clockFilters() -> void {
+  for(u32 index = 0; index < 2; index++) {
+    auto& item = channel[index];
+    if(!item.filterDelay || --item.filterDelay) continue;
+    item.filterLatch = item.filterSample;
+  }
+}
+
+auto POKEY::Audio::clockTimers(const Clock::Pulses& pulses, const Clock& clock,
+  bool holdTimer34) -> TimerEdges {
+  auto pipelineEvents = advanceTimerPipelines(clock, holdTimer34);
+  auto channelEvents = pipelineEvents.channels;
+  auto reloadedChannels = pipelineEvents.reloads;
+  bool timersReloaded = false;
+  if(startDelay && !--startDelay) {
+    reloadTimers();
+    timersReloaded = true;
+  }
+
+  for(u32 index = 0; index < 4; index++) {
+    if(holdTimer34 && index >= 2) continue;
+    auto fastClock = channelUsesFastClock(index);
+    auto channelClock = fastClock || (control.bit(0) ? pulses.clock15 : pulses.clock64);
+    if(timersReloaded || (reloadedChannels & 1 << index) || !channelClock) continue;
+    if(clockTimerCounter(index, clock)) channelEvents |= 1 << index;
+  }
+
+  advanceTwoToneResynchronization();
+  return {
+    .timer1 = (channelEvents & 1 << 0) != 0,
+    .timer2 = (channelEvents & 1 << 1) != 0,
+    .timer4 = (channelEvents & 1 << 3) != 0,
+  };
+}
+
+auto POKEY::Audio::writeFrequency(u32 index, n8 data) -> void {
+  channel[index].frequency = data;
+}
+
+auto POKEY::Audio::writeControl(u32 index, n8 data) -> void {
+  channel[index].control = data;
+}
+
+auto POKEY::Audio::writeAUDCTL(n8 data) -> void {
+  control = data;
+  if(!control.bit(2)) {
+    channel[0].filterLatch = 1;
+    channel[0].filterDelay = 0;
+  }
+  if(!control.bit(1)) {
+    channel[1].filterLatch = 1;
+    channel[1].filterDelay = 0;
+  }
+}
+
+auto POKEY::Audio::startTimers() -> void {
+  timersRunning = 1;
+  startDelay = 3;
+}
+
+auto POKEY::Audio::scheduleTwoToneResynchronization(u32 timerEvents) -> void {
+  bool delayed = ((timerEvents & 1 << 0) && channelUsesFastClock(0))
+    || ((timerEvents & 1 << 1) && channelUsesFastClock(1));
+  if(!delayed) {
+    resynchronizeTimer12();
+    return;
+  }
+  twoToneResyncPipeline |= 1 << 1;
+}
+
+auto POKEY::Audio::channelPeriod(u32 index) const -> u32 {
+  if(index == 0 && control.bit(6)) return (u8)channel[0].frequency + 4;
+  if(index == 2 && control.bit(5)) return (u8)channel[2].frequency + 4;
+  return (u8)channel[index].frequency + 1;
+}
+
+auto POKEY::Audio::channelIsJoined(u32 index) const -> bool {
+  return control.bit(index < 2 ? 4 : 3);
+}
+
+auto POKEY::Audio::channelIsJoinedHigh(u32 index) const -> bool {
+  return channelIsJoined(index) && (index & 1);
+}
+
+auto POKEY::Audio::channelUsesFastClock(u32 index) const -> bool {
+  return (index == 0 && control.bit(6))
+    || (index == 1 && control.bit(4) && control.bit(6))
+    || (index == 2 && control.bit(5))
+    || (index == 3 && control.bit(3) && control.bit(5));
+}
+
+auto POKEY::Audio::clockTimerCounter(u32 index, const Clock& clock) -> bool {
+  if(channelIsJoinedHigh(index)) return false;
+
+  auto& item = channel[index];
+  auto fastClock = channelUsesFastClock(index);
+  auto joined = channelIsJoined(index);
+  if(fastClock && joined) {
+    if(item.counter && --item.counter) return false;
+    item.counter = 256;
+    clockChannel(index, clock);
+    return true;
+  }
+
+  if(item.eventDelay || item.reloadDelay) return false;
+  if(item.counter && --item.counter) return false;
+
+  if(fastClock) {
+    item.eventDelay = 4;
+    item.reloadDelay = 3;
+    return false;
+  }
+
+  item.counter = joined ? 256 : 0;
+  item.eventDelay = 5;
+  if(!joined) item.reloadDelay = 3;
+  return false;
+}
+
+auto POKEY::Audio::advanceTimerPipelines(const Clock& clock, bool holdTimer34) -> PipelineEvents {
+  u32 events = 0;
+  u32 reloads = 0;
+  for(u32 index = 0; index < 4; index++) {
+    if(holdTimer34 && index >= 2) continue;
+    auto& item = channel[index];
+    if(item.eventDelay && !--item.eventDelay) events |= 1 << index;
+    if(item.reloadDelay && !--item.reloadDelay) reloads |= 1 << index;
+  }
+  for(u32 index = 0; index < 4; index++) {
+    if(events & 1 << index) clockChannel(index, clock);
+  }
+  for(u32 index = 0; index < 4; index++) {
+    if(!(reloads & 1 << index)) continue;
+    channel[index].counter = (u8)channel[index].frequency + 1;
+  }
+  return {.channels = events, .reloads = reloads};
+}
+
+auto POKEY::Audio::advanceTwoToneResynchronization() -> void {
+  if(twoToneResyncPipeline.bit(0)) resynchronizeTimer12();
+  twoToneResyncPipeline >>= 1;
+}
+
+auto POKEY::Audio::resynchronizeTimer(u32 index) -> void {
+  auto joined = channelIsJoined(index);
+  if(channelUsesFastClock(index) && !joined) {
+    channel[index].counter = (u8)channel[index].frequency + 1;
+    channel[index].eventDelay = 4;
+    channel[index].reloadDelay = 3;
+    return;
+  }
+  channel[index].counter = channelPeriod(index);
+  channel[index].eventDelay = 0;
+  channel[index].reloadDelay = 0;
+}
+
+auto POKEY::Audio::resynchronizeTimer12() -> void {
+  resynchronizeTimer(0);
+  resynchronizeTimer(1);
+}
+
+auto POKEY::Audio::resetSerialTimer34() -> void {
+  for(u32 index = 2; index < 4; index++) {
+    channel[index].counter = channelIsJoinedHigh(index) ? (u8)channel[index].frequency + 1 : channelPeriod(index);
+    channel[index].eventDelay = 0;
+    channel[index].reloadDelay = 0;
+  }
+}
+
+auto POKEY::Audio::clockChannel(u32 index, const Clock& clock) -> void {
+  clockChannelSource(index, clock);
+  sampleChannelFilters(index);
+  requestChannelIRQ(index);
+  clockJoinedCounters(index);
+}
+
+auto POKEY::Audio::clockChannelSource(u32 index, const Clock& clock) -> void {
+  auto& item = channel[index];
+  auto gate = item.control.bit(7) || clock.sample5(index);
+  if(gate) {
+    if(item.control.bit(5)) item.output ^= 1;
+    else if(item.control.bit(6)) item.output = clock.sample4(index);
+    else if(control.bit(7)) item.output = clock.sample9(index);
+    else item.output = clock.sample17(index);
+  }
+}
+
+auto POKEY::Audio::sampleChannelFilters(u32 index) -> void {
+  if(index == 2 && control.bit(2)) {
+    channel[0].filterSample = channel[0].output;
+    channel[0].filterDelay = 2;
+  }
+  if(index == 3 && control.bit(1)) {
+    channel[1].filterSample = channel[1].output;
+    channel[1].filterDelay = 2;
+  }
+}
+
+auto POKEY::Audio::requestChannelIRQ(u32 index) -> void {
+  if(timersRunning) {
+    if(index == 0 && !channelIsJoined(index)) self.irq.request(IRQ::Timer1);
+    if(index == 1) self.irq.request(IRQ::Timer2);
+    if(index == 3) self.irq.request(IRQ::Timer4);
+  }
+}
+
+auto POKEY::Audio::clockJoinedCounters(u32 index) -> void {
+  if(index == 0 && channelIsJoined(index)) {
+    if(channel[1].counter && !--channel[1].counter) channel[1].eventDelay = 3;
+  }
+  if(index == 2 && channelIsJoined(index)) {
+    if(channel[3].counter && !--channel[3].counter) channel[3].eventDelay = 3;
+  }
+  if(index == 1 && channelIsJoined(index)) {
+    channel[0].counter = channelPeriod(0);
+    channel[1].counter = (u8)channel[1].frequency + 1;
+  }
+  if(index == 3 && channelIsJoined(index)) {
+    channel[2].counter = channelPeriod(2);
+    channel[3].counter = (u8)channel[3].frequency + 1;
+  }
+}
+
+auto POKEY::Audio::reloadTimers() -> void {
+  for(u32 index = 0; index < 4; index++) {
+    auto joined = channelIsJoined(index);
+    auto joinedHigh = channelIsJoinedHigh(index);
+    if(joinedHigh || (channelUsesFastClock(index) && !joined)) {
+      channel[index].counter = (u8)channel[index].frequency + 1;
+    } else {
+      channel[index].counter = channelPeriod(index);
+    }
+    channel[index].eventDelay = 0;
+    channel[index].reloadDelay = 0;
+    channel[index].output = 1;
+  }
+}
+
+auto POKEY::Audio::levels() const -> Levels {
+  Levels levels;
+  for(u32 index = 0; index < 4; index++) {
+    auto& source = channel[index];
+    auto waveform = (bool)source.output;
+    if(index < 2) waveform ^= source.filterLatch;
+    auto active = source.control.bit(4) || waveform;
+    levels.channel[index] = active ? (u8)source.control & 15 : 0;
+  }
+  return levels;
+}

--- a/ares/a52/pokey/clock.cpp
+++ b/ares/a52/pokey/clock.cpp
@@ -1,0 +1,72 @@
+auto POKEY::Clock::power() -> void {
+  reset();
+}
+
+auto POKEY::Clock::reset() -> void {
+  prescaler64 = 19;
+  prescaler15 = 78;
+  polynomial4 = 0x0f;
+  polynomial5 = 0x1f;
+  polynomial9 = 0x1ff;
+  polynomial17 = 0x1ffff;
+  polynomial4History = 0;
+  polynomial5History = 15;
+  polynomial9History = 0;
+  polynomial17History = 0;
+}
+
+auto POKEY::Clock::clock(bool enabled) -> Pulses {
+  if(!enabled) {
+    reset();
+    return {};
+  }
+
+  advance();
+
+  Pulses pulses = {};
+  if(!--prescaler64) {
+    prescaler64 = 28;
+    pulses.clock64 = true;
+  }
+  if(!--prescaler15) {
+    prescaler15 = 114;
+    pulses.clock15 = true;
+  }
+  return pulses;
+}
+
+auto POKEY::Clock::random(bool usePolynomial9) const -> u8 {
+  return usePolynomial9 ? polynomial9 >> 1 : polynomial17 >> 9;
+}
+
+auto POKEY::Clock::sample4(u32 phase) const -> bool {
+  return polynomial4History >> phase & 1;
+}
+
+auto POKEY::Clock::sample5(u32 phase) const -> bool {
+  return polynomial5History >> phase & 1;
+}
+
+auto POKEY::Clock::sample9(u32 phase) const -> bool {
+  return polynomial9History >> phase & 1;
+}
+
+auto POKEY::Clock::sample17(u32 phase) const -> bool {
+  return polynomial17History >> phase & 1;
+}
+
+auto POKEY::Clock::advance() -> void {
+  auto shift = [](u32 value, u32 bits, u32 tap) -> u32 {
+    auto feedback = (value ^ (value >> tap)) & 1;
+    return value >> 1 | feedback << (bits - 1);
+  };
+
+  polynomial4 = shift(polynomial4, 4, 1);
+  polynomial5 = shift(polynomial5, 5, 2);
+  polynomial9 = shift(polynomial9, 9, 5);
+  polynomial17 = shift(polynomial17, 17, 5);
+  polynomial4History = polynomial4History << 1 | !(polynomial4 & 1);
+  polynomial5History = polynomial5History << 1 | (polynomial5 & 1);
+  polynomial9History = polynomial9History << 1 | !(polynomial9 & 1);
+  polynomial17History = polynomial17History << 1 | !(polynomial17 & 1);
+}

--- a/ares/a52/pokey/dac.cpp
+++ b/ares/a52/pokey/dac.cpp
@@ -1,0 +1,45 @@
+auto POKEY::output() const -> f64 {
+  // Altirra 4.40 fits these weights and the curve below to measurements of a
+  // POKEY output path. The measured machine is not identified as an Atari 5200,
+  // so this remains a provisional chip-level model until pin 37 is measured on
+  // an identified console.
+  // Sources: src/ATAudio/source/pokey.cpp, UpdateMixTable(), and
+  // src/ATAudio/source/pokeyrenderer.cpp, kVolMixLookup.
+  static constexpr u16 VolumeIndex[16] = {
+     0,  1,  5,  6,
+    25, 26, 30, 31,
+    50, 51, 55, 56,
+    75, 76, 80, 81,
+  };
+
+  struct MixTable {
+    f64 output[325];
+
+    MixTable() {
+      static constexpr f64 Bit0 = 0.12 / 8.24;
+      static constexpr f64 Bit1 = 0.26 / 8.24;
+      static constexpr f64 Bit2 = 0.56 / 8.24;
+      static constexpr f64 Threshold = 0.14;
+      static constexpr f64 Slope = 2.1;
+      static constexpr f64 Curve = 2.85;
+
+      u32 index = 0;
+      for(u32 bit23 = 0; bit23 < 13; bit23++) {
+        for(u32 bit1 = 0; bit1 < 5; bit1++) {
+          for(u32 bit0 = 0; bit0 < 5; bit0++) {
+            f64 input = bit23 * Bit2 + bit1 * Bit1 + bit0 * Bit0;
+            output[index++] = input < Threshold
+              ? -Slope * input
+              : -Slope * (Threshold + (1.0 - exp(-Curve * (input - Threshold))) / Curve);
+          }
+        }
+      }
+    }
+  };
+  static const MixTable table;
+
+  auto levels = audio.levels();
+  u32 index = 0;
+  for(auto level : levels.channel) index += VolumeIndex[level];
+  return table.output[index];
+}

--- a/ares/a52/pokey/io.cpp
+++ b/ares/a52/pokey/io.cpp
@@ -1,0 +1,87 @@
+auto POKEY::read(n8 address) -> n8 {
+  return peek(address);
+}
+
+auto POKEY::peek(n8 address) const -> n8 {
+  address &= 0x0f;
+  if(address <= 0x07) return pots.read(address);
+  if(address == 0x08) return pots.all();
+  if(address == 0x09) return keyboard.code();
+  if(address == 0x0a) {
+    if(!(control & 3)) return 0xff;
+    return clock.random(audio.control.bit(7));
+  }
+  if(address == 0x0d) return serial.input();
+  if(address == 0x0e) return irq.status();
+  if(address == 0x0f) return status.read();
+  return 0xff;
+}
+
+auto POKEY::write(n8 address, n8 data) -> void {
+  address &= 0x0f;
+  switch(address) {
+  case 0x00:
+  case 0x02:
+  case 0x04:
+  case 0x06:
+    return audio.writeFrequency(address >> 1, data);
+  case 0x01:
+  case 0x03:
+  case 0x05:
+  case 0x07:
+    return audio.writeControl(address >> 1, data);
+  case 0x08:
+    return audio.writeAUDCTL(data);
+  case 0x09:
+    return audio.startTimers();
+  case 0x0a:
+    return status.resetErrors();
+  case 0x0b:
+    return startPots();
+  case 0x0c:  //unused write register
+    return;
+  case 0x0d:
+    serial.write(data);
+    setIRQ();
+    return;
+  case 0x0e:
+    irq.writeEnable(data);
+    setIRQ();
+    return;
+  case 0x0f:
+    return writeSKCTL(data);
+  }
+}
+
+auto POKEY::writeSKCTL(n8 data) -> void {
+  control = data;
+  serial.configure();
+  if(control & 3) return;
+  irq.writeEnable(0);
+  status.resetErrors();
+  keyboard.disable();
+  serial.reset();
+  clock.reset();
+  setIRQ();
+}
+
+auto POKEY::startPots() -> void {
+  n8 targets[8];
+  for(u32 index = 0; index < 8; index++) {
+    auto& port = controllerPorts[index >> 1];
+    auto powered = gtia.controllerPower();
+    if(!port.connected()) {
+      targets[index] = powered ? 0xff : Pots::Maximum;
+      continue;
+    }
+    auto value = (s32)port.axis(index & 1, powered);
+    auto normalized = (u32)(value + 32768);
+    auto maximum = powered ? Pots::Maximum - 1 : Pots::Maximum;
+    targets[index] = (normalized * maximum + 32767u) / 65535u;
+  }
+  pots.start(targets);
+}
+
+auto POKEY::setIRQ() -> void {
+  cpu.irqLine(irq.line());
+}

--- a/ares/a52/pokey/irq.cpp
+++ b/ares/a52/pokey/irq.cpp
@@ -1,0 +1,58 @@
+auto POKEY::IRQ::power() -> void {
+  enable = 0;
+  statusValue = 0xff;
+  for(auto& age : enabledAge) age = 0;
+  for(auto& age : disabledAge) age = 2;
+}
+
+auto POKEY::IRQ::clock() -> void {
+  for(u32 source = 0; source < 3; source++) {
+    if(enable.bit(source)) {
+      enabledAge[source] = std::min(4u, enabledAge[source] + 1);
+    } else {
+      disabledAge[source] = std::min(2u, disabledAge[source] + 1);
+    }
+  }
+}
+
+auto POKEY::IRQ::request(Source source) -> void {
+  auto index = (u32)source;
+  if(index < 3) {
+    if(enable.bit(index)) {
+      if(enabledAge[index] < 4) return;
+    } else {
+      if(disabledAge[index] >= 2) return;
+    }
+  } else if(source != SerialComplete && !enable.bit(index)) {
+    return;
+  }
+  statusValue &= ~(1 << index);
+}
+
+auto POKEY::IRQ::acknowledge(Source source) -> void {
+  statusValue |= 1 << (u32)source;
+}
+
+auto POKEY::IRQ::pending(Source source) const -> bool {
+  return !statusValue.bit((u32)source);
+}
+
+auto POKEY::IRQ::writeEnable(n8 data) -> void {
+  bool serialComplete = statusValue.bit(3);
+  for(u32 source = 0; source < 3; source++) {
+    if(enable.bit(source) == data.bit(source)) continue;
+    if(data.bit(source)) enabledAge[source] = 0;
+    else disabledAge[source] = 0;
+  }
+  enable = data;
+  statusValue |= ~data;
+  statusValue.bit(3) = serialComplete;
+}
+
+auto POKEY::IRQ::status() const -> n8 {
+  return statusValue;
+}
+
+auto POKEY::IRQ::line() const -> bool {
+  return ((u8)~statusValue & (u8)enable) != 0;
+}

--- a/ares/a52/pokey/keyboard.cpp
+++ b/ares/a52/pokey/keyboard.cpp
@@ -1,0 +1,77 @@
+auto POKEY::Keyboard::power() -> void {
+  codeValue = 0xff;
+  scanCounter = 0;
+  compareValue = 0;
+  state = State::Released;
+  shiftLatch = 0;
+  controlLatch = 0;
+  breakLatch = 0;
+}
+
+auto POKEY::Keyboard::disable() -> void {
+  self.status.setKeyboardDown(false);
+  scanCounter = 0;
+  compareValue = 0;
+  state = State::Released;
+}
+
+auto POKEY::Keyboard::clock(bool debounce) -> void {
+  scanCounter++;
+  auto lines = self.sampleKeyboard(scanCounter);
+
+  if(scanCounter == 0x00) {
+    shiftLatch = lines.kr2;
+    self.status.setShift(shiftLatch);
+  }
+  if(scanCounter == 0x10) controlLatch = lines.kr2;
+  if(scanCounter == 0x30) {
+    if(lines.kr2 && !breakLatch) self.irq.request(IRQ::Break);
+    breakLatch = lines.kr2;
+  }
+
+  auto matches = !debounce || scanCounter == compareValue;
+  switch(state) {
+  case State::Released:
+    if(lines.kr1) {
+      compareValue = scanCounter;
+      state = State::DebouncePress;
+    }
+    return;
+
+  case State::DebouncePress:
+    if(!matches) {
+      if(lines.kr1) state = State::Released;
+      return;
+    }
+    if(lines.kr1) {
+      if(self.irq.pending(IRQ::Keyboard)) self.status.setKeyboardOverrun();
+      codeValue = debounce ? compareValue : scanCounter;
+      codeValue.bit(6) = shiftLatch;
+      codeValue.bit(7) = controlLatch;
+      self.status.setKeyboardDown(true);
+      self.irq.request(IRQ::Keyboard);
+      state = State::Pressed;
+    } else {
+      state = State::Released;
+    }
+    return;
+
+  case State::Pressed:
+    if(matches && !lines.kr1) state = State::DebounceRelease;
+    return;
+
+  case State::DebounceRelease:
+    if(!matches) return;
+    if(lines.kr1) {
+      state = State::Pressed;
+    } else {
+      self.status.setKeyboardDown(false);
+      state = State::Released;
+    }
+    return;
+  }
+}
+
+auto POKEY::Keyboard::code() const -> n8 {
+  return codeValue;
+}

--- a/ares/a52/pokey/output.cpp
+++ b/ares/a52/pokey/output.cpp
@@ -1,0 +1,12 @@
+auto POKEY::powerOutput() -> void {
+  auto frequency = system.frequency() / Timing::ColorClocksPerMachineCycle;
+  outputDecay = exp(-1.0 / (frequency * OutputTimeConstant));
+  previousInput = 0.0;
+  coupledOutput = 0.0;
+}
+
+auto POKEY::clockOutput(f64 input) -> void {
+  coupledOutput = coupledOutput * outputDecay + input - previousInput;
+  previousInput = input;
+  stream->frame(coupledOutput);
+}

--- a/ares/a52/pokey/pokey.cpp
+++ b/ares/a52/pokey/pokey.cpp
@@ -1,0 +1,29 @@
+#include <a52/a52.hpp>
+
+namespace ares::Atari5200 {
+
+POKEY pokey;
+
+auto POKEY::load(Node::Object parent) -> void {
+  node = parent->append<Node::Object>("POKEY");
+}
+
+auto POKEY::unload() -> void {
+  node = {};
+}
+
+auto POKEY::power() -> void {
+}
+
+auto POKEY::read(n8 address) -> n8 {
+  return peek(address);
+}
+
+auto POKEY::peek(n8 address) const -> n8 {
+  return 0xff;
+}
+
+auto POKEY::write(n8 address, n8 data) -> void {
+}
+
+}

--- a/ares/a52/pokey/pokey.cpp
+++ b/ares/a52/pokey/pokey.cpp
@@ -14,6 +14,7 @@ POKEY pokey;
 #include "serial.cpp"
 #include "output.cpp"
 #include "io.cpp"
+#include "serialization.cpp"
 
 auto POKEY::load(Node::Object parent) -> void {
   node = parent->append<Node::Object>("POKEY");

--- a/ares/a52/pokey/pokey.cpp
+++ b/ares/a52/pokey/pokey.cpp
@@ -4,26 +4,84 @@ namespace ares::Atari5200 {
 
 POKEY pokey;
 
+#include "clock.cpp"
+#include "audio.cpp"
+#include "dac.cpp"
+#include "irq.cpp"
+#include "pots.cpp"
+#include "status.cpp"
+#include "keyboard.cpp"
+#include "serial.cpp"
+#include "output.cpp"
+#include "io.cpp"
+
 auto POKEY::load(Node::Object parent) -> void {
   node = parent->append<Node::Object>("POKEY");
+  stream = node->append<Node::Audio::Stream>("Audio");
+  stream->setChannels(1);
+  stream->setFrequency(system.frequency() / Timing::ColorClocksPerMachineCycle);
 }
 
 auto POKEY::unload() -> void {
+  Thread::destroy();
+  if(node && stream) node->remove(stream);
+  stream.reset();
   node = {};
 }
 
+auto POKEY::main() -> void {
+  audio.clockFilters();
+  irq.clock();
+
+  auto pulses = clock.clock(control & 3);
+  auto timerEdges = audio.clockTimers(pulses, clock, serial.holdsTimer34());
+
+  if(control.bit(2)) pots.clockFast();
+  else if(pulses.clock15) pots.clock15();
+  clockKeyboard(pulses.clock15);
+  serial.clock(timerEdges, serialInput);
+  setIRQ();
+
+  clockOutput(output());
+  step();
+}
+
+auto POKEY::step(u32 clocks) -> void {
+  Thread::step(clocks);
+  Thread::synchronize(cpu);
+}
+
 auto POKEY::power() -> void {
+  Thread::create(system.frequency() / Timing::ColorClocksPerMachineCycle, std::bind_front(&POKEY::main, this));
+
+  audio.power();
+  clock.power();
+  irq.power();
+  pots.power();
+  status.power();
+  keyboard.power();
+  serial.power();
+  powerOutput();
+  control = 0;
+  setIRQ();
 }
 
-auto POKEY::read(n8 address) -> n8 {
-  return peek(address);
+auto POKEY::sampleKeyboard(n6 scanAddress) -> KeyboardLines {
+  auto& controller = controllerPorts[gtia.controllerSelect()];
+  n4 code = scanAddress >> 1;
+  return {
+    .kr1 = code && controller.keypad(code),
+    .kr2 = controller.topFire(),
+  };
 }
 
-auto POKEY::peek(n8 address) const -> n8 {
-  return 0xff;
-}
-
-auto POKEY::write(n8 address, n8 data) -> void {
+auto POKEY::clockKeyboard(bool clock15) -> void {
+  if(!control.bit(1)) {
+    keyboard.disable();
+    return;
+  }
+  if(!clock15) return;
+  keyboard.clock(control.bit(0));
 }
 
 }

--- a/ares/a52/pokey/pokey.hpp
+++ b/ares/a52/pokey/pokey.hpp
@@ -16,6 +16,9 @@ struct POKEY : Thread {
   //dac.cpp
   auto output() const -> f64;
 
+  //serialization.cpp
+  auto serialize(serializer&) -> void;
+
 //private:
   struct KeyboardLines {
     n1 kr1;
@@ -67,6 +70,9 @@ struct POKEY : Thread {
     auto sample9(u32 phase) const -> bool;
     auto sample17(u32 phase) const -> bool;
 
+    //serialization.cpp
+    auto serialize(serializer&) -> void;
+
   private:
     friend struct POKEY;
 
@@ -111,6 +117,9 @@ struct POKEY : Thread {
     auto resetSerialTimer34() -> void;
     auto scheduleTwoToneResynchronization(u32 timerEvents) -> void;
     auto levels() const -> Levels;
+
+    //serialization.cpp
+    auto serialize(serializer&) -> void;
 
   private:
     friend struct POKEY;
@@ -177,6 +186,9 @@ struct POKEY : Thread {
     auto status() const -> n8;
     auto line() const -> bool;
 
+    //serialization.cpp
+    auto serialize(serializer&) -> void;
+
   private:
     friend struct POKEY;
 
@@ -194,6 +206,9 @@ struct POKEY : Thread {
     auto clock15() -> void;
     auto read(u32 index) const -> n8;
     auto all() const -> n8;
+
+    //serialization.cpp
+    auto serialize(serializer&) -> void;
 
   private:
     friend struct POKEY;
@@ -226,6 +241,9 @@ struct POKEY : Thread {
     auto setSerialFrameError() -> void;
     auto read() const -> n8;
 
+    //serialization.cpp
+    auto serialize(serializer&) -> void;
+
   private:
     friend struct POKEY;
 
@@ -241,6 +259,9 @@ struct POKEY : Thread {
     auto disable() -> void;
     auto clock(bool debounce) -> void;
     auto code() const -> n8;
+
+    //serialization.cpp
+    auto serialize(serializer&) -> void;
 
   private:
     friend struct POKEY;
@@ -273,6 +294,9 @@ struct POKEY : Thread {
     auto reset() -> void;
     auto input() const -> n8;
     auto holdsTimer34() const -> bool;
+
+    //serialization.cpp
+    auto serialize(serializer&) -> void;
 
   //private:
     friend struct POKEY;

--- a/ares/a52/pokey/pokey.hpp
+++ b/ares/a52/pokey/pokey.hpp
@@ -1,0 +1,14 @@
+struct POKEY {
+  Node::Object node;
+
+  auto load(Node::Object parent) -> void;
+  auto unload() -> void;
+  auto power() -> void;
+
+  auto read(n8 address) -> n8;
+  auto peek(n8 address) const -> n8;
+  auto write(n8 address, n8 data) -> void;
+
+};
+
+extern POKEY pokey;

--- a/ares/a52/pokey/pokey.hpp
+++ b/ares/a52/pokey/pokey.hpp
@@ -1,14 +1,317 @@
-struct POKEY {
+struct POKEY : Thread {
   Node::Object node;
 
+  //pokey.cpp
   auto load(Node::Object parent) -> void;
   auto unload() -> void;
+  auto main() -> void;
+  auto step(u32 clocks = 1) -> void;
   auto power() -> void;
 
+  //io.cpp
   auto read(n8 address) -> n8;
   auto peek(n8 address) const -> n8;
   auto write(n8 address, n8 data) -> void;
 
+  //dac.cpp
+  auto output() const -> f64;
+
+//private:
+  struct KeyboardLines {
+    n1 kr1;
+    n1 kr2;
+  };
+
+  struct SerialInput {
+    n1 data;
+    n1 clock;
+  };
+
+  //pokey.cpp
+  auto sampleKeyboard(n6 scanAddress) -> KeyboardLines;
+  auto clockKeyboard(bool clock15) -> void;
+
+  //output.cpp
+  auto powerOutput() -> void;
+  auto clockOutput(f64 input) -> void;
+
+  //io.cpp
+  auto setIRQ() -> void;
+  auto startPots() -> void;
+  auto writeSKCTL(n8 data) -> void;
+
+  Node::Audio::Stream stream;
+  f64 outputDecay;
+  f64 previousInput;
+  f64 coupledOutput;
+
+  // Altirra measured a 1.8 ms half-decay on Atari 8-bit hardware, equivalent
+  // to this time constant. The Atari 5200 uses the same POKEY and a comparable
+  // AC-coupled output path, so this is a provisional cross-machine parameter
+  // until the post-coupling node is measured on an identified A5200 board.
+  // Source: Altirra 4.40, src/ATAudio/source/pokey.cpp, UpdateMixTable().
+  static constexpr f64 OutputTimeConstant = 0.002596851073600134;
+
+  struct Clock {
+    struct Pulses {
+      bool clock64;
+      bool clock15;
+    };
+
+    //clock.cpp
+    auto power() -> void;
+    auto clock(bool enabled) -> Pulses;
+    auto random(bool usePolynomial9) const -> u8;
+    auto sample4(u32 phase) const -> bool;
+    auto sample5(u32 phase) const -> bool;
+    auto sample9(u32 phase) const -> bool;
+    auto sample17(u32 phase) const -> bool;
+
+  private:
+    friend struct POKEY;
+
+    //clock.cpp
+    auto reset() -> void;
+    auto advance() -> void;
+
+    u32 prescaler64;
+    u32 prescaler15;
+    u32 polynomial4;
+    u32 polynomial5;
+    u32 polynomial9;
+    u32 polynomial17;
+    u32 polynomial4History;
+    u32 polynomial5History;
+    u32 polynomial9History;
+    u32 polynomial17History;
+  } clock;
+
+  struct Audio {
+    POKEY& self;
+    Audio(POKEY& self) : self(self) {}
+
+    struct Levels {
+      n4 channel[4];
+    };
+
+    struct TimerEdges {
+      n1 timer1;
+      n1 timer2;
+      n1 timer4;
+    };
+
+    //audio.cpp
+    auto power() -> void;
+    auto clockFilters() -> void;
+    auto clockTimers(const Clock::Pulses&, const Clock&, bool holdTimer34) -> TimerEdges;
+    auto writeFrequency(u32 channel, n8 data) -> void;
+    auto writeControl(u32 channel, n8 data) -> void;
+    auto writeAUDCTL(n8 data) -> void;
+    auto startTimers() -> void;
+    auto resetSerialTimer34() -> void;
+    auto scheduleTwoToneResynchronization(u32 timerEvents) -> void;
+    auto levels() const -> Levels;
+
+  private:
+    friend struct POKEY;
+
+    struct PipelineEvents {
+      u32 channels;
+      u32 reloads;
+    };
+
+    struct Channel {
+      n8 frequency;
+      n8 control;
+      u32 counter;
+      u32 eventDelay;
+      u32 reloadDelay;
+      n1 output;
+      n1 filterLatch;
+      n1 filterSample;
+      u32 filterDelay;
+    } channel[4];
+
+    //audio.cpp
+    auto channelPeriod(u32 index) const -> u32;
+    auto channelIsJoined(u32 index) const -> bool;
+    auto channelIsJoinedHigh(u32 index) const -> bool;
+    auto channelUsesFastClock(u32 index) const -> bool;
+    auto clockTimerCounter(u32 index, const Clock&) -> bool;
+    auto clockChannel(u32 index, const Clock&) -> void;
+    auto clockChannelSource(u32 index, const Clock&) -> void;
+    auto sampleChannelFilters(u32 index) -> void;
+    auto requestChannelIRQ(u32 index) -> void;
+    auto clockJoinedCounters(u32 index) -> void;
+    auto advanceTimerPipelines(const Clock&, bool holdTimer34) -> PipelineEvents;
+    auto advanceTwoToneResynchronization() -> void;
+    auto resynchronizeTimer(u32 index) -> void;
+    auto resynchronizeTimer12() -> void;
+    auto reloadTimers() -> void;
+
+    n8 control;
+    n1 timersRunning;
+    u32 startDelay;
+    n8 twoToneResyncPipeline;
+  } audio{*this};
+
+  struct IRQ {
+    enum Source : u32 {
+      Timer1,
+      Timer2,
+      Timer4,
+      SerialComplete,
+      SerialOutput,
+      SerialInput,
+      Keyboard,
+      Break,
+    };
+
+    //irq.cpp
+    auto power() -> void;
+    auto clock() -> void;
+    auto request(Source source) -> void;
+    auto acknowledge(Source source) -> void;
+    auto pending(Source source) const -> bool;
+    auto writeEnable(n8 data) -> void;
+    auto status() const -> n8;
+    auto line() const -> bool;
+
+  private:
+    friend struct POKEY;
+
+    n8 enable;
+    n8 statusValue;
+    u32 enabledAge[3];
+    u32 disabledAge[3];
+  } irq;
+
+  struct Pots {
+    //pots.cpp
+    auto power() -> void;
+    auto start(const n8 targets[8]) -> void;
+    auto clockFast() -> void;
+    auto clock15() -> void;
+    auto read(u32 index) const -> n8;
+    auto all() const -> n8;
+
+  private:
+    friend struct POKEY;
+
+    static constexpr u32 Maximum = 228;
+    static constexpr u32 FastMaximum = 229;
+    static constexpr u32 FastStop = 231;
+
+    //pots.cpp
+    auto advance() -> void;
+
+    n8 value[8];
+    n8 target[8];
+    n8 allValue;
+    u32 counter;
+    n1 scanning;
+  } pots;
+
+  struct Status {
+    //status.cpp
+    auto power() -> void;
+    auto resetErrors() -> void;
+    auto setKeyboardDown(bool active) -> void;
+    auto setShift(bool active) -> void;
+    auto setKeyboardOverrun() -> void;
+    auto setSerialInput(bool high) -> void;
+    auto setSerialBusy(bool active) -> void;
+    auto setSerialOutput(bool high) -> void;
+    auto setSerialInputOverrun() -> void;
+    auto setSerialFrameError() -> void;
+    auto read() const -> n8;
+
+  private:
+    friend struct POKEY;
+
+    n8 value;
+  } status;
+
+  struct Keyboard {
+    POKEY& self;
+    Keyboard(POKEY& self) : self(self) {}
+
+    //keyboard.cpp
+    auto power() -> void;
+    auto disable() -> void;
+    auto clock(bool debounce) -> void;
+    auto code() const -> n8;
+
+  private:
+    friend struct POKEY;
+
+    enum class State : u8 {
+      Released,
+      DebouncePress,
+      Pressed,
+      DebounceRelease,
+    };
+
+    n8 codeValue;
+    n6 scanCounter;
+    n6 compareValue;
+    State state;
+    n1 shiftLatch;
+    n1 controlLatch;
+    n1 breakLatch;
+  } keyboard{*this};
+
+  struct Serial {
+    POKEY& self;
+    Serial(POKEY& self) : self(self) {}
+
+    //serial.cpp
+    auto power() -> void;
+    auto write(n8 data) -> void;
+    auto configure() -> void;
+    auto clock(const Audio::TimerEdges&, SerialInput) -> void;
+    auto reset() -> void;
+    auto input() const -> n8;
+    auto holdsTimer34() const -> bool;
+
+  //private:
+    friend struct POKEY;
+
+    struct LineEdges {
+      bool inputFalling;
+      bool clockFalling;
+      bool clockRising;
+    };
+
+    //serial.cpp
+    auto observeLines(SerialInput) -> LineEdges;
+    auto clockInputPath(const Audio::TimerEdges&, bool data, const LineEdges&) -> void;
+    auto clockOutputPath(const Audio::TimerEdges&, const LineEdges&) -> void;
+    auto clockTwoTone(const Audio::TimerEdges&) -> void;
+    auto clockInput(bool data) -> void;
+    auto clockOutput() -> void;
+    auto loadOutput() -> void;
+    auto currentOutput() const -> bool;
+    auto mode() const -> n3;
+
+    n8 inputValue;
+    n10 inputShifter;
+    n4 inputProgress;
+    n8 outputHoldingValue;
+    n1 outputHoldingFull;
+    n10 outputShifter;
+    n4 outputProgress;
+    n1 inputClockPhase;
+    n1 outputClockPhase;
+    n1 outputLine;
+    n1 twoToneOutput;
+    n1 asynchronousReceiving;
+    n1 previousInputLine;
+    n1 previousExternalClock;
+  } serial{*this};
+
+  SerialInput serialInput{1, 1};
+  n8 control;
 };
 
 extern POKEY pokey;

--- a/ares/a52/pokey/pots.cpp
+++ b/ares/a52/pokey/pots.cpp
@@ -1,0 +1,64 @@
+auto POKEY::Pots::power() -> void {
+  for(auto& item : value) item = 0xff;
+  for(auto& item : target) item = 0;
+  allValue = 0x00;
+  counter = 0;
+  scanning = 0;
+}
+
+auto POKEY::Pots::start(const n8 targets[8]) -> void {
+  for(auto& item : value) item = 0;
+  for(u32 index = 0; index < 8; index++) target[index] = targets[index];
+  allValue = 0xff;
+  counter = 0;
+  scanning = 1;
+}
+
+auto POKEY::Pots::clockFast() -> void {
+  if(!scanning) return;
+  if(counter < FastStop) counter++;
+  if(counter <= Maximum) advance();
+  if(!scanning) return;
+
+  if(counter == FastMaximum) {
+    for(u32 index = 0; index < 8; index++) {
+      if(allValue.bit(index)) value[index] = FastMaximum;
+    }
+  }
+  if(counter == FastStop) {
+    allValue = 0;
+    scanning = 0;
+  }
+}
+
+auto POKEY::Pots::clock15() -> void {
+  if(!scanning) return;
+  if(counter < Maximum) counter++;
+  advance();
+  if(counter != Maximum || !allValue) return;
+  for(u32 index = 0; index < 8; index++) {
+    if(!allValue.bit(index)) continue;
+    value[index] = Maximum;
+  }
+  allValue = 0;
+  scanning = 0;
+}
+
+auto POKEY::Pots::advance() -> void {
+  for(u32 index = 0; index < 8; index++) {
+    if(!allValue.bit(index)) continue;
+    if(counter < target[index]) continue;
+    value[index] = target[index];
+    allValue.bit(index) = 0;
+  }
+  if(!allValue) scanning = 0;
+}
+
+auto POKEY::Pots::read(u32 index) const -> n8 {
+  if(allValue.bit(index)) return std::min(counter, FastMaximum);
+  return value[index];
+}
+
+auto POKEY::Pots::all() const -> n8 {
+  return allValue;
+}

--- a/ares/a52/pokey/serial.cpp
+++ b/ares/a52/pokey/serial.cpp
@@ -1,0 +1,201 @@
+auto POKEY::Serial::power() -> void {
+  inputValue = 0xff;
+  inputShifter = 0;
+  inputProgress = 0;
+  outputHoldingValue = 0;
+  outputHoldingFull = 0;
+  outputShifter = 0;
+  outputProgress = 0;
+  inputClockPhase = 0;
+  outputClockPhase = 0;
+  outputLine = 1;
+  twoToneOutput = 0;
+  asynchronousReceiving = 0;
+  previousInputLine = 1;
+  previousExternalClock = 1;
+  self.status.setSerialInput(true);
+  self.status.setSerialBusy(false);
+  self.status.setSerialOutput(true);
+  self.irq.request(IRQ::SerialComplete);
+}
+
+auto POKEY::Serial::write(n8 data) -> void {
+  if(!(self.control & 3)) return;
+  outputHoldingValue = data;
+  outputHoldingFull = 1;
+}
+
+auto POKEY::Serial::configure() -> void {
+  auto serialMode = mode();
+  if(serialMode == 0) {
+    inputClockPhase = 0;
+    outputClockPhase = 0;
+    previousExternalClock = self.serialInput.clock;
+  }
+  if(!self.control.bit(3)) twoToneOutput = 0;
+  if(self.control.bit(4) && !inputProgress) {
+    asynchronousReceiving = 0;
+    self.audio.resetSerialTimer34();
+  } else if(self.control.bit(4)) {
+    asynchronousReceiving = 1;
+  }
+  if(!self.control.bit(4)) asynchronousReceiving = 0;
+  self.status.setSerialOutput(currentOutput());
+}
+
+auto POKEY::Serial::clock(const Audio::TimerEdges& timerEdges, SerialInput lines) -> void {
+  self.status.setSerialInput(lines.data);
+  auto edges = observeLines(lines);
+  clockInputPath(timerEdges, lines.data, edges);
+  clockOutputPath(timerEdges, edges);
+  clockTwoTone(timerEdges);
+  self.status.setSerialOutput(currentOutput());
+}
+
+auto POKEY::Serial::observeLines(SerialInput lines) -> LineEdges {
+  LineEdges edges{
+    .inputFalling = previousInputLine && !lines.data,
+    .clockFalling = previousExternalClock && !lines.clock,
+    .clockRising = !previousExternalClock && lines.clock,
+  };
+  previousInputLine = lines.data;
+  previousExternalClock = lines.clock;
+  return edges;
+}
+
+auto POKEY::Serial::clockInputPath(const Audio::TimerEdges& timerEdges, bool data,
+  const LineEdges& edges) -> void {
+  auto serialMode = mode();
+  auto asynchronousInput = self.control.bit(4);
+  if(asynchronousInput && !inputProgress && edges.inputFalling) {
+    asynchronousReceiving = 1;
+    inputClockPhase = 1;
+    self.audio.resetSerialTimer34();
+  }
+
+  bool inputEdge = false;
+  if(serialMode == 0 || serialMode == 4) {
+    inputEdge = edges.clockFalling;
+  } else if(timerEdges.timer4 && (!asynchronousInput || asynchronousReceiving)) {
+    inputClockPhase ^= 1;
+    inputEdge = !inputClockPhase;
+  }
+  if(inputEdge) {
+    clockInput(data);
+    if(asynchronousInput && !inputProgress) {
+      asynchronousReceiving = 0;
+      self.audio.resetSerialTimer34();
+    }
+  }
+}
+
+auto POKEY::Serial::clockOutputPath(const Audio::TimerEdges& timerEdges, const LineEdges& edges) -> void {
+  auto serialMode = mode();
+  bool outputTimerEdge = false;
+  if(serialMode >= 2 && serialMode <= 5) outputTimerEdge = timerEdges.timer4;
+  if(serialMode >= 6) outputTimerEdge = timerEdges.timer2;
+  bool outputEdge = serialMode <= 1 ? edges.clockRising : false;
+  if(serialMode <= 1 && edges.clockFalling) outputClockPhase = 0;
+  if(serialMode <= 1 && edges.clockRising) outputClockPhase = 1;
+  if(outputTimerEdge) {
+    outputClockPhase ^= 1;
+    outputEdge = outputClockPhase;
+  }
+  if(outputEdge) clockOutput();
+}
+
+auto POKEY::Serial::clockTwoTone(const Audio::TimerEdges& timerEdges) -> void {
+  if(self.control.bit(3)) {
+    u32 acceptedEvents = timerEdges.timer2 ? 1 << 1 : 0;
+    if(timerEdges.timer1 && outputLine && !self.control.bit(7)) acceptedEvents |= 1 << 0;
+    if(acceptedEvents) {
+      twoToneOutput ^= 1;
+      self.audio.scheduleTwoToneResynchronization(acceptedEvents);
+    }
+  }
+}
+
+auto POKEY::Serial::reset() -> void {
+  inputShifter = 0;
+  inputProgress = 0;
+  outputHoldingValue = 0;
+  outputHoldingFull = 0;
+  outputShifter = 0;
+  outputProgress = 0;
+  inputClockPhase = 0;
+  outputClockPhase = 0;
+  asynchronousReceiving = 0;
+  self.status.setSerialBusy(false);
+  self.status.setSerialOutput(currentOutput());
+  self.irq.request(IRQ::SerialComplete);
+}
+
+auto POKEY::Serial::input() const -> n8 {
+  return inputValue;
+}
+
+auto POKEY::Serial::holdsTimer34() const -> bool {
+  return self.control.bit(4) && !asynchronousReceiving;
+}
+
+auto POKEY::Serial::clockInput(bool data) -> void {
+  if(!inputProgress) {
+    if(data) return;
+    inputShifter = 0;
+    inputProgress = 1;
+    self.status.setSerialBusy(true);
+    return;
+  }
+
+  inputShifter.bit(inputProgress) = data;
+  inputProgress++;
+  if(inputProgress < 10) return;
+
+  inputValue = inputShifter >> 1;
+  if(!data) self.status.setSerialFrameError();
+  if(self.irq.pending(IRQ::SerialInput)) self.status.setSerialInputOverrun();
+  self.irq.request(IRQ::SerialInput);
+  inputShifter = 0;
+  inputProgress = 0;
+  asynchronousReceiving = 0;
+  self.status.setSerialBusy(false);
+  if(self.control.bit(4)) self.audio.resetSerialTimer34();
+}
+
+auto POKEY::Serial::clockOutput() -> void {
+  if(!outputProgress) {
+    if(outputHoldingFull) loadOutput();
+    return;
+  }
+
+  if(outputProgress < 10) {
+    outputLine = outputShifter.bit(outputProgress);
+    outputProgress++;
+    return;
+  }
+
+  outputShifter = 0;
+  outputProgress = 0;
+  if(outputHoldingFull) loadOutput();
+  else self.irq.request(IRQ::SerialComplete);
+}
+
+auto POKEY::Serial::loadOutput() -> void {
+  outputShifter = (u16)outputHoldingValue << 1 | 1 << 9;
+  outputProgress = 1;
+  outputHoldingValue = 0;
+  outputHoldingFull = 0;
+  outputLine = outputShifter.bit(0);
+  self.irq.acknowledge(IRQ::SerialComplete);
+  self.irq.request(IRQ::SerialOutput);
+}
+
+auto POKEY::Serial::currentOutput() const -> bool {
+  if(self.control.bit(3)) return twoToneOutput;
+  if(self.control.bit(7)) return false;
+  return outputLine;
+}
+
+auto POKEY::Serial::mode() const -> n3 {
+  return (u8)self.control >> 4;
+}

--- a/ares/a52/pokey/serialization.cpp
+++ b/ares/a52/pokey/serialization.cpp
@@ -1,0 +1,90 @@
+auto POKEY::serialize(serializer& s) -> void {
+  Thread::serialize(s);
+  clock.serialize(s);
+  audio.serialize(s);
+  irq.serialize(s);
+  pots.serialize(s);
+  status.serialize(s);
+  keyboard.serialize(s);
+  serial.serialize(s);
+  s(control);
+  s(previousInput);
+  s(coupledOutput);
+}
+
+auto POKEY::Clock::serialize(serializer& s) -> void {
+  s(prescaler64);
+  s(prescaler15);
+  s(polynomial4);
+  s(polynomial5);
+  s(polynomial9);
+  s(polynomial17);
+  s(polynomial4History);
+  s(polynomial5History);
+  s(polynomial9History);
+  s(polynomial17History);
+}
+
+auto POKEY::Audio::serialize(serializer& s) -> void {
+  for(auto& item : channel) {
+    s(item.frequency);
+    s(item.control);
+    s(item.counter);
+    s(item.eventDelay);
+    s(item.reloadDelay);
+    s(item.output);
+    s(item.filterLatch);
+    s(item.filterSample);
+    s(item.filterDelay);
+  }
+  s(control);
+  s(timersRunning);
+  s(startDelay);
+  s(twoToneResyncPipeline);
+}
+
+auto POKEY::IRQ::serialize(serializer& s) -> void {
+  s(enable);
+  s(statusValue);
+  for(auto& age : enabledAge) s(age);
+  for(auto& age : disabledAge) s(age);
+}
+
+auto POKEY::Pots::serialize(serializer& s) -> void {
+  for(auto& item : value) s(item);
+  for(auto& item : target) s(item);
+  s(allValue);
+  s(counter);
+  s(scanning);
+}
+
+auto POKEY::Status::serialize(serializer& s) -> void {
+  s(value);
+}
+
+auto POKEY::Keyboard::serialize(serializer& s) -> void {
+  s(codeValue);
+  s(scanCounter);
+  s(compareValue);
+  s(state);
+  s(shiftLatch);
+  s(controlLatch);
+  s(breakLatch);
+}
+
+auto POKEY::Serial::serialize(serializer& s) -> void {
+  s(inputValue);
+  s(inputShifter);
+  s(inputProgress);
+  s(outputHoldingValue);
+  s(outputHoldingFull);
+  s(outputShifter);
+  s(outputProgress);
+  s(inputClockPhase);
+  s(outputClockPhase);
+  s(outputLine);
+  s(twoToneOutput);
+  s(asynchronousReceiving);
+  s(previousInputLine);
+  s(previousExternalClock);
+}

--- a/ares/a52/pokey/status.cpp
+++ b/ares/a52/pokey/status.cpp
@@ -1,0 +1,43 @@
+auto POKEY::Status::power() -> void {
+  value = 0xff;
+}
+
+auto POKEY::Status::resetErrors() -> void {
+  value |= 0xe0;
+}
+
+auto POKEY::Status::setKeyboardDown(bool active) -> void {
+  value.bit(2) = !active;
+}
+
+auto POKEY::Status::setShift(bool active) -> void {
+  value.bit(3) = !active;
+}
+
+auto POKEY::Status::setKeyboardOverrun() -> void {
+  value.bit(6) = 0;
+}
+
+auto POKEY::Status::setSerialInput(bool high) -> void {
+  value.bit(4) = high;
+}
+
+auto POKEY::Status::setSerialBusy(bool active) -> void {
+  value.bit(1) = !active;
+}
+
+auto POKEY::Status::setSerialOutput(bool high) -> void {
+  value.bit(0) = high;
+}
+
+auto POKEY::Status::setSerialInputOverrun() -> void {
+  value.bit(5) = 0;
+}
+
+auto POKEY::Status::setSerialFrameError() -> void {
+  value.bit(7) = 0;
+}
+
+auto POKEY::Status::read() const -> n8 {
+  return value;
+}

--- a/ares/a52/system/serialization.cpp
+++ b/ares/a52/system/serialization.cpp
@@ -1,0 +1,50 @@
+static const string SerializerVersion = "v148";
+
+auto System::serialize(bool synchronize) -> serializer {
+  if(synchronize) scheduler.enter(Scheduler::Mode::Synchronize);
+  serializer s;
+
+  u32 signature = SerializerSignature;
+  char version[16] = {};
+  char description[512] = {};
+  memory::copy(&version, (const char*)SerializerVersion, SerializerVersion.size());
+
+  s(signature);
+  s(synchronize);
+  s(version);
+  s(description);
+
+  serialize(s, synchronize);
+  return s;
+}
+
+auto System::unserialize(serializer& s) -> bool {
+  u32 signature = 0;
+  bool synchronize = true;
+  char version[16] = {};
+  char description[512] = {};
+
+  s(signature);
+  s(synchronize);
+  s(version);
+  s(description);
+
+  char expectedVersion[16] = {};
+  memory::copy(&expectedVersion, (const char*)SerializerVersion, SerializerVersion.size());
+  if(signature != SerializerSignature) return false;
+  if(memory::compare(version, expectedVersion, sizeof(version))) return false;
+
+  if(synchronize) power(/* reset = */ false);
+  serialize(s, synchronize);
+  return true;
+}
+
+auto System::serialize(serializer& s, bool synchronize) -> void {
+  scheduler.setSynchronize(synchronize);
+  s(ram);
+  s(cartridge);
+  s(cpu);
+  s(antic);
+  s(gtia);
+  s(pokey);
+}

--- a/ares/a52/system/system.cpp
+++ b/ares/a52/system/system.cpp
@@ -1,0 +1,106 @@
+#include <a52/a52.hpp>
+#include <algorithm>
+
+namespace ares::Atari5200 {
+
+auto enumerate() -> std::vector<string> {
+  return {
+    "[Atari] Atari 5200 (NTSC)",
+  };
+}
+
+auto load(Node::System& node, string name) -> bool {
+  auto configurations = enumerate();
+  if(std::find(configurations.begin(), configurations.end(), name) == configurations.end()) return false;
+  return system.load(node, name);
+}
+
+Random random;
+Scheduler scheduler;
+System system;
+
+auto System::game() -> string {
+  if(cartridge.node) return cartridge.title();
+  return "(no cartridge connected)";
+}
+
+auto System::run() -> void {
+  scheduler.enter();
+}
+
+auto System::load(Node::System& root, string name) -> bool {
+  if(node) unload();
+
+  information = {};
+  node = std::make_shared<Core::System>(information.name);
+  node->setAttribute("configuration", name);
+  node->setGame(std::bind_front(&System::game, this));
+  node->setRun(std::bind_front(&System::run, this));
+  node->setPower(std::bind_front(&System::power, this));
+  node->setSave(std::bind_front(&System::save, this));
+  node->setUnload(std::bind_front(&System::unload, this));
+  root = node;
+
+  if(!node->setPak(pak = platform->pak(node))) {
+    root = {};
+    node = {};
+    return false;
+  }
+
+  auto firmware = pak->read("bios.rom");
+  if(!firmware || firmware->size() != 2_KiB) {
+    pak.reset();
+    root = {};
+    node = {};
+    return false;
+  }
+
+  ram.allocate(16_KiB);
+  bios.allocate(2_KiB);
+  bios.load(firmware);
+
+  scheduler.reset();
+  cpu.load(node);
+  antic.load(node);
+  gtia.load(node);
+  pokey.load(node);
+  cartridgeSlot.load(node);
+  return true;
+}
+
+auto System::save() -> void {
+  if(!node) return;
+  cartridge.save();
+}
+
+auto System::unload() -> void {
+  if(!node) return;
+  save();
+  cpu.unload();
+  antic.unload();
+  gtia.unload();
+  pokey.unload();
+  cartridgeSlot.unload();
+  ram.reset();
+  bios.reset();
+  pak.reset();
+  node.reset();
+}
+
+auto System::power(bool reset) -> void {
+  for(auto& setting : node->find<Node::Setting::Setting>()) setting->setLatch();
+
+  random.entropy(Random::Entropy::Low);
+  if(!reset) {
+    for(auto& byte : ram) byte = random();
+  }
+
+  cartridge.power();
+  antic.power();
+  gtia.power();
+  pokey.power();
+  cpu.power(reset);
+  scheduler.power(cpu);
+}
+
+}

--- a/ares/a52/system/system.cpp
+++ b/ares/a52/system/system.cpp
@@ -26,6 +26,7 @@ auto System::game() -> string {
 
 auto System::run() -> void {
   scheduler.enter();
+  for(auto& port : controllerPorts) port.poll();
 }
 
 auto System::load(Node::System& root, string name) -> bool {
@@ -65,6 +66,7 @@ auto System::load(Node::System& root, string name) -> bool {
   gtia.load(node);
   pokey.load(node);
   cartridgeSlot.load(node);
+  for(auto& port : controllerPorts) port.load(node);
   return true;
 }
 
@@ -81,6 +83,7 @@ auto System::unload() -> void {
   gtia.unload();
   pokey.unload();
   cartridgeSlot.unload();
+  for(auto& port : controllerPorts) port.unload();
   ram.reset();
   bios.reset();
   pak.reset();

--- a/ares/a52/system/system.cpp
+++ b/ares/a52/system/system.cpp
@@ -3,6 +3,8 @@
 
 namespace ares::Atari5200 {
 
+#include "serialization.cpp"
+
 auto enumerate() -> std::vector<string> {
   return {
     "[Atari] Atari 5200 (NTSC)",
@@ -40,6 +42,8 @@ auto System::load(Node::System& root, string name) -> bool {
   node->setPower(std::bind_front(&System::power, this));
   node->setSave(std::bind_front(&System::save, this));
   node->setUnload(std::bind_front(&System::unload, this));
+  node->setSerialize([this](bool synchronize) { return serialize(synchronize); });
+  node->setUnserialize([this](serializer& s) { return unserialize(s); });
   root = node;
 
   if(!node->setPak(pak = platform->pak(node))) {

--- a/ares/a52/system/system.hpp
+++ b/ares/a52/system/system.hpp
@@ -15,6 +15,11 @@ struct System {
   auto unload() -> void;
   auto power(bool reset) -> void;
 
+  //serialization.cpp
+  auto serialize(bool synchronize) -> serializer;
+  auto unserialize(serializer&) -> bool;
+  auto serialize(serializer&, bool synchronize) -> void;
+
   Memory::Writable<n8> ram;
   Memory::Readable<n8> bios;
 

--- a/ares/a52/system/system.hpp
+++ b/ares/a52/system/system.hpp
@@ -1,0 +1,28 @@
+extern Random random;
+
+struct System {
+  Node::System node;
+  VFS::Pak pak;
+
+  auto name() const -> string { return information.name; }
+  auto frequency() const -> f64 { return information.frequency; }
+
+  auto game() -> string;
+  auto run() -> void;
+
+  auto load(Node::System& node, string name) -> bool;
+  auto save() -> void;
+  auto unload() -> void;
+  auto power(bool reset) -> void;
+
+  Memory::Writable<n8> ram;
+  Memory::Readable<n8> bios;
+
+private:
+  struct Information {
+    string name = "Atari 5200";
+    f64 frequency = Constants::Colorburst::NTSC;
+  } information;
+};
+
+extern System system;

--- a/desktop-ui/cmake/sources.cmake
+++ b/desktop-ui/cmake/sources.cmake
@@ -60,6 +60,7 @@ target_sources(
   PRIVATE
     emulator/arcade.cpp
     emulator/atari-2600.cpp
+    emulator/atari-5200.cpp
     emulator/colecovision.cpp
     emulator/emulator.cpp
     emulator/emulator.hpp

--- a/desktop-ui/emulator/atari-5200.cpp
+++ b/desktop-ui/emulator/atari-5200.cpp
@@ -44,6 +44,28 @@ Atari5200::Atari5200() {
     device.digital("Reset",      virtualPorts[id].pad.north);
     port.append(device); }
 
+  { InputDevice device{"Trak-Ball"};
+    device.relative("X-Axis",      virtualPorts[id].mouse.x);
+    device.relative("Y-Axis",      virtualPorts[id].mouse.y);
+    device.digital ("Top Fire",    virtualPorts[id].pad.east);
+    device.digital ("Bottom Fire", virtualPorts[id].pad.south);
+    device.digital ("1",           virtualPorts[id].pad.one);
+    device.digital ("2",           virtualPorts[id].pad.two);
+    device.digital ("3",           virtualPorts[id].pad.three);
+    device.digital ("4",           virtualPorts[id].pad.four);
+    device.digital ("5",           virtualPorts[id].pad.five);
+    device.digital ("6",           virtualPorts[id].pad.six);
+    device.digital ("7",           virtualPorts[id].pad.seven);
+    device.digital ("8",           virtualPorts[id].pad.eight);
+    device.digital ("9",           virtualPorts[id].pad.nine);
+    device.digital ("*",           virtualPorts[id].pad.star);
+    device.digital ("0",           virtualPorts[id].pad.zero);
+    device.digital ("#",           virtualPorts[id].pad.pound);
+    device.digital ("Start",       virtualPorts[id].pad.start);
+    device.digital ("Pause",       virtualPorts[id].pad.select);
+    device.digital ("Reset",       virtualPorts[id].pad.north);
+    port.append(device); }
+
     ports.push_back(port);
   }
 }

--- a/desktop-ui/emulator/atari-5200.cpp
+++ b/desktop-ui/emulator/atari-5200.cpp
@@ -1,0 +1,57 @@
+struct Atari5200 : Emulator {
+  Atari5200();
+  auto load() -> LoadResult override;
+  auto save() -> bool override;
+  auto pak(ares::Node::Object node) -> std::shared_ptr<vfs::directory> override;
+};
+
+Atari5200::Atari5200() {
+  manufacturer = "Atari";
+  name = "Atari 5200";
+
+  firmware.push_back({
+    "BIOS",
+    "NTSC-U Four-port",
+    "06b250f18983d058c0f156ce7ee88ae48b6eaf11e6f10f21dccf6ac7ffb6a6af"
+  });
+}
+
+auto Atari5200::load() -> LoadResult {
+  game = mia::Medium::create("Atari 5200");
+  string location = Emulator::load(game, configuration.game);
+  if(!location) return noFileSelected;
+
+  LoadResult result = game->load(location);
+  if(result != successful) return result;
+
+  system = mia::System::create("Atari 5200");
+  if(system->load(firmware[0].location) != successful) {
+    result.firmwareSystemName = "Atari 5200";
+    result.firmwareType = firmware[0].type;
+    result.firmwareRegion = firmware[0].region;
+    result.result = noFirmware;
+    return result;
+  }
+
+  if(!ares::Atari5200::load(root, "[Atari] Atari 5200 (NTSC)")) return otherError;
+
+  if(auto port = root->find<ares::Node::Port>("Cartridge Slot")) {
+    port->allocate();
+    port->connect();
+  }
+
+  return successful;
+}
+
+auto Atari5200::save() -> bool {
+  root->save();
+  system->save(system->location);
+  game->save(game->location);
+  return true;
+}
+
+auto Atari5200::pak(ares::Node::Object node) -> std::shared_ptr<vfs::directory> {
+  if(node->name() == "Atari 5200") return system->pak;
+  if(node->name() == "Atari 5200 Cartridge") return game->pak;
+  return {};
+}

--- a/desktop-ui/emulator/atari-5200.cpp
+++ b/desktop-ui/emulator/atari-5200.cpp
@@ -14,6 +14,38 @@ Atari5200::Atari5200() {
     "NTSC-U Four-port",
     "06b250f18983d058c0f156ce7ee88ae48b6eaf11e6f10f21dccf6ac7ffb6a6af"
   });
+
+  for(auto id : range(4)) {
+    InputPort port{string{"Controller Port ", 1 + id}};
+
+  { InputDevice device{"Controller"};
+    device.analog ("L-Up",       virtualPorts[id].pad.lstick_up);
+    device.analog ("L-Down",     virtualPorts[id].pad.lstick_down);
+    device.analog ("L-Left",     virtualPorts[id].pad.lstick_left);
+    device.analog ("L-Right",    virtualPorts[id].pad.lstick_right);
+    device.analog ("X-Axis",     virtualPorts[id].pad.lstick_left, virtualPorts[id].pad.lstick_right);
+    device.analog ("Y-Axis",     virtualPorts[id].pad.lstick_up,   virtualPorts[id].pad.lstick_down);
+    device.digital("Top Fire",   virtualPorts[id].pad.east);
+    device.digital("Bottom Fire", virtualPorts[id].pad.south);
+    device.digital("1",          virtualPorts[id].pad.one);
+    device.digital("2",          virtualPorts[id].pad.two);
+    device.digital("3",          virtualPorts[id].pad.three);
+    device.digital("4",          virtualPorts[id].pad.four);
+    device.digital("5",          virtualPorts[id].pad.five);
+    device.digital("6",          virtualPorts[id].pad.six);
+    device.digital("7",          virtualPorts[id].pad.seven);
+    device.digital("8",          virtualPorts[id].pad.eight);
+    device.digital("9",          virtualPorts[id].pad.nine);
+    device.digital("*",          virtualPorts[id].pad.star);
+    device.digital("0",          virtualPorts[id].pad.zero);
+    device.digital("#",          virtualPorts[id].pad.pound);
+    device.digital("Start",      virtualPorts[id].pad.start);
+    device.digital("Pause",      virtualPorts[id].pad.select);
+    device.digital("Reset",      virtualPorts[id].pad.north);
+    port.append(device); }
+
+    ports.push_back(port);
+  }
 }
 
 auto Atari5200::load() -> LoadResult {
@@ -38,6 +70,13 @@ auto Atari5200::load() -> LoadResult {
   if(auto port = root->find<ares::Node::Port>("Cartridge Slot")) {
     port->allocate();
     port->connect();
+  }
+
+  for(auto id : range(4)) {
+    if(auto port = root->find<ares::Node::Port>(string{"Controller Port ", 1 + id})) {
+      port->allocate("Controller");
+      port->connect();
+    }
   }
 
   return successful;

--- a/desktop-ui/emulator/emulators.cpp
+++ b/desktop-ui/emulator/emulators.cpp
@@ -6,6 +6,13 @@ namespace ares::Atari2600 {
 #include "atari-2600.cpp"
 #endif
 
+#ifdef CORE_A52
+namespace ares::Atari5200 {
+  auto load(Node::System& node, string name) -> bool;
+}
+#include "atari-5200.cpp"
+#endif
+
 #ifdef CORE_CV
   namespace ares::ColecoVision {
     auto load(Node::System& node, string name) -> bool;
@@ -167,6 +174,10 @@ auto Emulator::construct() -> void {
 
   #ifdef CORE_A26
   emulators.push_back(std::make_shared<Atari2600>());
+  #endif
+
+  #ifdef CORE_A52
+  emulators.push_back(std::make_shared<Atari5200>());
   #endif
 
   #ifdef CORE_WS

--- a/mia/CMakeLists.txt
+++ b/mia/CMakeLists.txt
@@ -16,6 +16,7 @@ target_sources(
     resource/resource.hpp
     medium/arcade.cpp
     medium/atari-2600.cpp
+    medium/atari-5200.cpp
     medium/bs-memory.cpp
     medium/colecovision.cpp
     medium/famicom-disk-system.cpp
@@ -81,6 +82,7 @@ target_sources(
   PRIVATE
     system/arcade.cpp
     system/atari-2600.cpp
+    system/atari-5200.cpp
     system/colecovision.cpp
     system/famicom.cpp
     system/game-boy-advance.cpp

--- a/mia/Database/Atari 5200.bml
+++ b/mia/Database/Atari 5200.bml
@@ -1,0 +1,1057 @@
+database
+  revision: 2026-08-05
+
+game
+  sha256: f3c1a48b736a06cf5c181e2d3c6c093512a592c4adf91c3e7e8f3e2bbdc2a126
+  name:    Astro Chase
+  title:   Astro Chase
+  region:  NTSC
+  board:   TwoChip16K
+    memory
+      type: ROM
+      size: 0x4000
+      content: Program
+game
+  sha256: 0eaf2b96806f2b6f4f6e0a7dc8887472597b3ad4c48e4a82c49b236637f968ea
+  name:    Ballblazer
+  title:   Ballblazer
+  region:  NTSC
+  board:   Linear32K
+    memory
+      type: ROM
+      size: 0x8000
+      content: Program
+
+game
+  sha256: 1ca70eb59bf139b494f8440ad958794db0f2fa18ee96cbec713426987c853226
+  name:    Beamrider
+  title:   Beamrider
+  region:  NTSC
+  board:   OneChip16K
+    memory
+      type: ROM
+      size: 0x4000
+      content: Program
+
+game
+  sha256: 3f3a9aa1ed3768be015ecba399655d7eb30b1ed4bfaecce472fba3c7f959967d
+  name:    Berzerk
+  title:   Berzerk
+  region:  NTSC
+  board:   OneChip16K
+    memory
+      type: ROM
+      size: 0x4000
+      content: Program
+
+game
+  sha256: a4bfac6b2b477ac111f3668ed162736e6a134ec59c349b9e4407f52e523043fa
+  name:    Blue-Print
+  title:   Blue-Print
+  region:  NTSC
+  board:   OneChip16K
+    memory
+      type: ROM
+      size: 0x4000
+      content: Program
+
+game
+  sha256: d5e86a3fb67325d5633050ebbc14df5073497d9791656045559a9816aee65ddf
+  name:    Bounty Bob Strikes Back!
+  title:   Bounty Bob Strikes Back!
+  region:  NTSC
+  board:   DualWindow40K
+    memory
+      type: ROM
+      size: 0xa000
+      content: Program
+
+game
+  sha256: 29d66bb75791a7ced485a49cf2116aa667b32713dc1a67d22430035dde1c4c08
+  name:    Buck Rogers - Planet of Zoom
+  title:   Buck Rogers - Planet of Zoom
+  region:  NTSC
+  board:   TwoChip16K
+    memory
+      type: ROM
+      size: 0x4000
+      content: Program
+
+game
+  sha256: 06312922c2fe951c6980e9fcec041607db6babab7bfd0ca8d0b2c2b0c8964039
+  name:    Centipede
+  title:   Centipede
+  region:  NTSC
+  board:   TwoChip16K
+    memory
+      type: ROM
+      size: 0x4000
+      content: Program
+
+game
+  sha256: 15583375bc28a8d94d8726a9f35ecb095430ccd817e34c169b715d396c3d379a
+  name:    Choplifter!
+  title:   Choplifter!
+  region:  NTSC
+  board:   OneChip16K
+    memory
+      type: ROM
+      size: 0x4000
+      content: Program
+
+game
+  sha256: 254662bb792fddbfe9846dbdd68a2b78479b4b1f4c77a7b85eae2dabdc9888a7
+  name:    Congo Bongo
+  title:   Congo Bongo
+  region:  NTSC
+  board:   TwoChip16K
+    memory
+      type: ROM
+      size: 0x4000
+      content: Program
+
+game
+  sha256: 1a453b467c75c736ba9e96884721286608976ce7f3d8b81fccc619168955f4d1
+  name:    Countermeasure
+  title:   Countermeasure
+  region:  NTSC
+  board:   TwoChip16K
+    memory
+      type: ROM
+      size: 0x4000
+      content: Program
+
+game
+  sha256: 9095b40ab3b2219a1ce931a99d57de2299a0e641e78005836739323c8a1daca3
+  name:    David Crane's Pitfall II - Lost Caverns
+  title:   David Crane's Pitfall II - Lost Caverns
+  region:  NTSC
+  board:   OneChip16K
+    memory
+      type: ROM
+      size: 0x4000
+      content: Program
+
+game
+  sha256: 0bc2f5fee89560f286b9c6444642d92ab12b922d1f3a1246c9511ce24ea73507
+  name:    Defender
+  title:   Defender
+  region:  NTSC
+  board:   TwoChip16K
+    memory
+      type: ROM
+      size: 0x4000
+      content: Program
+
+game
+  sha256: e68dfe857ae9f602403fa990d97e0e9989768e5f110984babaf9960adb199ac1
+  name:    Dig Dug
+  title:   Dig Dug
+  region:  NTSC
+  board:   TwoChip16K
+    memory
+      type: ROM
+      size: 0x4000
+      content: Program
+
+game
+  sha256: 16e4a304548e60b98cf3db125115d8ca11232d4ef8dc7d0ebeb1f06ed764bdd6
+  name:    Frogger
+  title:   Frogger
+  region:  NTSC
+  board:   Linear8K
+    memory
+      type: ROM
+      size: 0x2000
+      content: Program
+
+game
+  sha256: 87bdba18b4db61d3701f7c8ce931a9ddc75b5b75892ca69b7e4e419bfa68e46d
+  name:    Frogger II: Threeedeep!
+  title:   Frogger II: Threeedeep!
+  region:  NTSC
+  board:   TwoChip16K
+    memory
+      type: ROM
+      size: 0x4000
+      content: Program
+
+game
+  sha256: 469209803f3c2d9119be2ef4347d25dcb94e6c30930e107cd93a5b94bde16b8c
+  name:    Galaxian
+  title:   Galaxian
+  region:  NTSC
+  board:   Linear8K
+    memory
+      type: ROM
+      size: 0x2000
+      content: Program
+
+game
+  sha256: e017a57cd829e6e57f8cc973713178748d5bf25bb9c4fb4e3aa680fa5639693a
+  name:    Gorf
+  title:   Gorf
+  region:  NTSC
+  board:   Linear8K
+    memory
+      type: ROM
+      size: 0x2000
+      content: Program
+
+game
+  sha256: 2940b26dc24edc33a9fb840a9f3ef77be73ab0e223525d4bca7d0e0cf14d4a3e
+  name:    Gremlins
+  title:   Gremlins
+  region:  NTSC
+  board:   Linear32K
+    memory
+      type: ROM
+      size: 0x8000
+      content: Program
+
+game
+  sha256: 8e2a264ee07f486de9b40e74d405acc5405d9d1da5e64a24564d4d769366ba54
+  name:    Gyruss
+  title:   Gyruss
+  region:  NTSC
+  board:   TwoChip16K
+    memory
+      type: ROM
+      size: 0x4000
+      content: Program
+
+game
+  sha256: 34a5c081c26a71ae883cd474c7db7e76aa264a5dbd392424d51f224766bf707f
+  name:    H.E.R.O.
+  title:   H.E.R.O.
+  region:  NTSC
+  board:   OneChip16K
+    memory
+      type: ROM
+      size: 0x4000
+      content: Program
+
+game
+  sha256: 5ac85a569f6fe178db4e2111f608949045999d5123b047b20ef03feeccfb1b49
+  name:    James Bond
+  title:   James Bond
+  region:  NTSC
+  board:   TwoChip16K
+    memory
+      type: ROM
+      size: 0x4000
+      content: Program
+
+game
+  sha256: 17ba9da3996bbb907dc8bf0abda17c78512507c3de86171db8e9cbc1f4667f07
+  name:    Joust
+  title:   Joust
+  region:  NTSC
+  board:   TwoChip16K
+    memory
+      type: ROM
+      size: 0x4000
+      content: Program
+
+game
+  sha256: 53795541ce22cacb9397475926e28ac545940054172a7720650918ab8f693a81
+  name:    Jungle Hunt
+  title:   Jungle Hunt
+  region:  NTSC
+  board:   TwoChip16K
+    memory
+      type: ROM
+      size: 0x4000
+      content: Program
+
+game
+  sha256: 2468f75c9ae7a96a2eeb9e9a32b62f56740e6a78687cd90e02d694368577c246
+  name:    K-Razy Shoot Out
+  title:   K-Razy Shoot Out
+  region:  NTSC
+  board:   Linear8K
+    memory
+      type: ROM
+      size: 0x2000
+      content: Program
+
+game
+  sha256: 2382504eba619372d7f5fb780a7489163bce198376900405f28f6e8fa452030e
+  name:    Kaboom!
+  title:   Kaboom!
+  region:  NTSC
+  board:   Linear4K
+    memory
+      type: ROM
+      size: 0x1000
+      content: Program
+
+game
+  sha256: 94b994879aa91434da1e72bff6aa1b9fffb1a50cbe26052ea21eed54c6e16ded
+  name:    Kangaroo
+  title:   Kangaroo
+  region:  NTSC
+  board:   TwoChip16K
+    memory
+      type: ROM
+      size: 0x4000
+      content: Program
+
+game
+  sha256: 2269556b53b9c28a1ed75208605f92ae21ccf5e29fc0cd51b160a50bcc1bb5d0
+  name:    Keystone Kapers
+  title:   Keystone Kapers
+  region:  NTSC
+  board:   Linear8K
+    memory
+      type: ROM
+      size: 0x2000
+      content: Program
+
+game
+  sha256: d8b66ea9b9f4f13584ce349ddefea219c31eee99d0a5565627b9322b4b183cbb
+  name:    Mario Bros.
+  title:   Mario Bros.
+  region:  NTSC
+  board:   Linear32K
+    memory
+      type: ROM
+      size: 0x8000
+      content: Program
+
+game
+  sha256: 75b60c591276918fa0e208086900133484d5edd050c931422cbbc19cb9b23997
+  name:    MegaMania
+  title:   MegaMania
+  region:  NTSC
+  board:   Linear8K
+    memory
+      type: ROM
+      size: 0x2000
+      content: Program
+
+game
+  sha256: 73e372b99cdf8f2f30c071dcc0a7ac0bc532ce5300595f166eefa23c46915e77
+  name:    Meteorites
+  title:   Meteorites
+  region:  NTSC
+  board:   OneChip16K
+    memory
+      type: ROM
+      size: 0x4000
+      content: Program
+
+game
+  sha256: 6207cb90590953dd48db0afeb6b40db6f447a8f0a9d48dc758b0654769a2e871
+  name:    Miner 2049er
+  title:   Miner 2049er
+  region:  NTSC
+  board:   OneChip16K
+    memory
+      type: ROM
+      size: 0x4000
+      content: Program
+
+game
+  sha256: 792b23a61fd5af990538bf4d7c81bf773079caed875603efca01ca6d6fa4d00b
+  name:    Missile Command
+  title:   Missile Command
+  region:  NTSC
+  board:   Linear8K
+    memory
+      type: ROM
+      size: 0x2000
+      content: Program
+
+game
+  sha256: 0dcd83e64083e12a358425f6c256bf2bb384d7f9705784035b183dd1db205e16
+  name:    Montezuma's Revenge
+  title:   Montezuma's Revenge
+  region:  NTSC
+  board:   TwoChip16K
+    memory
+      type: ROM
+      size: 0x4000
+      content: Program
+
+game
+  sha256: 549394b200ea0d58aa5d166d81e7a7439b11c810cd53eee186839dd5239b1ad5
+  name:    Moon Patrol
+  title:   Moon Patrol
+  region:  NTSC
+  board:   OneChip16K
+    memory
+      type: ROM
+      size: 0x4000
+      content: Program
+
+game
+  sha256: 8d99f09862caf68212d1d22a28e5964c41307ef52d8b8be027feefba675f9e6a
+  name:    Mountain King
+  title:   Mountain King
+  region:  NTSC
+  board:   Linear8K
+    memory
+      type: ROM
+      size: 0x2000
+      content: Program
+
+game
+  sha256: 6b0832baf6b9d84e79c9ec4fc41fb4b40930855d44d554f0f237619849841548
+  name:    Mr. Do!'s Castle
+  title:   Mr. Do!'s Castle
+  region:  NTSC
+  board:   Linear8K
+    memory
+      type: ROM
+      size: 0x2000
+      content: Program
+
+game
+  sha256: 305181464b8ee3733c0de2c8329ea763143f68cd8413aa02731dec2da21ca1ba
+  name:    Ms. Pac-Man
+  title:   Ms. Pac-Man
+  region:  NTSC
+  board:   TwoChip16K
+    memory
+      type: ROM
+      size: 0x4000
+      content: Program
+
+game
+  sha256: 5097b4763eefd8650781698e36b68bc0c9ae0863916312e6fa4364e4da104080
+  name:    Pac-Man
+  title:   Pac-Man
+  region:  NTSC
+  board:   TwoChip16K
+    memory
+      type: ROM
+      size: 0x4000
+      content: Program
+
+game
+  sha256: 2897aac47fefadd344b5a39e5aaf8bd5d097821cc6321b2d83fa3a04232a2971
+  name:    Pengo
+  title:   Pengo
+  region:  NTSC
+  board:   Linear32K
+    memory
+      type: ROM
+      size: 0x8000
+      content: Program
+
+game
+  sha256: e57563c4f469b58a768c00f3dabcdfa4e52883906ab64263961ed5a033968651
+  name:    Pitfall!
+  title:   Pitfall!
+  region:  NTSC
+  board:   Linear8K
+    memory
+      type: ROM
+      size: 0x2000
+      content: Program
+
+game
+  sha256: 700bdbb98aef4494e39bce978e788dcf2c28a49e06f111c57ff29004f54d7f22
+  name:    Pole Position
+  title:   Pole Position
+  region:  NTSC
+  board:   TwoChip16K
+    memory
+      type: ROM
+      size: 0x4000
+      content: Program
+
+game
+  sha256: 2ac41cd4643a81716597de8c4132f421aa9a7d1bec97c30b7706780f66ff9c5c
+  name:    Popeye
+  title:   Popeye
+  region:  NTSC
+  board:   TwoChip16K
+    memory
+      type: ROM
+      size: 0x4000
+      content: Program
+
+game
+  sha256: dd71b0c2eb40c27bc2e5bf428743e7086f5e23fd23a1125652a9256bcfb55df4
+  name:    Q*bert
+  title:   Q*bert
+  region:  NTSC
+  board:   Linear8K
+    memory
+      type: ROM
+      size: 0x2000
+      content: Program
+
+game
+  sha256: 29537d2da46d760cdb98c4c968fe37763e3da32c434b2bf7118e811b7e0d7673
+  name:    Qix
+  title:   Qix
+  region:  NTSC
+  board:   TwoChip16K
+    memory
+      type: ROM
+      size: 0x4000
+      content: Program
+
+game
+  sha256: 7ed12b0ef8746429661006f26acead4a87748e389c89bc19ed2a058bea091857
+  name:    Quest for Quintana Roo
+  title:   Quest for Quintana Roo
+  region:  NTSC
+  board:   OneChip16K
+    memory
+      type: ROM
+      size: 0x4000
+      content: Program
+
+game
+  sha256: 698e156b564645913aef5a9a874bf21b2f0a4e9dde2005a6bb5f4446c4e4edc0
+  name:    RealSports Baseball
+  title:   RealSports Baseball
+  region:  NTSC
+  board:   Linear32K
+    memory
+      type: ROM
+      size: 0x8000
+      content: Program
+
+game
+  sha256: cc8a5829a923361cd1a6898053f199f7b46a00cb3b3c8ab979c52fd4c95089db
+  name:    RealSports Football
+  title:   RealSports Football
+  region:  NTSC
+  board:   TwoChip16K
+    memory
+      type: ROM
+      size: 0x4000
+      content: Program
+
+game
+  sha256: b13bbb9e3dc3d47812b7626dcd3483002ca7698c1b2aceb7aa54e09f5dd6de5a
+  name:    RealSports Soccer
+  title:   RealSports Soccer
+  region:  NTSC
+  board:   TwoChip16K
+    memory
+      type: ROM
+      size: 0x4000
+      content: Program
+
+game
+  sha256: 5cb84867d6d781e3688c1d346a1947340f6aaefef0c118179b5c89e92e0843b5
+  name:    RealSports Tennis
+  title:   RealSports Tennis
+  region:  NTSC
+  board:   TwoChip16K
+    memory
+      type: ROM
+      size: 0x4000
+      content: Program
+
+game
+  sha256: 145514c439665e7d37929283039c1e2d4b4713f067ecfd011c303e34531e144d
+  name:    Rescue on Fractalus!
+  title:   Rescue on Fractalus!
+  region:  NTSC
+  board:   Linear32K
+    memory
+      type: ROM
+      size: 0x8000
+      content: Program
+
+game
+  sha256: 65a649a34ae8e2942eec74e6ca849145ad605e5742602339427887656a9317d9
+  name:    River Raid
+  title:   River Raid
+  region:  NTSC
+  board:   Linear8K
+    memory
+      type: ROM
+      size: 0x2000
+      content: Program
+
+game
+  sha256: e70955b742ebba1835ed1f4f95a10e059a1142d0d68a2d81dbeb54a2d7b59016
+  name:    Robotron: 2084
+  title:   Robotron: 2084
+  region:  NTSC
+  board:   OneChip16K
+    memory
+      type: ROM
+      size: 0x4000
+      content: Program
+
+game
+  sha256: 1d688fc6f572e6fb437530e917ff033f6ed037c09a5c95161482a9a1429b3a22
+  name:    Space Dungeon
+  title:   Space Dungeon
+  region:  NTSC
+  board:   TwoChip16K
+    memory
+      type: ROM
+      size: 0x4000
+      content: Program
+
+game
+  sha256: 5ee4d7c4834fb2faee22e326a51d0131faeddc4988d774c81ce84692143a4a84
+  name:    Space Invaders
+  title:   Space Invaders
+  region:  NTSC
+  board:   Linear8K
+    memory
+      type: ROM
+      size: 0x2000
+      content: Program
+
+game
+  sha256: a7b30ffe1e43e481920e72a5bad30fe81d81d32245c8f0893c42b134eac4eff6
+  name:    Space Shuttle - A Journey Into Space
+  title:   Space Shuttle - A Journey Into Space
+  region:  NTSC
+  board:   OneChip16K
+    memory
+      type: ROM
+      size: 0x4000
+      content: Program
+
+game
+  sha256: cffaf52ae0e7755ad908652964598489b66ea3513677114b5d457313260f2c5e
+  name:    Star Raiders
+  title:   Star Raiders
+  region:  NTSC
+  board:   TwoChip16K
+    memory
+      type: ROM
+      size: 0x4000
+      content: Program
+
+game
+  sha256: 09b9b5e1c23453d3d60c00ed0b35f742640eaeda3f036d105dca958b72cdbc28
+  name:    Star Trek
+  title:   Star Trek
+  region:  NTSC
+  board:   TwoChip16K
+    memory
+      type: ROM
+      size: 0x4000
+      content: Program
+
+game
+  sha256: 970d7cdf11f06373828c27ba9cc0a2e01e616b40c59352838fa0ee32d2fae222
+  name:    Star Wars - Return of the Jedi - Death Star Battle
+  title:   Star Wars - Return of the Jedi - Death Star Battle
+  region:  NTSC
+  board:   Linear8K
+    memory
+      type: ROM
+      size: 0x2000
+      content: Program
+
+game
+  sha256: 919b65f04ef0c64b3cb551d50bfaa3d923eba4bd33ed17d15af1ed7ad5dc599c
+  name:    Star Wars - The Arcade Game
+  title:   Star Wars - The Arcade Game
+  region:  NTSC
+  board:   TwoChip16K
+    memory
+      type: ROM
+      size: 0x4000
+      content: Program
+
+game
+  sha256: 81d99c73080e57e4066138c44ca34ae9cf5f0fef1ca43f6b3136a36c7435e031
+  name:    Super Breakout
+  title:   Super Breakout
+  region:  NTSC
+  board:   Linear4K
+    memory
+      type: ROM
+      size: 0x1000
+      content: Program
+
+game
+  sha256: 2b06045c19600011b8adab0209e097af367aba0e72cb678211e7fe98738d2d6d
+  name:    Super Cobra
+  title:   Super Cobra
+  region:  NTSC
+  board:   Linear8K
+    memory
+      type: ROM
+      size: 0x2000
+      content: Program
+
+game
+  sha256: 9ffda583a583582991ac504d92741a4fe41da094ab63373425937be94eef086d
+  name:    The Activision Decathlon
+  title:   The Activision Decathlon
+  region:  NTSC
+  board:   OneChip16K
+    memory
+      type: ROM
+      size: 0x4000
+      content: Program
+
+game
+  sha256: 5493c7d3145c68392c3f12972be30a2db4c75e14a12740d7b3b0abbfe3f36747
+  name:    The Dreadnaught Factor
+  title:   The Dreadnaught Factor
+  region:  NTSC
+  board:   Linear8K
+    memory
+      type: ROM
+      size: 0x2000
+      content: Program
+
+game
+  sha256: 871bd42c17733667ddbd3eca844dbf99f330c350c8da3166f004f4a13b018d02
+  name:    Vanguard
+  title:   Vanguard
+  region:  NTSC
+  board:   Linear32K
+    memory
+      type: ROM
+      size: 0x8000
+      content: Program
+
+game
+  sha256: 8483d4bf3a7ff75112ef3dad3d2bde44e0698c27629499c9cad0cc3b9cdedff8
+  name:    Wizard of Wor
+  title:   Wizard of Wor
+  region:  NTSC
+  board:   OneChip16K
+    memory
+      type: ROM
+      size: 0x4000
+      content: Program
+
+game
+  sha256: 2644685d76ba806f7f078831cd93644d37d9a5ef62561a70ae4345b2021a8f3d
+  name:    Zaxxon
+  title:   Zaxxon
+  region:  NTSC
+  board:   Linear32K
+    memory
+      type: ROM
+      size: 0x8000
+      content: Program
+
+game
+  sha256: 981df40e898891e098493ae4c5c0c6062c8acbb2cad74510b9fdba3b3e57a0c4
+  name:    Zenji
+  title:   Zenji
+  region:  NTSC
+  board:   Linear8K
+    memory
+      type: ROM
+      size: 0x2000
+      content: Program
+
+game
+  sha256: 8edbded59f4fa7182b31dbf0a6ef8da3a3bce1fcca12328aca15446ca1bccd79
+  name:    Zone Ranger
+  title:   Zone Ranger
+  region:  NTSC
+  board:   OneChip16K
+    memory
+      type: ROM
+      size: 0x4000
+      content: Program
+
+game
+  sha256: 73b910172bbb3b124be25ccccbcf0ce3db9ac7b886aa67aa82b3ee6cb1eab06a
+  name:    A.E.
+  title:   A.E.
+  region:  NTSC
+  board:   OneChip16K
+    memory
+      type: ROM
+      size: 0x4000
+      content: Program
+
+game
+  sha256: 3ec0c3d2ed71af8628025cea938d0bb1403ebf5f71aefb12b03e51b84486f8f3
+  name:    Atari PAM Diagnostics v2.0
+  title:   Atari PAM Diagnostics v2.0
+  region:  NTSC
+  board:   Overlapping16K
+    memory
+      type: ROM
+      size: 0x4000
+      content: Program
+
+game
+  sha256: 3ecbee24baaa079524ff6f8d5d4e78500a665d5752169799099020940b983195
+  name:    Atari PAM Diagnostics v2.3
+  title:   Atari PAM Diagnostics v2.3
+  region:  NTSC
+  board:   TwoChip16K
+    memory
+      type: ROM
+      size: 0x4000
+      content: Program
+
+game
+  sha256: db6e5251b350e8d09ae53b1f44bb50f6d2c0d6bcec0b5a8b61d6a5b214bfb0d9
+  name:    Battlezone (Prototype)
+  title:   Battlezone (Prototype)
+  region:  NTSC
+  board:   TwoChip16K
+    memory
+      type: ROM
+      size: 0x4000
+      content: Program
+
+game
+  sha256: e8c863fd55c1a261a86ea812467119ed6f46b99aea668fa30cbe446447fa48ac
+  name:    Blaster (Prototype)
+  title:   Blaster (Prototype)
+  region:  NTSC
+  board:   OneChip16K
+    memory
+      type: ROM
+      size: 0x4000
+      content: Program
+
+game
+  sha256: 1690a1c9e896e238462bd2c0d39abc9089aac61dcc9fcae53d556fdf979f8b45
+  name:    Buck Rogers - Planet of Zoom (Alternate)
+  title:   Buck Rogers - Planet of Zoom (Alternate)
+  region:  NTSC
+  board:   TwoChip16K
+    memory
+      type: ROM
+      size: 0x4000
+      content: Program
+
+game
+  sha256: 29f64b6f3d0daae5a876114cca8faead11f8fd0854f4a69033c66e16a15eaa43
+  name:    Final Legacy (Prototype)
+  title:   Final Legacy (Prototype)
+  region:  NTSC
+  board:   OneChip16K
+    memory
+      type: ROM
+      size: 0x4000
+      content: Program
+
+game
+  sha256: 53dac12aedfd9efaf11a8619a84f6914f67cf63febddc02ed2c48bdf591c3653
+  name:    Frisky Tom (Prototype)
+  title:   Frisky Tom (Prototype)
+  region:  NTSC
+  board:   TwoChip16K
+    memory
+      type: ROM
+      size: 0x4000
+      content: Program
+
+game
+  sha256: d922f6e2f1166f76354832741e10228bac50dfb91741399698e70723eb4d9e4b
+  name:    Gyruss (Alternate)
+  title:   Gyruss (Alternate)
+  region:  NTSC
+  board:   TwoChip16K
+    memory
+      type: ROM
+      size: 0x4000
+      content: Program
+
+game
+  sha256: 91cb207d0c6a7ee576a32d591814b22c2539aa5410d0c4a543369937e3a2fdfc
+  name:    Jr. Pac-Man (Prototype)
+  title:   Jr. Pac-Man (Prototype)
+  region:  NTSC
+  board:   TwoChip16K
+    memory
+      type: ROM
+      size: 0x4000
+      content: Program
+
+game
+  sha256: 01e6f03012aaade5ab6001f75bc52afe5b403edbc4b932cc80b4ba6f23cf178a
+  name:    The Last Starfighter (Prototype)
+  title:   The Last Starfighter (Prototype)
+  region:  NTSC
+  board:   OneChip16K
+    memory
+      type: ROM
+      size: 0x4000
+      content: Program
+
+game
+  sha256: f9ee3a083d89fd78e60d6169888c39faee6bf6b699d371c79bc3f37b00961c3e
+  name:    Looney Tunes Hotel (Prototype)
+  title:   Looney Tunes Hotel (Prototype)
+  region:  NTSC
+  board:   TwoChip16K
+    memory
+      type: ROM
+      size: 0x4000
+      content: Program
+
+game
+  sha256: f275c21845c71aaa0fe94bbd93e6bc49b5d740601c82e53dfedd9c64a56e0b2f
+  name:    Microgammon SB (Prototype)
+  title:   Microgammon SB (Prototype)
+  region:  NTSC
+  board:   TwoChip16K
+    memory
+      type: ROM
+      size: 0x4000
+      content: Program
+
+game
+  sha256: 3cd0e22123f2add19c9af41f1f283d3f2f5739b260a5183b305d1d5fc8aab771
+  name:    Millipede (Prototype)
+  title:   Millipede (Prototype)
+  region:  NTSC
+  board:   OneChip16K
+    memory
+      type: ROM
+      size: 0x4000
+      content: Program
+
+game
+  sha256: 9c62ba7e382cb0ddc91623cb114b586b372fd063fe21fd78dd9fcdfeecc9bda3
+  name:    Miniature Golf (Prototype)
+  title:   Miniature Golf (Prototype)
+  region:  NTSC
+  board:   TwoChip16K
+    memory
+      type: ROM
+      size: 0x4000
+      content: Program
+
+game
+  sha256: 6d2c4642e18dadeb6bd9d1a1f2132132241f7e088d37cf480d0f01a8bc9e8ff7
+  name:    RealSports Basketball (1982 Prototype)
+  title:   RealSports Basketball (1982 Prototype)
+  region:  NTSC
+  board:   TwoChip16K
+    memory
+      type: ROM
+      size: 0x4000
+      content: Program
+
+game
+  sha256: 2f90e50d57d751155cd3553a67e8d92e0ed2880d42fdb7c73bb6295c859cd882
+  name:    Road Runner (Prototype)
+  title:   Road Runner (Prototype)
+  region:  NTSC
+  board:   TwoChip16K
+    memory
+      type: ROM
+      size: 0x4000
+      content: Program
+
+game
+  sha256: a23784ba01982b33179ba8f07683877b498d2f3d143e143d4694d7f1b640cada
+  name:    Sport Goofy (Prototype)
+  title:   Sport Goofy (Prototype)
+  region:  NTSC
+  board:   TwoChip16K
+    memory
+      type: ROM
+      size: 0x4000
+      content: Program
+
+game
+  sha256: dc6099476d37cbd85f368bee597492e1f305e1cddab2c17bd6a47c898751a487
+  name:    Star Raiders (Alternate)
+  title:   Star Raiders (Alternate)
+  region:  NTSC
+  board:   TwoChip16K
+    memory
+      type: ROM
+      size: 0x4000
+      content: Program
+
+game
+  sha256: 820174485d32ff27811b48b5a1525493fcb6281ddf74f1d1d9cfd874f2918331
+  name:    Star Trek - Strategic Operations Simulator (Alternate)
+  title:   Star Trek - Strategic Operations Simulator (Alternate)
+  region:  NTSC
+  board:   OneChip16K
+    memory
+      type: ROM
+      size: 0x4000
+      content: Program
+
+game
+  sha256: 4bda10d851864513df0ec47c307c7fcc7ea9b0afc141c6a67ef6ab636c79d61e
+  name:    Stargate (Prototype)
+  title:   Stargate (Prototype)
+  region:  NTSC
+  board:   TwoChip16K
+    memory
+      type: ROM
+      size: 0x4000
+      content: Program
+
+game
+  sha256: 484e2488429eb5b1598566cd832a3e3b0b90cb277b99e8c3dfe7e9fc8ecffaaa
+  name:    Super Pac-Man (Prototype)
+  title:   Super Pac-Man (Prototype)
+  region:  NTSC
+  board:   OneChip16K
+    memory
+      type: ROM
+      size: 0x4000
+      content: Program
+
+game
+  sha256: 29af287d437a500ca79086e35d93d327cee0136b0655a82204a28d59ae869847
+  name:    Super Pac-Man (Alternate Prototype)
+  title:   Super Pac-Man (Alternate Prototype)
+  region:  NTSC
+  board:   TwoChip16K
+    memory
+      type: ROM
+      size: 0x4000
+      content: Program
+
+game
+  sha256: b7283b53cfd6e4972ec3cd04e49ffd20de3195f895ec6a59c92da719f0aa9cce
+  name:    Tempest (Prototype)
+  title:   Tempest (Prototype)
+  region:  NTSC
+  board:   OneChip16K
+    memory
+      type: ROM
+      size: 0x4000
+      content: Program
+
+game
+  sha256: 2a74517e4eadd286b8c2d507bba0fc5f530ce6746686a95d6a60d22dd10ae6cd
+  name:    Track and Field (Prototype)
+  title:   Track and Field (Prototype)
+  region:  NTSC
+  board:   OneChip16K
+    memory
+      type: ROM
+      size: 0x4000
+      content: Program
+
+game
+  sha256: 51c902b011785bcf5192d6fafb83e133fdde88952b2b5a0a4f11ecae418d7ace
+  name:    Xari Arena (Prototype 2)
+  title:   Xari Arena (Prototype 2)
+  region:  NTSC
+  board:   TwoChip16K
+    memory
+      type: ROM
+      size: 0x4000
+      content: Program
+
+game
+  sha256: c4c9a5fe83d70df121233e4187225f3ddf6c240464ea6b35b7df4628e3ae08c9
+  name:    Xari Arena (Prototype)
+  title:   Xari Arena (Prototype)
+  region:  NTSC
+  board:   TwoChip16K
+    memory
+      type: ROM
+      size: 0x4000
+      content: Program

--- a/mia/medium/atari-5200.cpp
+++ b/mia/medium/atari-5200.cpp
@@ -1,0 +1,61 @@
+struct Atari5200 : Cartridge {
+  auto name() -> string override { return "Atari 5200"; }
+  auto extensions() -> std::vector<string> override { return {"a52", "bin", "car"}; }
+  auto load(string location) -> LoadResult override;
+  auto save(string location) -> bool override;
+  auto analyze(const std::vector<u8>& rom) -> string;
+};
+
+auto Atari5200::load(string location) -> LoadResult {
+  std::vector<u8> rom;
+  if(directory::exists(location)) {
+    append(rom, {location, "program.rom"});
+  } else if(file::exists(location)) {
+    rom = Cartridge::read(location);
+  }
+  if(rom.empty()) return romNotFound;
+
+  if(rom.size() >= 4 && rom[0] == 'C' && rom[1] == 'A' && rom[2] == 'R' && rom[3] == 'T') {
+    return invalidROM;
+  }
+
+  sha256 = Hash::SHA256(rom).digest();
+  if(rom.size() != 32_KiB) {
+    // Raw 16 KiB images are ambiguous between one-chip and two-chip boards.
+    // Smaller images, headered .car files, and additional board layouts belong
+    // to the mapper child so this scaffold never guesses a wiring layout.
+    return invalidROM;
+  }
+
+  this->location = location;
+  this->manifest = analyze(rom);
+  auto document = BML::unserialize(manifest);
+  if(!document) return couldNotParseManifest;
+
+  pak = std::make_shared<vfs::directory>();
+  pak->setAttribute("title", document["game/title"].string());
+  pak->setAttribute("region", document["game/region"].string());
+  pak->setAttribute("board", document["game/board"].string());
+  pak->append("manifest.bml", manifest);
+  pak->append("program.rom", rom);
+  return successful;
+}
+
+auto Atari5200::save(string location) -> bool {
+  return true;
+}
+
+auto Atari5200::analyze(const std::vector<u8>& rom) -> string {
+  string manifest;
+  manifest += "game\n";
+  manifest +={"  name:   ", Medium::name(location), "\n"};
+  manifest +={"  title:  ", Medium::name(location), "\n"};
+  manifest += "  region: NTSC\n";
+  manifest +={"  sha256: ", sha256, "\n"};
+  manifest += "  board:  Linear32K\n";
+  manifest += "    memory\n";
+  manifest += "      type: ROM\n";
+  manifest +={"      size: 0x", hex(rom.size()), "\n"};
+  manifest += "      content: Program\n";
+  return manifest;
+}

--- a/mia/medium/atari-5200.cpp
+++ b/mia/medium/atari-5200.cpp
@@ -3,59 +3,263 @@ struct Atari5200 : Cartridge {
   auto extensions() -> std::vector<string> override { return {"a52", "bin", "car"}; }
   auto load(string location) -> LoadResult override;
   auto save(string location) -> bool override;
-  auto analyze(const std::vector<u8>& rom) -> string;
+
+private:
+  struct Board {
+    string name;
+    u32 size = 0;
+
+    explicit operator bool() const { return size; }
+  };
+
+  enum class CARTKind {
+    Unknown,
+    AtariComputer,
+    Atari5200,
+    UnsupportedAtari5200,
+  };
+
+  struct CARTLayout {
+    CARTKind kind = CARTKind::Unknown;
+    Board board;
+  };
+
+  auto loadDirectory(string location) -> LoadResult;
+  auto loadCART(string location, const std::vector<u8>& image) -> LoadResult;
+  auto loadROM(string location, std::vector<u8> rom, Board expectedBoard) -> LoadResult;
+  auto mount(string location, std::vector<u8> rom, string packageManifest) -> LoadResult;
+
+  auto validateManifest(const string& packageManifest, const std::vector<u8>& rom) const -> string;
+  auto analyze(string location, const std::vector<u8>& rom, const Board& board, string digest) const -> string;
+
+  auto identifyBoard(string name) const -> Board;
+  auto identifyCART(u32 type) const -> CARTLayout;
+  auto identifySource(string digest) const -> Board;
+  auto inferBoard(u32 size) const -> Board;
+  auto normalize(Board& board, std::vector<u8>& rom) const -> void;
+  auto checksum(const std::vector<u8>& image, u32 offset) const -> u32;
 };
 
 auto Atari5200::load(string location) -> LoadResult {
-  std::vector<u8> rom;
-  if(directory::exists(location)) {
-    append(rom, {location, "program.rom"});
-  } else if(file::exists(location)) {
-    rom = Cartridge::read(location);
-  }
-  if(rom.empty()) return romNotFound;
+  this->location = {};
+  pak.reset();
+  manifest = {};
+  sha256 = {};
 
-  if(rom.size() >= 4 && rom[0] == 'C' && rom[1] == 'A' && rom[2] == 'R' && rom[3] == 'T') {
-    return invalidROM;
+  if(directory::exists(location)) return loadDirectory(location);
+  if(!file::exists(location)) return romNotFound;
+
+  auto image = Cartridge::read(location);
+  if(image.empty()) return romNotFound;
+
+  bool hasCARTMagic = image.size() >= 4
+    && image[0] == 'C' && image[1] == 'A' && image[2] == 'R' && image[3] == 'T';
+  if(hasCARTMagic || location.iendsWith(".car")) return loadCART(location, image);
+  return loadROM(location, std::move(image), {});
+}
+
+auto Atari5200::loadDirectory(string location) -> LoadResult {
+  auto manifestPath = string{location, "/manifest.bml"};
+  auto programPath = string{location, "/program.rom"};
+  if(!file::exists(manifestPath) || !file::exists(programPath)) {
+    return {invalidROM, "The normalized package requires manifest.bml and program.rom. "};
   }
 
-  sha256 = Hash::SHA256(rom).digest();
-  if(rom.size() != 32_KiB) {
-    // Raw 16 KiB images are ambiguous between one-chip and two-chip boards.
-    // Smaller images, headered .car files, and additional board layouts belong
-    // to the mapper child so this scaffold never guesses a wiring layout.
-    return invalidROM;
+  string packageManifest = file::read(manifestPath);
+  auto rom = file::read(programPath);
+  if(rom.empty()) return {invalidROM, "The normalized package has an empty program.rom. "};
+
+  auto detail = validateManifest(packageManifest, rom);
+  if(detail) return {invalidROM, detail};
+  return mount(location, std::move(rom), std::move(packageManifest));
+}
+
+auto Atari5200::loadCART(string location, const std::vector<u8>& image) -> LoadResult {
+  if(image.size() < 16) return {invalidROM, "The CART header is truncated. "};
+  if(image[0] != 'C' || image[1] != 'A' || image[2] != 'R' || image[3] != 'T') {
+    return {invalidROM, "The CART header magic is invalid. "};
   }
 
-  this->location = location;
-  this->manifest = analyze(rom);
-  auto document = BML::unserialize(manifest);
+  u32 type = (u32)image[4] << 24 | (u32)image[5] << 16 | (u32)image[6] << 8 | image[7];
+  auto layout = identifyCART(type);
+
+  switch(layout.kind) {
+  case CARTKind::AtariComputer: {
+    LoadResult result(wrongMediaType);
+    result.mediaType = "Atari 8-bit computer cartridge";
+    result.info = {"CART type ", type, ". "};
+    return result;
+  }
+  case CARTKind::UnsupportedAtari5200:
+    return {invalidROM, {"CART type ", type, " is an unsupported Atari 5200 cartridge layout. "}};
+  case CARTKind::Unknown:
+    return {invalidROM, {"CART type ", type, " is not recognized. "}};
+  case CARTKind::Atari5200:
+    break;
+  }
+
+  if(image.size() != 16 + layout.board.size) {
+    return {invalidROM, {"CART type ", type, " requires exactly ", layout.board.size, " payload bytes. "}};
+  }
+  if(image[12] || image[13] || image[14] || image[15]) {
+    return {invalidROM, "The CART reserved header bytes must be zero. "};
+  }
+
+  u32 expectedChecksum = (u32)image[8] << 24 | (u32)image[9] << 16 | (u32)image[10] << 8 | image[11];
+  if(checksum(image, 16) != expectedChecksum) return {invalidROM, "The CART payload checksum is invalid. "};
+
+  std::vector<u8> rom(image.begin() + 16, image.end());
+  normalize(layout.board, rom);
+
+  return loadROM(location, std::move(rom), layout.board);
+}
+
+auto Atari5200::loadROM(string location, std::vector<u8> rom, Board expectedBoard) -> LoadResult {
+  auto digest = Hash::SHA256(rom).digest();
+  if(!expectedBoard) {
+    expectedBoard = identifySource(digest);
+    if(expectedBoard) {
+      normalize(expectedBoard, rom);
+      digest = Hash::SHA256(rom).digest();
+    }
+  }
+
+  auto databaseManifest = manifestDatabase(digest);
+  if(databaseManifest) {
+    auto detail = validateManifest(databaseManifest, rom);
+    if(detail) return {couldNotParseManifest, {"Atari 5200.bml: ", detail}};
+
+    if(expectedBoard) {
+      auto document = BML::unserialize(databaseManifest);
+      if(document["game/board"].string() != expectedBoard.name) {
+        return {couldNotParseManifest, "Atari 5200.bml: CART type and database board disagree. "};
+      }
+    }
+    return mount(location, std::move(rom), std::move(databaseManifest));
+  }
+
+  if(!expectedBoard) expectedBoard = inferBoard(rom.size());
+  if(!expectedBoard && rom.size() == 16_KiB) {
+    return {
+      invalidROM,
+      "Raw 16 KiB images require an Atari 5200 database match to select one- or two-chip wiring. "
+    };
+  }
+  if(!expectedBoard && rom.size() == 40_KiB) {
+    return {
+      invalidROM,
+      "Raw 40 KiB images require an Atari 5200 database match to select the Bounty Bob source variant. "
+    };
+  }
+  if(!expectedBoard) return {invalidROM, {"Raw cartridge size ", rom.size(), " is not supported. "}};
+
+  auto fallbackManifest = analyze(location, rom, expectedBoard, digest);
+  return mount(location, std::move(rom), std::move(fallbackManifest));
+}
+
+auto Atari5200::mount(string location, std::vector<u8> rom, string packageManifest) -> LoadResult {
+  auto document = BML::unserialize(packageManifest);
   if(!document) return couldNotParseManifest;
 
+  this->location = location;
+  this->manifest = packageManifest;
+  sha256 = Hash::SHA256(rom).digest();
   pak = std::make_shared<vfs::directory>();
   pak->setAttribute("title", document["game/title"].string());
   pak->setAttribute("region", document["game/region"].string());
   pak->setAttribute("board", document["game/board"].string());
-  pak->append("manifest.bml", manifest);
+  pak->append("manifest.bml", packageManifest);
   pak->append("program.rom", rom);
   return successful;
 }
 
-auto Atari5200::save(string location) -> bool {
-  return true;
+auto Atari5200::validateManifest(const string& packageManifest, const std::vector<u8>& rom) const -> string {
+  auto document = BML::unserialize(packageManifest);
+  if(!document) return "The manifest could not be parsed. ";
+
+  auto board = identifyBoard(document["game/board"].string());
+  if(!board) return {"The manifest board '", document["game/board"].string(), "' is unsupported. "};
+
+  auto memories = document.find("game/board/memory(type=ROM,content=Program)");
+  if(memories.size() != 1) return "The manifest must contain exactly one Program ROM memory node. ";
+  if(memories[0]["size"].natural() != board.size) {
+    return {"The manifest Program ROM size does not match board ", board.name, ". "};
+  }
+  if(rom.size() != board.size) return {"program.rom does not match board ", board.name, ". "};
+
+  auto expectedHash = document["game/sha256"].string();
+  if(expectedHash && expectedHash != Hash::SHA256(rom).digest()) {
+    return "program.rom does not match the manifest SHA-256. ";
+  }
+  return {};
 }
 
-auto Atari5200::analyze(const std::vector<u8>& rom) -> string {
+auto Atari5200::analyze(string location, const std::vector<u8>& rom, const Board& board,
+  string digest) const -> string {
   string manifest;
   manifest += "game\n";
   manifest +={"  name:   ", Medium::name(location), "\n"};
   manifest +={"  title:  ", Medium::name(location), "\n"};
   manifest += "  region: NTSC\n";
-  manifest +={"  sha256: ", sha256, "\n"};
-  manifest += "  board:  Linear32K\n";
+  manifest +={"  sha256: ", digest, "\n"};
+  manifest +={"  board:  ", board.name, "\n"};
   manifest += "    memory\n";
   manifest += "      type: ROM\n";
   manifest +={"      size: 0x", hex(rom.size()), "\n"};
   manifest += "      content: Program\n";
   return manifest;
+}
+
+auto Atari5200::identifyBoard(string name) const -> Board {
+  if(name == "Linear4K"      ) return {name,  4_KiB};
+  if(name == "Linear8K"      ) return {name,  8_KiB};
+  if(name == "OneChip16K"    ) return {name, 16_KiB};
+  if(name == "TwoChip16K"    ) return {name, 16_KiB};
+  if(name == "Overlapping16K") return {name, 16_KiB};
+  if(name == "Linear32K"     ) return {name, 32_KiB};
+  if(name == "DualWindow40K" ) return {name, 40_KiB};
+  return {};
+}
+
+auto Atari5200::identifyCART(u32 type) const -> CARTLayout {
+  if(type ==   4) return {CARTKind::Atari5200, identifyBoard("Linear32K")};
+  if(type ==   6) return {CARTKind::Atari5200, identifyBoard("TwoChip16K")};
+  if(type ==   7) return {CARTKind::Atari5200, identifyBoard("DualWindow40K")};
+  if(type ==  16) return {CARTKind::Atari5200, identifyBoard("OneChip16K")};
+  if(type ==  19) return {CARTKind::Atari5200, identifyBoard("Linear8K")};
+  if(type ==  20) return {CARTKind::Atari5200, identifyBoard("Linear4K")};
+  if(type == 159) return {CARTKind::Atari5200, {"DualWindow40KAlt", 40_KiB}};
+  if(type >= 71 && type <= 74) return {CARTKind::UnsupportedAtari5200};
+  if((type >= 1 && type <= 112) || type == 160) return {CARTKind::AtariComputer};
+  return {};
+}
+
+auto Atari5200::identifySource(string digest) const -> Board {
+  if(digest == "957aee5457f89ff9a89b87d045f4803c870b54f40045e3c397b47f716fedadff") {
+    return identifyCART(159).board;
+  }
+  return {};
+}
+
+auto Atari5200::inferBoard(u32 size) const -> Board {
+  if(size ==  4_KiB) return identifyBoard("Linear4K");
+  if(size ==  8_KiB) return identifyBoard("Linear8K");
+  if(size == 32_KiB) return identifyBoard("Linear32K");
+  return {};
+}
+
+auto Atari5200::normalize(Board& board, std::vector<u8>& rom) const -> void {
+  if(board.name != "DualWindow40KAlt") return;
+  std::rotate(rom.begin(), rom.begin() + 0x2000, rom.end());
+  board = identifyBoard("DualWindow40K");
+}
+
+auto Atari5200::checksum(const std::vector<u8>& image, u32 offset) const -> u32 {
+  u32 checksum = 0;
+  while(offset < image.size()) checksum += image[offset++];
+  return checksum;
+}
+
+auto Atari5200::save(string location) -> bool {
+  return true;
 }

--- a/mia/medium/medium.cpp
+++ b/mia/medium/medium.cpp
@@ -3,6 +3,7 @@ namespace Media {
   #include "mame.cpp"
   #include "arcade.cpp"
   #include "atari-2600.cpp"
+  #include "atari-5200.cpp"
   #include "colecovision.cpp"
   #include "myvision.cpp"
   #include "famicom.cpp"
@@ -48,6 +49,7 @@ namespace Media {
 auto Medium::create(string name) -> std::shared_ptr<Pak> {
   if(name == "Arcade") return std::make_shared<Media::Arcade>();
   if(name == "Atari 2600") return std::make_shared<Media::Atari2600>();
+  if(name == "Atari 5200") return std::make_shared<Media::Atari5200>();
   if(name == "ColecoVision") return std::make_shared<Media::ColecoVision>();
   if(name == "MyVision") return std::make_shared<Media::MyVision>();
   if(name == "Famicom") return std::make_shared<Media::Famicom>();

--- a/mia/mia.cpp
+++ b/mia/mia.cpp
@@ -87,6 +87,7 @@ auto construct() -> void {
   initialized = true;
 
   media.push_back("Atari 2600");
+  media.push_back("Atari 5200");
   media.push_back("BS Memory");
   media.push_back("ColecoVision");
   media.push_back("MyVision");

--- a/mia/system/atari-5200.cpp
+++ b/mia/system/atari-5200.cpp
@@ -1,0 +1,20 @@
+struct Atari5200 : System {
+  auto name() -> string override { return "Atari 5200"; }
+  auto load(string location) -> LoadResult override;
+  auto save(string location) -> bool override;
+};
+
+auto Atari5200::load(string location) -> LoadResult {
+  auto bios = Pak::read(location);
+  if(bios.empty()) return romNotFound;
+  if(bios.size() != 2_KiB) return invalidROM;
+
+  this->location = locate();
+  pak = std::make_shared<vfs::directory>();
+  pak->append("bios.rom", bios);
+  return successful;
+}
+
+auto Atari5200::save(string location) -> bool {
+  return true;
+}

--- a/mia/system/system.cpp
+++ b/mia/system/system.cpp
@@ -1,6 +1,7 @@
 namespace Systems {
   #include "arcade.cpp"
   #include "atari-2600.cpp"
+  #include "atari-5200.cpp"
   #include "colecovision.cpp"
   #include "myvision.cpp"
   #include "famicom.cpp"
@@ -40,6 +41,7 @@ namespace Systems {
 auto System::create(string name) -> std::shared_ptr<Pak> {
   if(name == "Arcade") return std::make_shared<Systems::Arcade>();
   if(name == "Atari 2600") return std::make_shared<Systems::Atari2600>();
+  if(name == "Atari 5200") return std::make_shared<Systems::Atari5200>();
   if(name == "ColecoVision") return std::make_shared<Systems::ColecoVision>();
   if(name == "MyVision") return std::make_shared<Systems::MyVision>();
   if(name == "Famicom") return std::make_shared<Systems::Famicom>();


### PR DESCRIPTION
adds Atari 5200 support, targeting the NTSC four-port system.

It includes:

- ANTIC, GTIA, and POKEY emulation
- Standard Atari 5200 controllers
- CX53 Trak-Ball support
- Common cartridge layouts