### PR TITLE
md: add kmod message log channel

### DIFF
--- a/ares/md/vdp/debugger.cpp
+++ b/ares/md/vdp/debugger.cpp
@@ -31,6 +31,13 @@ auto VDP::Debugger::load(Node::Object parent) -> void {
   tracer.interrupt = parent->append<Node::Debugger::Tracer::Notification>("Interrupt", "VDP");
   tracer.dma = parent->append<Node::Debugger::Tracer::Notification>("DMA", "VDP");
   tracer.io = parent->append<Node::Debugger::Tracer::Notification>("I/O", "VDP");
+
+  //Off until asked for, like every other tracer here: `enabled()` is
+  //`file() || terminal()`, so setting either of them here would have this one
+  //channel printing from boot for every user. The line break is suppressed
+  //because a message arrives a character at a time and ends on a zero write.
+  tracer.message = parent->append<Node::Debugger::Tracer::Notification>("Message", "VDP");
+  tracer.message->setAutoLineBreak(false);
 }
 
 auto VDP::Debugger::unload() -> void {
@@ -100,9 +107,9 @@ auto VDP::Debugger::io(n5 register, n8 data) -> void {
       /* $1a */ "",
       /* $1b */ "",
       /* $1c */ "",
-      /* $1d */ "",
-      /* $1e */ "",
-      /* $1f */ "",
+      /* $1d */ "KMod control",
+      /* $1e */ "KMod message",
+      /* $1f */ "KMod timer",
     };
     tracer.io->notify({
       "$", hex(register, 2L), " = #$", hex(data, 2L),
@@ -110,4 +117,10 @@ auto VDP::Debugger::io(n5 register, n8 data) -> void {
       "  ", name[register]
     });
   }
+}
+
+auto VDP::Debugger::messageChar(n8 data) -> void {
+  //Gens KMod convention: characters accumulate until a zero write ends the message
+  if(!tracer.message->enabled()) return;
+  tracer.message->notify(data ? (char)data : '\n');
 }

--- a/ares/md/vdp/io.cpp
+++ b/ares/md/vdp/io.cpp
@@ -376,6 +376,12 @@ auto VDP::writeControlPort(n16 data) -> void {
     return;
   }
 
+  //KMod message (an emulator debug extension; not a register on real hardware)
+  case 0x1e: {
+    debugger.messageChar(data.bit(0,7));
+    return;
+  }
+
   //unused
   default: {
     return;

--- a/ares/md/vdp/vdp.hpp
+++ b/ares/md/vdp/vdp.hpp
@@ -18,6 +18,7 @@ struct VDP : Thread {
     auto dmaFill(n4 target, n17 address, n16 data) -> void;
     auto dmaCopy(n22 source, n4 target, n17 address, n16 data) -> void;
     auto io(n5 register, n8 data) -> void;
+    auto messageChar(n8 data) -> void;
 
     struct Memory {
       Node::Debugger::Memory vram;
@@ -29,6 +30,7 @@ struct VDP : Thread {
       Node::Debugger::Tracer::Notification interrupt;
       Node::Debugger::Tracer::Notification dma;
       Node::Debugger::Tracer::Notification io;
+      Node::Debugger::Tracer::Notification message;
     } tracer;
   } debugger{*this};
 


### PR DESCRIPTION
Mega Drive homebrew and test ROMs can log text through the Gens KMod debug registers. $1e on the VDP control port takes one character at a time, and a zero write ends the line. ares currently ignores those writes, so a ROM that prints its progress that way is silent.
