### PR TITLE
n64: fix builds with ARES_UNITY_CORES=OFF

### DIFF
--- a/ares/n64/vulkan/vulkan.cpp
+++ b/ares/n64/vulkan/vulkan.cpp
@@ -1,5 +1,9 @@
 #include <n64/n64.hpp>
 
+//included here rather than in vulkan.hpp so that parallel-rdp headers are only
+//parsed in this translation unit
+#include "rdp_device.hpp"
+
 namespace ares::Nintendo64 {
 
 Vulkan vulkan;

--- a/ares/n64/vulkan/vulkan.hpp
+++ b/ares/n64/vulkan/vulkan.hpp
@@ -1,5 +1,3 @@
-#include "rdp_device.hpp"
-
 namespace ares::Nintendo64 {
 
 struct Vulkan {


### PR DESCRIPTION
Fixes #2597 