### PR TITLE
recompiler: fix floating-point issues impacting n64 core

### DIFF
--- a/ares/n64/cpu/recompiler-fpu.cpp
+++ b/ares/n64/cpu/recompiler-fpu.cpp
@@ -804,14 +804,14 @@ auto CPU::Recompiler::emitFPU(u32 instruction, EmitPcMode pcMode) -> EmitExecute
       if(isDouble) {
         mov64(freg(0), reg(0));
         mov64(freg(1), reg(1));
-        fcmp64(freg(0), freg(1));
+        fcmp64(freg(0), freg(1), set_feq);
         mov32(reg(2), imm(0));
         mov32(reg(3), imm(1));
         cmov32(reg(2), reg(3), reg(2), flag_feq);
       } else {
         mov32(freg(0), reg(0));
         mov32(freg(1), reg(1));
-        fcmp32(freg(0), freg(1));
+        fcmp32(freg(0), freg(1), set_feq);
         mov32(reg(2), imm(0));
         mov32(reg(3), imm(1));
         cmov32(reg(2), reg(3), reg(2), flag_feq);
@@ -822,14 +822,14 @@ auto CPU::Recompiler::emitFPU(u32 instruction, EmitPcMode pcMode) -> EmitExecute
       if(isDouble) {
         mov64(freg(0), reg(0));
         mov64(freg(1), reg(1));
-        fcmp64(freg(0), freg(1));
+        fcmp64(freg(0), freg(1), set_flt);
         mov32(reg(2), imm(0));
         mov32(reg(3), imm(1));
         cmov32(reg(2), reg(3), reg(2), flag_flt);
       } else {
         mov32(freg(0), reg(0));
         mov32(freg(1), reg(1));
-        fcmp32(freg(0), freg(1));
+        fcmp32(freg(0), freg(1), set_flt);
         mov32(reg(2), imm(0));
         mov32(reg(3), imm(1));
         cmov32(reg(2), reg(3), reg(2), flag_flt);
@@ -840,14 +840,14 @@ auto CPU::Recompiler::emitFPU(u32 instruction, EmitPcMode pcMode) -> EmitExecute
       if(isDouble) {
         mov64(freg(0), reg(0));
         mov64(freg(1), reg(1));
-        fcmp64(freg(0), freg(1));
+        fcmp64(freg(0), freg(1), set_fle);
         mov32(reg(2), imm(0));
         mov32(reg(3), imm(1));
         cmov32(reg(2), reg(3), reg(2), flag_fle);
       } else {
         mov32(freg(0), reg(0));
         mov32(freg(1), reg(1));
-        fcmp32(freg(0), freg(1));
+        fcmp32(freg(0), freg(1), set_fle);
         mov32(reg(2), imm(0));
         mov32(reg(3), imm(1));
         cmov32(reg(2), reg(3), reg(2), flag_fle);

--- a/ares/n64/cpu/recompiler.cpp
+++ b/ares/n64/cpu/recompiler.cpp
@@ -603,7 +603,7 @@ auto CPU::Recompiler::emit(u64 vaddr, u32 address, u64 stateKey) -> Block* {
   };
 
   // Phase 3: begin host emission.
-  beginFunction(3, 3, 6);
+  beginFunction(3, 3, 6, 2);
   slowPaths.clear();
   emitDeferredCycles = 0;
 

--- a/nall/nall/recompiler/generic/constants.hpp
+++ b/nall/nall/recompiler/generic/constants.hpp
@@ -13,6 +13,9 @@
     set_sle = SLJIT_SET_SIG_LESS_EQUAL,
     set_o = SLJIT_SET_OVERFLOW,
     set_c = SLJIT_SET_CARRY,
+    set_feq = SLJIT_SET_F_EQUAL,
+    set_flt = SLJIT_SET_F_LESS,
+    set_fle = SLJIT_SET_F_LESS_EQUAL,
   };
 
   enum flags {

--- a/nall/nall/recompiler/generic/encoder-instructions.hpp
+++ b/nall/nall/recompiler/generic/encoder-instructions.hpp
@@ -356,13 +356,13 @@
   }
 
   template<typename T, typename U>
-  auto fcmp32(T x, U y) -> void {
-    sljit_emit_fop1(compiler, SLJIT_CMP_F32, x.fst, x.snd, y.fst, y.snd);
+  auto fcmp32(T x, U y, sljit_s32 flags) -> void {
+    sljit_emit_fop1(compiler, SLJIT_CMP_F32 | flags, x.fst, x.snd, y.fst, y.snd);
   }
 
   template<typename T, typename U>
-  auto fcmp64(T x, U y) -> void {
-    sljit_emit_fop1(compiler, SLJIT_CMP_F64, x.fst, x.snd, y.fst, y.snd);
+  auto fcmp64(T x, U y, sljit_s32 flags) -> void {
+    sljit_emit_fop1(compiler, SLJIT_CMP_F64 | flags, x.fst, x.snd, y.fst, y.snd);
   }
 
   template<typename T, typename U>
@@ -420,7 +420,7 @@
   }
 
   auto mov128(mem dst, mem src) -> void {
-    static constexpr sljit_s32 kSimdTmp = SLJIT_FR(6);
+    static constexpr sljit_s32 kSimdTmp = SLJIT_TMP_DEST_VREG;
     static constexpr sljit_s32 kSimdType = SLJIT_SIMD_REG_128 | SLJIT_SIMD_ELEM_8 | SLJIT_SIMD_MEM_UNALIGNED;
     sljit_emit_simd_mov(compiler, SLJIT_SIMD_LOAD | kSimdType, kSimdTmp, src.fst, src.snd);
     sljit_emit_simd_mov(compiler, SLJIT_SIMD_STORE | kSimdType, kSimdTmp, dst.fst, dst.snd);

--- a/nall/nall/recompiler/generic/generic.hpp
+++ b/nall/nall/recompiler/generic/generic.hpp
@@ -14,7 +14,7 @@ namespace nall::recompiler {
     generic(bump_allocator& alloc) : allocator(alloc) {}
     ~generic() { resetCompiler(); }
 
-    auto beginFunction(int args, int savedRegs = 3, int scratchRegs = 4) -> void {
+    auto beginFunction(int args, int savedRegs = 3, int scratchRegs = 4, int fscratchRegs = 0) -> void {
       assert(args <= 3);
       assert(scratchRegs >= 3);
       assert(savedRegs >= 3);
@@ -25,7 +25,7 @@ namespace nall::recompiler {
       if(args >= 1) options |= SLJIT_ARG_VALUE(SLJIT_ARG_TYPE_W, 1);
       if(args >= 2) options |= SLJIT_ARG_VALUE(SLJIT_ARG_TYPE_W, 2);
       if(args >= 3) options |= SLJIT_ARG_VALUE(SLJIT_ARG_TYPE_W, 3);
-      sljit_emit_enter(compiler, 0, options, scratchRegs, savedRegs, 0);
+      sljit_emit_enter(compiler, 0, options, scratchRegs | SLJIT_ENTER_FLOAT(fscratchRegs), savedRegs, 0);
       sljit_jump* entry = sljit_emit_jump(compiler, SLJIT_JUMP);
       epilogue = sljit_emit_label(compiler);
       sljit_emit_return_void(compiler);


### PR DESCRIPTION
Fix nonvolatile xmm register corruption in Windows builds:
- Use temporary vector register for 128-bit moves

Fix sljit asserts in debug builds:
- Declare floating-point scratch register usage
- Declare flags required to be set by floating-point comparisons