### PR TITLE
hiro: ensure focus when launched from a frontend in macos

### DIFF
--- a/hiro/cocoa/application.cpp
+++ b/hiro/cocoa/application.cpp
@@ -131,6 +131,14 @@ NSTimer* applicationTimer = nullptr;
 
 namespace hiro {
 
+auto pApplication::_activateApplication() -> void {
+  @autoreleasepool {
+    // Promote to regular GUI application to gain focus when launched from a frontend
+    [NSApp setActivationPolicy:NSApplicationActivationPolicyRegular];
+    [NSApp activateIgnoringOtherApps:YES];
+  }
+}
+
 auto pApplication::exit() -> void {
   quit();
   ::exit(EXIT_SUCCESS);

--- a/hiro/cocoa/application.hpp
+++ b/hiro/cocoa/application.hpp
@@ -26,6 +26,8 @@ struct pApplication {
   static auto quit() -> void;
   static auto setScreenSaver(bool screenSaver) -> void;
 
+  static auto _activateApplication() -> void;
+
   static auto initialize() -> void;
 };
 

--- a/hiro/cocoa/window.cpp
+++ b/hiro/cocoa/window.cpp
@@ -166,6 +166,7 @@ auto pWindow::setDroppable(bool droppable) -> void {
 
 auto pWindow::setFocused() -> void {
   [cocoaWindow makeKeyAndOrderFront:nil];
+  pApplication::_activateApplication();
 }
 
 auto pWindow::setFullScreen(bool fullScreen) -> void {
@@ -246,7 +247,10 @@ auto pWindow::setAssociatedFile(const string& filename) -> void {
 }
 
 auto pWindow::setVisible(bool visible) -> void {
-  if(visible) [cocoaWindow makeKeyAndOrderFront:nil];
+  if(visible) {
+    [cocoaWindow makeKeyAndOrderFront:nil];
+    pApplication::_activateApplication();
+  }
   else [cocoaWindow orderOut:nil];
 }
 


### PR DESCRIPTION
On macOS, a binary executed directly by another process (e.g. a frontend spawning an emulator) starts as an unregistered background process. It must be promoted to a regular GUI application to reclaim focus.