### PR TITLE
n64: fix two bugs related COP0 timer in recompiler

### DIFF
--- a/ares/n64/cpu/cpu.cpp
+++ b/ares/n64/cpu/cpu.cpp
@@ -65,6 +65,15 @@ auto CPU::forceSynchronize() -> void {
   jitClockTarget = 0;
 }
 
+auto CPU::stepCount(u64 clocks) -> void {
+  if(!clocks) return;
+  u64 remaining = (u64)(scc.compare - scc.count) & CountMask;
+  if(remaining && clocks >= remaining) setInterruptPending(Interrupt::Timer, 1);
+  scc.count += clocks;
+  profile.cpuCycles += clocks;
+  if(scc.status.exceptionLevel) profile.cpuCyclesExc += clocks;
+}
+
 auto CPU::synchronize() -> void {
   auto clocks = Thread::clock;
   Thread::clock = 0;
@@ -100,13 +109,7 @@ auto CPU::synchronize() -> void {
     }
   });
 
-  clocks >>= 1;
-  if(scc.count < scc.compare && scc.count + clocks >= scc.compare) {
-    setInterruptPending(Interrupt::Timer, 1);
-  }
-  scc.count += clocks;
-  profile.cpuCycles += clocks;
-  if (scc.status.exceptionLevel) profile.cpuCyclesExc += clocks;
+  stepCount(clocks >> 1);
 }
 
 auto CPU::setInterruptPending(u32 bit, bool value) -> void {

--- a/ares/n64/cpu/cpu.cpp
+++ b/ares/n64/cpu/cpu.cpp
@@ -74,9 +74,17 @@ auto CPU::stepCount(u64 clocks) -> void {
   if(scc.status.exceptionLevel) profile.cpuCyclesExc += clocks;
 }
 
+auto CPU::flushCount() -> void {
+  auto clocks = pendingCount();
+  countClock += clocks << 1;
+  stepCount(clocks);
+}
+
 auto CPU::synchronize() -> void {
   auto clocks = Thread::clock;
+  auto counted = countClock;
   Thread::clock = 0;
+  countClock = 0;
   jitClockTarget = 0;
 
    vi.clock -= clocks;
@@ -109,7 +117,7 @@ auto CPU::synchronize() -> void {
     }
   });
 
-  stepCount(clocks >> 1);
+  stepCount((clocks - counted) >> 1);
 }
 
 auto CPU::setInterruptPending(u32 bit, bool value) -> void {
@@ -154,7 +162,7 @@ auto CPU::instruction() -> bool {
     auto block = recompiler.block(ipu.pc, access.paddr);
     if(block) {
       if(Thread::clock >= jitClockTarget) {
-        s64 timerDelta = (s64)scc.compare - (s64)scc.count;
+        s64 timerDelta = (s64)scc.compare - (s64)effectiveCount();
         if(timerDelta < 0) timerDelta = 0;
         s64 queueDelta = queue.timeToNextEvent();
         if(queueDelta < 0) queueDelta = 0;

--- a/ares/n64/cpu/cpu.hpp
+++ b/ares/n64/cpu/cpu.hpp
@@ -33,8 +33,11 @@ struct CPU : Thread {
   auto load(Node::Object) -> void;
   auto unload() -> void;
 
+  static constexpr u64 CountMask = (1ull << 33) - 1;
+
   auto main() -> void;
   auto synchronize() -> void;
+  auto stepCount(u64 clocks) -> void;
   auto forceSynchronize() -> void;
   auto setInterruptPending(u32 bit, bool value) -> void;
   auto interruptPoll() -> void;

--- a/ares/n64/cpu/cpu.hpp
+++ b/ares/n64/cpu/cpu.hpp
@@ -38,6 +38,9 @@ struct CPU : Thread {
   auto main() -> void;
   auto synchronize() -> void;
   auto stepCount(u64 clocks) -> void;
+  auto flushCount() -> void;
+  auto pendingCount() const -> u64 { return (Thread::clock - countClock) >> 1; }
+  auto effectiveCount() const -> u64 { return (scc.count + pendingCount()) & CountMask; }
   auto forceSynchronize() -> void;
   auto setInterruptPending(u32 bit, bool value) -> void;
   auto interruptPoll() -> void;
@@ -1248,6 +1251,7 @@ struct CPU : Thread {
     std::vector<u8> sectionDirty;
   } recompiler{*this};
   s64 jitClockTarget = 0;
+  s64 countClock = 0;
 
   struct Disassembler {
     CPU& self;

--- a/ares/n64/cpu/interpreter-scc.cpp
+++ b/ares/n64/cpu/interpreter-scc.cpp
@@ -36,7 +36,7 @@ auto CPU::getControlRegister(n5 index) -> u64 {
     data = scc.badVirtualAddress;
     break;
   case  9:  //count
-    data.bit(0,31) = scc.count >> 1;
+    data.bit(0,31) = effectiveCount() >> 1;
     break;
   case 10:  //entryhi
     data.bit( 0, 7) = scc.tlb.addressSpaceID;
@@ -169,6 +169,7 @@ auto CPU::setControlRegister(n5 index, n64 data) -> void {
   //scc.badVirtualAddress = data;  //read-only
     break;
   case  9:  //count
+    flushCount();
     scc.count = data.bit(0,31) << 1;
     break;
   case 10:  //entryhi
@@ -177,6 +178,7 @@ auto CPU::setControlRegister(n5 index, n64 data) -> void {
     scc.tlb.region                    = data.bit(62,63);
     break;
   case 11:  //compare
+    flushCount();
     scc.compare = data.bit(0,31) << 1;
     setInterruptPending(Interrupt::Timer, 0);
     break;
@@ -274,6 +276,7 @@ auto CPU::DMFC0(r64& rt, u8 rd) -> void {
     if(!scc.status.enable.coprocessor0) return exception.coprocessor0();
     if(context.bits == 32) return exception.reservedInstruction();
   }
+  if(rd == 9) flushCount();
   rt.u64 = getControlRegister(rd);
 }
 
@@ -306,6 +309,7 @@ auto CPU::MFC0(r64& rt, u8 rd) -> void {
   if(!context.kernelMode()) {
     if(!scc.status.enable.coprocessor0) return exception.coprocessor0();
   }
+  if(rd == 9) flushCount();
   rt.u64 = s32(getControlRegister(rd));
 }
 

--- a/ares/n64/cpu/serialization.cpp
+++ b/ares/n64/cpu/serialization.cpp
@@ -70,6 +70,7 @@ auto CPU::serialize(serializer& s) -> void {
   s(scc.badVirtualAddress);
   s(scc.count);
   s(scc.compare);
+  s(countClock);
   s(scc.status.interruptEnable);
   s(scc.status.exceptionLevel);
   s(scc.status.errorLevel);


### PR DESCRIPTION
TL;DR:

* COMPARE=0 was buggy and would never trigger an exception
* Reading COUNT multiple times in the same JIT block was returning a stale value