### PR TITLE
fc: implement PPU internal shift registers

### DIFF
--- a/ares/fc/ppu/ppu.hpp
+++ b/ares/fc/ppu/ppu.hpp
@@ -53,6 +53,7 @@ struct PPU : Thread {
   auto rendering() const -> bool;
   auto loadCHR(n16 address) -> n8;
 
+  auto bgShift() -> u32;
   auto renderPixel() -> void;
   auto renderScanline() -> void;
 
@@ -162,11 +163,13 @@ struct PPU : Thread {
 
     n8 tiledataLo;
     n8 tiledataHi;
+
+    bool counting;
   };
 
   struct Latches {
-    n16 nametable;
-    n16 attribute;
+    n16 attributeLo;
+    n16 attributeHi;
     n16 tiledataLo;
     n16 tiledataHi;
 

--- a/ares/fc/ppu/render.cpp
+++ b/ares/fc/ppu/render.cpp
@@ -16,56 +16,69 @@ auto PPU::loadCHR(n16 address) -> n8 {
   }
 }
 
+auto PPU::bgShift() -> u32 {
+  if(!enable()) return 0;
+
+  u32 mask = 0x8000 >> scroll.fineX;
+  u32 palette = 0;
+
+  palette |= latch.tiledataLo  & mask ? 1 : 0;
+  palette |= latch.tiledataHi  & mask ? 2 : 0;
+  palette |= latch.attributeLo & mask ? 4 : 0;
+  palette |= latch.attributeHi & mask ? 8 : 0;
+  latch.tiledataLo <<= 1;
+  latch.tiledataHi <<= 1;
+  latch.tiledataHi |= 0x0001;
+  latch.attributeLo <<= 1;
+  latch.attributeHi <<= 1;
+
+  return palette;
+}
+
 auto PPU::renderPixel() -> void {
   if(io.ly >= screen->canvasHeight()) return;
 
   u32  x = io.lx - 1;
-  u32  mask = 0x8000 >> (scroll.fineX + (x & 7));
-  u32  palette = 0;
   u32  objectPalette = 0;
   bool objectPriority = 0;
 
-  if(!model->raster.pixelVisible(x, io.ly)) return;
-
-  palette |= latch.tiledataLo & mask ? 1 : 0;
-  palette |= latch.tiledataHi & mask ? 2 : 0;
-  if(palette) {
-    u32 attr = latch.attribute;
-    if(mask >= 256) attr >>= 2;
-    palette |= (attr & 3) << 2;
-  }
-
+  u32 palette = bgShift();
+  if(!(palette & 3)) palette = 0;
   if(!io.bgEnable) palette = 0;
   if(!io.bgEdgeEnable && x < 8) palette = 0;
 
-  if(io.spriteEnable)
-    for(i32 sprite = 7; sprite >= 0; sprite--) {
-      if(!io.spriteEdgeEnable && x < 8) continue;
-      if(latch.oam[sprite].id == 64) continue;
+  if(!model->raster.pixelVisible(x, io.ly)) return;
 
-      u32 spriteX = x - latch.oam[sprite].x;
-      if(spriteX >= 8) continue;
-
-      if(latch.oam[sprite].attr & 0x40) spriteX ^= 7;
-      u32 mask = 0x80 >> spriteX;
-      u32 spritePalette = 0;
-      spritePalette |= latch.oam[sprite].tiledataLo & mask ? 1 : 0;
-      spritePalette |= latch.oam[sprite].tiledataHi & mask ? 2 : 0;
-      if(spritePalette == 0) continue;
-
-      if(latch.oam[sprite].id == 0 && palette && x != 255) io.spriteZeroHit = 1;
-      spritePalette |= (latch.oam[sprite].attr & 3) << 2;
-
-      objectPriority = latch.oam[sprite].attr & 0x20;
-      objectPalette = 16 + spritePalette;
+  for(i32 sprite = 7; sprite >= 0; sprite--) {
+    if(latch.oam[sprite].id == 64) continue;
+    if(!latch.oam[sprite].x) latch.oam[sprite].counting = false;
+    if(latch.oam[sprite].counting) {
+      latch.oam[sprite].x--;
+      continue;
     }
+    if(!enable()) continue;
 
-  if(objectPalette) {
-    if(palette == 0 || objectPriority == 0) palette = objectPalette;
+    //shift out sprite pixels once x-position countdown expires
+    u32 spritePalette = 0;
+    spritePalette |= latch.oam[sprite].tiledataLo & 0x80 ? 1 : 0;
+    spritePalette |= latch.oam[sprite].tiledataHi & 0x80 ? 2 : 0;
+    latch.oam[sprite].tiledataLo <<= 1;
+    latch.oam[sprite].tiledataHi <<= 1;
+
+    if(!io.spriteEnable) continue;
+    if(!io.spriteEdgeEnable && x < 8) continue;
+    if(spritePalette == 0) continue;
+
+    if(latch.oam[sprite].id == 0 && palette && x != 255) io.spriteZeroHit = 1;
+    spritePalette |= (latch.oam[sprite].attr & 3) << 2;
+    objectPriority = latch.oam[sprite].attr & 0x20;
+    objectPalette = 16 + spritePalette;
   }
 
+  if(objectPalette && (palette == 0 || objectPriority == 0)) palette = objectPalette;
+
   u32 color = 0;
-  if (enable() || (n14)var.address < 0x3f00) {
+  if(enable() || (n14)var.address < 0x3f00) {
     color = io.emphasis << 6 | readCGRAM(palette);
   } else {
     color = io.emphasis << 6 | readCGRAM((n5)var.address);
@@ -87,8 +100,8 @@ auto PPU::renderScanline() -> void {
   //  0
   step(1);
 
-  // force clear sprite counter at start of each scanline
-  for (auto& id : latch.oamId) id = 64;
+  //force clear sprite counter at start of each scanline
+  for(auto& id : latch.oamId) id = 64;
 
   //  1-256
   for(u32 tile : range(32)) {
@@ -123,10 +136,10 @@ auto PPU::renderScanline() -> void {
     renderPixel();
     step(1);
 
-    latch.nametable = latch.nametable << 8 | nametable;
-    latch.attribute = latch.attribute << 2 | (attribute & 3);
-    latch.tiledataLo = latch.tiledataLo << 8 | tiledataLo;
-    latch.tiledataHi = latch.tiledataHi << 8 | tiledataHi;
+    latch.attributeLo.byte(0) = (attribute & 1) ? 0xff : 0x00;
+    latch.attributeHi.byte(0) = (attribute & 2) ? 0xff : 0x00;
+    latch.tiledataLo.byte(0) = tiledataLo;
+    latch.tiledataHi.byte(0) = tiledataHi;
   }
 
   for(u32 n : range(8)) {
@@ -153,9 +166,11 @@ auto PPU::renderScanline() -> void {
     tileaddr += spriteY + (spriteY & 8);
 
     latch.oam[sprite].tiledataLo = loadCHR(tileaddr + 0);
+    if(latch.oam[sprite].attr & 0x40) latch.oam[sprite].tiledataLo = bit::reverse<u8>(latch.oam[sprite].tiledataLo);
     step(2);
 
     latch.oam[sprite].tiledataHi = loadCHR(tileaddr + 8);
+    if(latch.oam[sprite].attr & 0x40) latch.oam[sprite].tiledataHi = bit::reverse<u8>(latch.oam[sprite].tiledataHi);
     step(2);
   }
 
@@ -163,23 +178,35 @@ auto PPU::renderScanline() -> void {
   for(u32 tile : range(2)) {
     u32 nametable = loadCHR(0x2000 | (n12)var.address);
     u32 tileaddr = io.bgAddress | nametable << 4 | var.fineY;
-    step(2);
+    bgShift();
+    step(1);
+    bgShift();
+    step(1);
 
     u32 attribute = loadCHR(0x23c0 | var.nametable << 10 | (var.tileY >> 2) << 3 | var.tileX >> 2);
     if(var.tileY & 2) attribute >>= 4;
     if(var.tileX & 2) attribute >>= 2;
-    step(2);
+    bgShift();
+    step(1);
+    bgShift();
+    step(1);
 
     u32 tiledataLo = loadCHR(tileaddr + 0);
-    step(2);
+    bgShift();
+    step(1);
+    bgShift();
+    step(1);
 
     u32 tiledataHi = loadCHR(tileaddr + 8);
-    step(2);
+    bgShift();
+    step(1);
+    bgShift();
+    step(1);
 
-    latch.nametable = latch.nametable << 8 | nametable;
-    latch.attribute = latch.attribute << 2 | (attribute & 3);
-    latch.tiledataLo = latch.tiledataLo << 8 | tiledataLo;
-    latch.tiledataHi = latch.tiledataHi << 8 | tiledataHi;
+    latch.attributeLo.byte(0) = (attribute & 1) ? 0xff : 0x00;
+    latch.attributeHi.byte(0) = (attribute & 2) ? 0xff : 0x00;
+    latch.tiledataLo.byte(0) = tiledataLo;
+    latch.tiledataHi.byte(0) = tiledataHi;
   }
 
   //337-338
@@ -189,6 +216,9 @@ auto PPU::renderScanline() -> void {
 
   //339
   loadCHR(0x2000 | (n12)var.address);
+  if(enable()) {
+    for(u32 sprite : range(8)) latch.oam[sprite].counting = true;
+  }
   step(1);
 
   //340

--- a/ares/fc/ppu/serialization.cpp
+++ b/ares/fc/ppu/serialization.cpp
@@ -31,8 +31,8 @@ auto PPU::serialize(serializer& s) -> void {
   s(io.spriteEnable);
   s(io.emphasis);
   s(io.spriteZeroHit);
-  s(latch.nametable);
-  s(latch.attribute);
+  s(latch.attributeLo);
+  s(latch.attributeHi);
   s(latch.tiledataLo);
   s(latch.tiledataHi);
   s(latch.oamId);
@@ -54,4 +54,5 @@ auto PPU::OAM::serialize(serializer& s) -> void {
   s(x);
   s(tiledataLo);
   s(tiledataHi);
+  s(counting);
 }

--- a/ares/fc/ppu/sprite.cpp
+++ b/ares/fc/ppu/sprite.cpp
@@ -7,6 +7,7 @@ auto PPU::cycleSpriteEvaluation() -> void {
     } else {
       soam[sprite.oamTempCounter++] = sprite.oamData;
     }
+    if (io.lx == 64) sprite.oamTempCounter = 0;
     return;
   }
 

--- a/ares/fc/system/serialization.cpp
+++ b/ares/fc/system/serialization.cpp
@@ -1,4 +1,4 @@
-static const string SerializerVersion = "v154";
+static const string SerializerVersion = "v155";
 
 auto System::serialize(bool synchronize) -> serializer {
   if(synchronize) scheduler.enter(Scheduler::Mode::Synchronize);


### PR DESCRIPTION
Implements the internal PPU shift registers used for background and sprite rendering. Fixes the AccuracyCoin "Stale BG Shift Registers" test, and improves the result in the "Stale Sprite Shift Regs" test.